### PR TITLE
support importing unsecure JWS (alg=none)

### DIFF
--- a/include/cjose/header.h
+++ b/include/cjose/header.h
@@ -37,6 +37,9 @@ extern const char *CJOSE_HDR_CTY;
 /** The Jose "kid" header attribute. */
 extern const char *CJOSE_HDR_KID;
 
+/** The JWA algorithm attribute value for none. */
+extern const char *CJOSE_HDR_ALG_NONE;
+
 /** The JWE algorithm attribute value for RSA-OAEP. */
 extern const char *CJOSE_HDR_ALG_RSA_OAEP;
 

--- a/src/header.c
+++ b/src/header.c
@@ -13,6 +13,7 @@
 
 
 const char *CJOSE_HDR_ALG = "alg";
+const char *CJOSE_HDR_ALG_NONE = "none";
 const char *CJOSE_HDR_ALG_RSA_OAEP = "RSA-OAEP";
 const char *CJOSE_HDR_ALG_RSA1_5 = "RSA1_5";
 const char *CJOSE_HDR_ALG_A128KW = "A128KW";

--- a/src/jws.c
+++ b/src/jws.c
@@ -859,9 +859,20 @@ cjose_jws_t *cjose_jws_import(
     // validate the JSON header segment
     if (!_cjose_jws_validate_hdr(jws, err))
     {
-        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-        cjose_jws_release(jws);
-        return NULL;        
+        // make an exception for alg=none so that it will import/parse but not sign/verify
+        json_t *alg_obj = json_object_get(jws->hdr, CJOSE_HDR_ALG);
+        if (NULL == alg_obj)
+        {
+            CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+            return NULL;
+        }
+        const char *alg = json_string_value(alg_obj);
+        if ((!alg) || (strcmp(alg, CJOSE_HDR_ALG_NONE) != 0))
+        {
+            CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+            cjose_jws_release(jws);
+            return NULL;
+        }
     }
 
     // copy and b64u decode data segment


### PR DESCRIPTION
import only, verify or sign not allowed; alternatively the signature of the `_cjose_jws_validate_hdr` could have an extra bool `allow_none`