### PR TITLE
Fix: remove use of strdup

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,4 +14,5 @@ libcjose_la_SOURCES=version.c \
 					include/header_int.h \
 					include/jwk_int.h \
 					include/jwe_int.h \
-					include/jws_int.h
+					include/jws_int.h \
+					include/util_int.h

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -362,7 +362,8 @@ libcjose_la_SOURCES = version.c \
 					include/header_int.h \
 					include/jwk_int.h \
 					include/jwe_int.h \
-					include/jws_int.h
+					include/jws_int.h \
+					include/util_int.h
 
 all: all-am
 

--- a/src/include/util_int.h
+++ b/src/include/util_int.h
@@ -1,0 +1,17 @@
+/*!
+ * Copyrights
+ *
+ * Portions created or assigned to Cisco Systems, Inc. are
+ * Copyright (c) 2014-2016 Cisco Systems, Inc.  All Rights Reserved.
+ */
+
+#ifndef SRC_UTIL_INT_H
+#define SRC_UTIL_INT_H
+
+#include <cjose/error.h>
+
+#include <string.h>
+
+char *_cjose_strndup(const char *str, ssize_t len, cjose_err *err);
+
+#endif // SRC_UTIL_INT_H

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -22,6 +22,7 @@
 #include "include/header_int.h"
 #include "include/jwk_int.h"
 #include "include/jwe_int.h"
+#include "include/util_int.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -151,14 +152,16 @@ static bool _cjose_jwe_build_hdr(
     }
 
     // copy the serialized header to JWE (hdr_str is owned by header object)
-    jwe->part[0].raw = (uint8_t *)strdup(hdr_str);
-    if (NULL == jwe->part[0].raw)
+    size_t  len = strlen(hdr_str);
+    uint8_t *data = (uint8_t *)_cjose_strndup(hdr_str, len, err);
+    if (!data)
     {
-        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         cjose_get_dealloc()(hdr_str);
         return false;
     }
-    jwe->part[0].raw_len = strlen(hdr_str);
+
+    jwe->part[0].raw = data;
+    jwe->part[0].raw_len = len;
     cjose_get_dealloc()(hdr_str);
     
     return true;
@@ -1284,12 +1287,7 @@ bool _cjose_jwe_import_part(
     }
 
     // copy the b64u part to the jwe
-    jwe->part[p].b64u = strdup(b64u);
-    if (NULL == jwe->part[p].b64u)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
-        return false;
-    }
+    jwe->part[p].b64u = _cjose_strndup(b64u, b64u_len, err);
     jwe->part[p].b64u_len = b64u_len;
 
     // b64u decode the part

--- a/src/util.c
+++ b/src/util.c
@@ -5,6 +5,8 @@
  * Copyright (c) 2014-2016 Cisco Systems, Inc.  All Rights Reserved.
  */
 
+#include "include/util_int.h"
+
 #include <cjose/util.h>
 
 #include <jansson.h>
@@ -59,5 +61,31 @@ int cjose_const_memcmp(
     {
         result |= a[i] ^ b[i];
     }
+
+    return result;
+}
+
+char *_cjose_strndup(const char *str, ssize_t len, cjose_err *err)
+{
+    if (NULL == str)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return NULL;
+    }
+
+    if (0 > len)
+    {
+        len = strlen(str);
+    }
+
+    char *result = cjose_get_alloc()(sizeof(char) * (len + 1));
+    if (!result)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        return NULL;
+    }
+    memcpy(result, str, len);
+    result[len] = 0;
+
     return result;
 }


### PR DESCRIPTION
Removes the use of strdup, which does not support custom memory allocation, and is considered unsafe.