### PR TITLE
Replace free with dealloc

### DIFF
--- a/src/jws.c
+++ b/src/jws.c
@@ -397,7 +397,7 @@ static bool _cjose_jws_build_sig_ps256(
     retval = true;
 
     _cjose_jws_build_sig_ps256_cleanup:
-    free(em);
+    cjose_get_dealloc()(em);
 
     return retval;
 }
@@ -596,14 +596,14 @@ void cjose_jws_release(cjose_jws_t *jws)
         json_decref(jws->hdr);
     }
 
-    free(jws->hdr_b64u);
-    free(jws->dat);
-    free(jws->dat_b64u);
-    free(jws->dig);
-    free(jws->sig);
-    free(jws->sig_b64u);
-    free(jws->cser);
-    free(jws);
+    cjose_get_dealloc()(jws->hdr_b64u);
+    cjose_get_dealloc()(jws->dat);
+    cjose_get_dealloc()(jws->dat_b64u);
+    cjose_get_dealloc()(jws->dig);
+    cjose_get_dealloc()(jws->sig);
+    cjose_get_dealloc()(jws->sig_b64u);
+    cjose_get_dealloc()(jws->cser);
+    cjose_get_dealloc()(jws);
 }
 
 
@@ -707,7 +707,7 @@ cjose_jws_t *cjose_jws_import(
 
     // deserialize JSON header
     jws->hdr = json_loadb((const char *)hdr_str, len, 0, NULL);
-    free(hdr_str);
+    cjose_get_dealloc()(hdr_str);
     if (NULL == jws->hdr)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -801,7 +801,7 @@ static bool _cjose_jws_verify_sig_ps256(
     retval = true;
 
     _cjose_jws_verify_sig_ps256_cleanup:
-    free(em);
+    cjose_get_dealloc()(em);
 
     return retval;
 }
@@ -867,7 +867,7 @@ static bool _cjose_jws_verify_sig_rs256(
     retval = true;
 
     _cjose_jws_verify_sig_rs256_cleanup:
-    free(dig);
+    cjose_get_dealloc()(dig);
 
     return retval;
 }

--- a/test/check_base64.c
+++ b/test/check_base64.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <check.h>
 #include <cjose/base64.h>
+#include <cjose/util.h>
 
 START_TEST(test_cjose_base64_encode)
 {
@@ -17,7 +18,7 @@ START_TEST(test_cjose_base64_encode)
     ck_assert(cjose_base64_encode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(16, outlen);
     ck_assert_str_eq("aGVsbG8gdGhlcmU=", output);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = (uint8_t *)"A B C D E F ";
     inlen = 12;
@@ -26,7 +27,7 @@ START_TEST(test_cjose_base64_encode)
     ck_assert(cjose_base64_encode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(16, outlen);
     ck_assert_str_eq("QSBCIEMgRCBFIEYg", output);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = (uint8_t *)"hello\xfethere";
     inlen = 11;
@@ -35,7 +36,7 @@ START_TEST(test_cjose_base64_encode)
     ck_assert(cjose_base64_encode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(16, outlen);
     ck_assert_str_eq("aGVsbG/+dGhlcmU=", output);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = (uint8_t *)"\xfe";
     inlen = 1;
@@ -44,7 +45,7 @@ START_TEST(test_cjose_base64_encode)
     ck_assert(cjose_base64_encode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(4, outlen);
     ck_assert_str_eq("/g==", output);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = (uint8_t *)"\x01\x02";
     inlen = 2;
@@ -53,7 +54,7 @@ START_TEST(test_cjose_base64_encode)
     ck_assert(cjose_base64_encode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(4, outlen);
     ck_assert_str_eq("AQI=", output);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = (uint8_t *)"\x01";
     inlen = 1;
@@ -62,7 +63,7 @@ START_TEST(test_cjose_base64_encode)
     ck_assert(cjose_base64_encode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(4, outlen);
     ck_assert_str_eq("AQ==", output);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = (uint8_t *)"";
     inlen = 0;
@@ -71,7 +72,7 @@ START_TEST(test_cjose_base64_encode)
     ck_assert(cjose_base64_encode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(0, outlen);
     ck_assert_str_eq("", output);
-    free(output);
+    cjose_get_dealloc()(output);
 
     // input may be NULL iff inlen is 0
     input = NULL;
@@ -116,7 +117,7 @@ START_TEST(test_cjose_base64url_encode)
     ck_assert(cjose_base64url_encode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(15, outlen);
     ck_assert_str_eq("aGVsbG8gdGhlcmU", output);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = (uint8_t *)"A B C D E F ";
     inlen = 12;
@@ -125,7 +126,7 @@ START_TEST(test_cjose_base64url_encode)
     ck_assert(cjose_base64url_encode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(16, outlen);
     ck_assert_str_eq("QSBCIEMgRCBFIEYg", output);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = (uint8_t *)"hello\xfethere";
     inlen = 11;
@@ -134,7 +135,7 @@ START_TEST(test_cjose_base64url_encode)
     ck_assert(cjose_base64url_encode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(15, outlen);
     ck_assert_str_eq("aGVsbG_-dGhlcmU", output);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = (uint8_t *)"\xfe";
     inlen = 1;
@@ -143,7 +144,7 @@ START_TEST(test_cjose_base64url_encode)
     ck_assert(cjose_base64url_encode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(2, outlen);
     ck_assert_str_eq("_g", output);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = (uint8_t *)"\x01\x02";
     inlen = 2;
@@ -152,7 +153,7 @@ START_TEST(test_cjose_base64url_encode)
     ck_assert(cjose_base64url_encode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(3, outlen);
     ck_assert_str_eq("AQI", output);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = (uint8_t *)"\x01";
     inlen = 1;
@@ -161,7 +162,7 @@ START_TEST(test_cjose_base64url_encode)
     ck_assert(cjose_base64url_encode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(2, outlen);
     ck_assert_str_eq("AQ", output);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = (uint8_t *)"";
     inlen = 0;
@@ -170,7 +171,7 @@ START_TEST(test_cjose_base64url_encode)
     ck_assert(cjose_base64url_encode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(0, outlen);
     ck_assert_str_eq("", output);
-    free(output);
+    cjose_get_dealloc()(output);
 
     // input may be NULL off inlen is 0
     input = NULL;
@@ -217,7 +218,7 @@ START_TEST(test_cjose_base64_decode)
     ck_assert(cjose_base64_decode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(11, outlen);
     ck_assert_bin_eq((uint8_t *)"hello there", output, 11);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = "QSBCIEMgRCBFIEYg";
     inlen = 16;
@@ -226,7 +227,7 @@ START_TEST(test_cjose_base64_decode)
     ck_assert(cjose_base64_decode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(12, outlen);
     ck_assert_bin_eq((uint8_t *)"A B C D E F ", output, 12);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = "aGVsbG/+dGhlcmU=";
     inlen = 16;
@@ -235,7 +236,7 @@ START_TEST(test_cjose_base64_decode)
     ck_assert(cjose_base64_decode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(11, outlen);
     ck_assert_bin_eq((uint8_t *)"hello\xfethere", output, 11);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = "/g==";
     inlen = 4;
@@ -244,7 +245,7 @@ START_TEST(test_cjose_base64_decode)
     ck_assert(cjose_base64_decode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(1, outlen);
     ck_assert_bin_eq((uint8_t *)"\xfe", output, 1);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = "AQI=";
     inlen = 4;
@@ -253,7 +254,7 @@ START_TEST(test_cjose_base64_decode)
     ck_assert(cjose_base64_decode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(2, outlen);
     ck_assert_bin_eq((uint8_t *)"\x01\x02", output, 2);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = "AQ==";
     inlen = 4;
@@ -262,7 +263,7 @@ START_TEST(test_cjose_base64_decode)
     ck_assert(cjose_base64_decode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(1, outlen);
     ck_assert_bin_eq((uint8_t *)"\x01", output, 1);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = "";
     inlen = 0;
@@ -271,7 +272,7 @@ START_TEST(test_cjose_base64_decode)
     ck_assert(cjose_base64_decode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(0, outlen);
     ck_assert_bin_eq((uint8_t *)"", output, 0);
-    free(output);
+    cjose_get_dealloc()(output);
 
     // invalid arguments -- input == NULL
     input = NULL;
@@ -329,7 +330,7 @@ START_TEST(test_cjose_base64url_decode)
     ck_assert(cjose_base64url_decode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(11, outlen);
     ck_assert_bin_eq((uint8_t *)"hello there", output, 11);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = "QSBCIEMgRCBFIEYg";
     inlen = 16;
@@ -338,7 +339,7 @@ START_TEST(test_cjose_base64url_decode)
     ck_assert(cjose_base64url_decode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(12, outlen);
     ck_assert_bin_eq((uint8_t *)"A B C D E F ", output, 12);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = "aGVsbG_-dGhlcmU";
     inlen = 15;
@@ -347,7 +348,7 @@ START_TEST(test_cjose_base64url_decode)
     ck_assert(cjose_base64url_decode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(11, outlen);
     ck_assert_bin_eq((uint8_t *)"hello\xfethere", output, 11);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = "_g";
     inlen = 2;
@@ -356,7 +357,7 @@ START_TEST(test_cjose_base64url_decode)
     ck_assert(cjose_base64url_decode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(1, outlen);
     ck_assert_bin_eq((uint8_t *)"\xfe", output, 1);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = "AQI";
     inlen = 3;
@@ -365,7 +366,7 @@ START_TEST(test_cjose_base64url_decode)
     ck_assert(cjose_base64url_decode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(2, outlen);
     ck_assert_bin_eq((uint8_t *)"\x01\x02", output, 2);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = "AQ";
     inlen = 2;
@@ -374,7 +375,7 @@ START_TEST(test_cjose_base64url_decode)
     ck_assert(cjose_base64url_decode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(1, outlen);
     ck_assert_bin_eq((uint8_t *)"\x01", output, 1);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = "";
     inlen = 0;
@@ -383,7 +384,7 @@ START_TEST(test_cjose_base64url_decode)
     ck_assert(cjose_base64url_decode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(0, outlen);
     ck_assert_bin_eq((uint8_t *)"", output, 0);
-    free(output);
+    cjose_get_dealloc()(output);
 
     input = "valids";
     inlen = 6;
@@ -392,7 +393,7 @@ START_TEST(test_cjose_base64url_decode)
     ck_assert(cjose_base64url_decode(input, inlen, &output, &outlen, &err));
     ck_assert_int_eq(4, outlen);
     ck_assert_bin_eq((uint8_t *)"\xbd\xa9\x62\x76", output, 4);
-    free(output);
+    cjose_get_dealloc()(output);
 
     // invalid arguments -- input == NULL
     input = NULL;

--- a/test/check_base64.c
+++ b/test/check_base64.c
@@ -181,6 +181,7 @@ START_TEST(test_cjose_base64url_encode)
     ck_assert(cjose_base64url_encode(input, inlen, &output, &outlen, &err));
     ck_assert_str_eq("", output);
     ck_assert(0 == outlen);
+    cjose_get_dealloc()(output);
 
     // invalid arguments -- output == NULL
     input = "valid";

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -78,6 +78,7 @@ START_TEST(test_cjose_jwe_node_jose_encrypt_self_decrypt)
             strncmp(PLAINTEXT, plain2, plain2_len) == 0,
             "decrypted plaintext does not match encrypted plaintext");
 
+    cjose_get_dealloc()(plain2);
     cjose_jwk_release(jwk);
     cjose_jwe_release(jwe);
 }
@@ -152,6 +153,7 @@ static void _self_encrypt_self_decrypt_with_key(
             strncmp(plain1, plain2, plain2_len) == 0,
             "decrypted plaintext does not match encrypted plaintext");
 
+    cjose_get_dealloc()(plain2);
     cjose_header_release(hdr);
     cjose_jwe_release(jwe1);
     cjose_jwe_release(jwe2);

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -158,7 +158,7 @@ static void _self_encrypt_self_decrypt_with_key(
     cjose_jwe_release(jwe1);
     cjose_jwe_release(jwe2);
     cjose_jwk_release(jwk);
-    free(compact);
+    cjose_get_dealloc()(compact);
 }
 
 
@@ -451,7 +451,7 @@ START_TEST(test_cjose_jwe_import_export_compare)
 
     cjose_jwk_release(jwk);
     cjose_jwe_release(jwe);
-    free(cser);
+    cjose_get_dealloc()(cser);
 }
 END_TEST
 

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -983,6 +983,7 @@ START_TEST(test_cjose_jwk_hkdf)
         ck_assert_msg(
                 ephemeral_key[i] == expected[i], "HKDF failed on byte: %d", i);     
     }
+    free(ephemeral_key);
 }
 END_TEST
 

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -547,6 +547,7 @@ START_TEST(test_cjose_jwk_to_json_rsa)
     ck_assert(NULL != json);
     ck_assert_str_eq(RSA_PUBLIC_JSON, json
     );
+    free(json);
 
     json = cjose_jwk_to_json(jwk, true, &err);
     ck_assert(NULL != json);
@@ -562,6 +563,7 @@ START_TEST(test_cjose_jwk_to_json_rsa)
             "}",
             json
     );
+    free(json);
 
     cjose_jwk_release(jwk);
 }
@@ -866,6 +868,7 @@ START_TEST(test_cjose_jwk_import_no_zero_termination)
         ck_assert_str_eq(JWK, jwk_str);
     }
 
+    free(jwk_str);
     json_decref(left_json);
     json_decref(right_json);
     cjose_jwk_release(jwk);
@@ -909,6 +912,7 @@ START_TEST(test_cjose_jwk_import_with_base64url_padding)
         ck_assert_str_eq(JWK_OUT, jwk_str);
     }
 
+    free(jwk_str);
     json_decref(left_json);
     json_decref(right_json);
     cjose_jwk_release(jwk);

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -10,6 +10,7 @@
 #include <check.h>
 #include <cjose/jwk.h>
 #include <cjose/base64.h>
+#include <cjose/util.h>
 #include "include/jwk_int.h"
 
 /**
@@ -101,7 +102,7 @@ START_TEST (test_cjose_jwk_create_RSA_spec)
     cjose_jwk_release(jwk);
 
     // only private
-    free(specPriv.e);
+    cjose_get_dealloc()(specPriv.e);
     specPriv.e = NULL;
     jwk = cjose_jwk_create_RSA_spec(&specPriv, &err);
     ck_assert(NULL != jwk);
@@ -114,15 +115,15 @@ START_TEST (test_cjose_jwk_create_RSA_spec)
     cjose_jwk_release(jwk);
 
     // minimal private
-    free(specPriv.p);
+    cjose_get_dealloc()(specPriv.p);
     specPriv.p = NULL;
-    free(specPriv.q);
+    cjose_get_dealloc()(specPriv.q);
     specPriv.q = NULL;
-    free(specPriv.dp);
+    cjose_get_dealloc()(specPriv.dp);
     specPriv.dp = NULL;
-    free(specPriv.dq);
+    cjose_get_dealloc()(specPriv.dq);
     specPriv.dq = NULL;
-    free(specPriv.qi);
+    cjose_get_dealloc()(specPriv.qi);
     specPriv.qi = NULL;
     jwk = cjose_jwk_create_RSA_spec(&specPriv, &err);
     ck_assert(NULL != jwk);
@@ -134,9 +135,9 @@ START_TEST (test_cjose_jwk_create_RSA_spec)
     ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
     cjose_jwk_release(jwk);
 
-    free(specPriv.n);
+    cjose_get_dealloc()(specPriv.n);
     specPriv.n = NULL;
-    free(specPriv.d);
+    cjose_get_dealloc()(specPriv.d);
     specPriv.d = NULL;
 
     // public only
@@ -154,9 +155,9 @@ START_TEST (test_cjose_jwk_create_RSA_spec)
     ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
     cjose_jwk_release(jwk);
 
-    free(specPub.n);
+    cjose_get_dealloc()(specPub.n);
     specPub.n = NULL;
-    free(specPub.e);
+    cjose_get_dealloc()(specPub.e);
     specPub.e = NULL;
 }
 END_TEST
@@ -219,9 +220,9 @@ START_TEST (test_cjose_jwk_create_EC_P256_spec)
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
     ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
-    free(spec.d);
-    free(spec.x);
-    free(spec.y);
+    cjose_get_dealloc()(spec.d);
+    cjose_get_dealloc()(spec.x);
+    cjose_get_dealloc()(spec.y);
 
     // cleanup
     cjose_jwk_release(jwk);
@@ -268,9 +269,9 @@ START_TEST (test_cjose_jwk_create_EC_P384_spec)
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
     ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
-    free(spec.d);
-    free(spec.x);
-    free(spec.y);
+    cjose_get_dealloc()(spec.d);
+    cjose_get_dealloc()(spec.x);
+    cjose_get_dealloc()(spec.y);
 
     // cleanup
     cjose_jwk_release(jwk);
@@ -361,7 +362,7 @@ START_TEST (test_cjose_jwk_create_oct_spec)
     ck_assert(NULL != jwk->keydata);
     ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
     ck_assert_bin_eq(k, jwk->keydata, klen);
-    free(k);
+    cjose_get_dealloc()(k);
 
     // cleanup
     cjose_jwk_release(jwk);
@@ -455,7 +456,7 @@ START_TEST(test_cjose_jwk_to_json_oct)
 
     cjose_base64url_decode(OCT_KEY, strlen(OCT_KEY), &k, &klen, &err);
     jwk = cjose_jwk_create_oct_spec(k, klen, &err);
-    free(k);
+    cjose_get_dealloc()(k);
 
     const char *json;
     json = cjose_jwk_to_json(jwk, false, &err);
@@ -484,9 +485,9 @@ START_TEST(test_cjose_jwk_to_json_ec)
     cjose_base64url_decode(EC_P256_y, strlen(EC_P256_y), &spec.y, &spec.ylen, &err);
 
     jwk = cjose_jwk_create_EC_spec(&spec, &err);
-    free(spec.d);
-    free(spec.x);
-    free(spec.y);
+    cjose_get_dealloc()(spec.d);
+    cjose_get_dealloc()(spec.x);
+    cjose_get_dealloc()(spec.y);
 
     const char *json;
     json = cjose_jwk_to_json(jwk, false, &err);
@@ -532,14 +533,14 @@ START_TEST(test_cjose_jwk_to_json_rsa)
     cjose_base64url_decode(RSA_qi, strlen(RSA_qi), &spec.qi, &spec.qilen, &err);
 
     jwk = cjose_jwk_create_RSA_spec(&spec, &err);
-    free(spec.e);
-    free(spec.n);
-    free(spec.d);
-    free(spec.p);
-    free(spec.q);
-    free(spec.dp);
-    free(spec.dq);
-    free(spec.qi);
+    cjose_get_dealloc()(spec.e);
+    cjose_get_dealloc()(spec.n);
+    cjose_get_dealloc()(spec.d);
+    cjose_get_dealloc()(spec.p);
+    cjose_get_dealloc()(spec.q);
+    cjose_get_dealloc()(spec.dp);
+    cjose_get_dealloc()(spec.dq);
+    cjose_get_dealloc()(spec.qi);
 
     const char *json;
     json = cjose_jwk_to_json(jwk, false, &err);

--- a/test/check_util.c
+++ b/test/check_util.c
@@ -1,6 +1,7 @@
 
 #include "check_cjose.h"
 #include <cjose/util.h>
+#include <check.h>
 #include <jansson.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
replace free() calls with cjose_get_dealloc()() where appropriate; additionally fix some memory leaks in the test suite