### PR TITLE
introduce _cjson_json_stringn so cjose compiles against Jansson 2.6

### DIFF
--- a/src/include/jwk_int.h
+++ b/src/include/jwk_int.h
@@ -69,4 +69,6 @@ bool cjose_jwk_hkdf(
         unsigned int okm_len,
         cjose_err *err);
 
+json_t *_cjose_json_stringn(const char *value, size_t len);
+
 #endif // SRC_JWK_INT_H

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -317,7 +317,7 @@ static bool _oct_private_fields(
         return false;
     }
 
-    field = json_stringn(k, klen);
+    field = _cjose_json_stringn(k, klen);
     cjose_get_dealloc()(k);
     k = NULL;
     if (!field)
@@ -621,7 +621,7 @@ static bool _EC_public_fields(
     {
         goto _ec_to_string_cleanup;
     }
-    field = json_stringn(b64u, len);
+    field = _cjose_json_stringn(b64u, len);
     if (!field)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
@@ -641,7 +641,7 @@ static bool _EC_public_fields(
     {
         goto _ec_to_string_cleanup;
     }
-    field = json_stringn(b64u, len);
+    field = _cjose_json_stringn(b64u, len);
     if (!field)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
@@ -715,7 +715,7 @@ static bool _EC_private_fields(
     {
         goto _ec_to_string_cleanup;
     }
-    field = json_stringn(b64u, len);
+    field = _cjose_json_stringn(b64u, len);
     if (!field)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
@@ -1001,7 +1001,7 @@ static inline bool _RSA_json_field(
     {
         goto RSA_json_field_cleanup;
     }
-    field = json_stringn(b64u, b64ulen);
+    field = _cjose_json_stringn(b64u, b64ulen);
     if (!field)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);

--- a/src/util.c
+++ b/src/util.c
@@ -10,6 +10,7 @@
 #include <jansson.h>
 #include <openssl/crypto.h>
 #include <stdlib.h>
+#include <string.h>
 
 static cjose_alloc_fn_t _alloc;
 static cjose_realloc_fn_t _realloc;
@@ -60,4 +61,15 @@ int cjose_const_memcmp(
         result |= a[i] ^ b[i];
     }
     return result;
+}
+
+json_t *_cjose_json_stringn(const char *value, size_t len) {
+#if JANSSON_VERSION_HEX <= 0x020600
+    char *s = strndup(value, len);
+    json_t *r = json_string(s);
+    free(s);
+    return r;
+#else
+    return json_stringn(value, len);
+#endif
 }


### PR DESCRIPTION
if you could merge in your no-strdup branch that would also increase support for older platforms