### PR TITLE
Build: use cjose_err.message instead of errno

### DIFF
--- a/src/jws.c
+++ b/src/jws.c
@@ -371,11 +371,17 @@ static bool _cjose_jws_build_sig_ps(
     uint8_t *em = NULL;
     size_t em_len = 0;
 
-    // ensure jwk is RSA
+    // ensure jwk is private RSA
     if (jwk->kty != CJOSE_JWK_KTY_RSA)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto _cjose_jws_build_sig_ps_cleanup;
+    }
+    RSA *rsa = (RSA *)jwk->keydata;
+    if (!rsa || !rsa->e || !rsa->n || !rsa->d)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
     }
 
     // make sure we have an alg header
@@ -457,8 +463,14 @@ static bool _cjose_jws_build_sig_rs(
         const cjose_jwk_t *jwk,
         cjose_err *err)
 {
-    // ensure jwk is RSA
+    // ensure jwk is private RSA
     if (jwk->kty != CJOSE_JWK_KTY_RSA)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+    RSA *rsa = (RSA *)jwk->keydata;
+    if (!rsa || !rsa->e || !rsa->n || !rsa->d)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return false;

--- a/test/check_header.c
+++ b/test/check_header.c
@@ -4,7 +4,6 @@
 
 #include "check_cjose.h"
 
-#include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <check.h>

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -4,7 +4,6 @@
 
 #include "check_cjose.h"
 
-#include <errno.h>
 #include <stdlib.h>
 #include <openssl/evp.h>
 #include <check.h>
@@ -390,7 +389,6 @@ START_TEST (test_cjose_jwk_create_oct_random_inval)
     cjose_err err;
     cjose_jwk_t *   jwk = NULL;
 
-    errno = 0;
     jwk = cjose_jwk_create_oct_random(0, &err);
     ck_assert(NULL == jwk);
     ck_assert(CJOSE_ERR_INVALID_ARG == err.code);


### PR DESCRIPTION
This prevents test failures on other platforms