### PR TITLE
Fix: missing 'util.h' in superheader

### DIFF
--- a/include/cjose/cjose.h
+++ b/include/cjose/cjose.h
@@ -26,5 +26,6 @@
 #include "jwk.h"
 #include "jwe.h"
 #include "jws.h"
+#include "util.h"
 
 #endif  // CJOSE_CJOSE_H


### PR DESCRIPTION
cjose/cjose.h does not include cjose/util.h -- this PR fixes that.