### PR TITLE
compiler warning/error fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Implementation of JOSE for C/C++
 ### Libraries ###
 
 * OpenSSL >= 1.0.1h (or its API equivalent)
-* Jansson >= 2.6
+* Jansson >= 2.3
 
 ## Getting Started ##
 

--- a/cjose.pc.in
+++ b/cjose.pc.in
@@ -11,6 +11,6 @@ Name: cjose
 URL: https://github.com/cisco/cjose
 Description: JOSE implementation for C
 Version: @VERSION@
-Requires: jansson >= 2.4, libcrypto >= 1.0.1
+Requires: jansson >= 2.3, libcrypto >= 1.0.1
 Cflags: -I${includedir}
 Libs: -L${libdir} -lcjose

--- a/cjose.pc.in
+++ b/cjose.pc.in
@@ -11,6 +11,6 @@ Name: cjose
 URL: https://github.com/cisco/cjose
 Description: JOSE implementation for C
 Version: @VERSION@
-Requires: jansson >= 2.6, libcrypto >= 1.0.1
+Requires: jansson >= 2.4, libcrypto >= 1.0.1
 Cflags: -I${includedir}
 Libs: -L${libdir} -lcjose

--- a/src/header.c
+++ b/src/header.c
@@ -47,7 +47,7 @@ const char *CJOSE_HDR_KID = "kid";
 cjose_header_t *cjose_header_new(
         cjose_err *err)
 {
-    cjose_header_t *retval = json_object();
+    cjose_header_t *retval = (cjose_header_t *)json_object();
     if (NULL == retval)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
@@ -61,7 +61,7 @@ cjose_header_t *cjose_header_retain(
 {
     if (NULL != header)
     {
-        header = json_incref(header);
+        header = (cjose_header_t *)json_incref((json_t *)header);
     }
     return header;
 }
@@ -72,7 +72,7 @@ void cjose_header_release(
 {
     if (NULL != header)
     {
-        json_decref(header);
+        json_decref((json_t *)header);
     }
 }
 
@@ -98,7 +98,7 @@ bool cjose_header_set(
     }
 
     json_object_set(
-            header, attr, value_obj);
+            (json_t *)header, attr, value_obj);
 
     json_decref(value_obj);
 
@@ -118,7 +118,7 @@ const char *cjose_header_get(
         return NULL;
     }
 
-    json_t *value_obj = json_object_get(header, attr);
+    json_t *value_obj = json_object_get((json_t *)header, attr);
     if (NULL == value_obj)
     {
         return NULL;

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -140,11 +140,11 @@ static bool _cjose_jwe_build_hdr(
         cjose_err *err)
 {
     // save header object as part of the JWE (and incr. refcount)
-    jwe->hdr = header;
+    jwe->hdr = (json_t *)header;
     json_incref(jwe->hdr);
 
     // serialize the header
-    char *hdr_str = json_dumps(header, JSON_ENCODE_ANY | JSON_PRESERVE_ORDER);
+    char *hdr_str = json_dumps(jwe->hdr, JSON_ENCODE_ANY | JSON_PRESERVE_ORDER);
     if (NULL == hdr_str)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
@@ -175,7 +175,7 @@ static bool _cjose_jwe_validate_hdr(
         cjose_err *err)
 {
     // make sure we have an alg header
-    json_t *alg_obj = json_object_get(header, CJOSE_HDR_ALG);
+    json_t *alg_obj = json_object_get((json_t *)header, CJOSE_HDR_ALG);
     if (NULL == alg_obj)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -184,7 +184,7 @@ static bool _cjose_jwe_validate_hdr(
     const char *alg = json_string_value(alg_obj);
 
     // make sure we have an enc header
-    json_t *enc_obj = json_object_get(header, CJOSE_HDR_ENC);
+    json_t *enc_obj = json_object_get((json_t *)header, CJOSE_HDR_ENC);
     if (NULL == enc_obj)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1381,7 +1381,7 @@ cjose_jwe_t *cjose_jwe_import(
     }
 
     // validate the JSON header
-    if (!_cjose_jwe_validate_hdr(jwe, jwe->hdr, err))
+    if (!_cjose_jwe_validate_hdr(jwe, (cjose_header_t *)jwe->hdr, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         cjose_jwe_release(jwe);
@@ -1433,5 +1433,5 @@ cjose_header_t *cjose_jwe_get_protected(cjose_jwe_t *jwe)
     {
         return NULL;
     }
-    return jwe->hdr;
+    return (cjose_header_t *)jwe->hdr;
 }

--- a/src/jws.c
+++ b/src/jws.c
@@ -82,7 +82,7 @@ static bool _cjose_jws_build_hdr(
         cjose_err *err)
 {
     // save header object as part of the JWS (and incr. refcount)
-    jws->hdr = header;
+    jws->hdr = (json_t *)header;
     json_incref(jws->hdr);
 
     // base64url encode the header
@@ -1202,5 +1202,5 @@ cjose_header_t *cjose_jws_get_protected(
         return NULL;
     }
 
-    return jws->hdr;
+    return (cjose_header_t *)jws->hdr;
 }

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -143,8 +143,8 @@ static void _self_encrypt_self_decrypt_with_key(
 
     // confirm plain2 == plain1
     ck_assert(json_equal(
-        cjose_jwe_get_protected(jwe1),
-        cjose_jwe_get_protected(jwe2)));
+        (json_t *)cjose_jwe_get_protected(jwe1),
+        (json_t *)cjose_jwe_get_protected(jwe2)));
     ck_assert_msg(
             plain2_len == strlen(plain1),
             "length of decrypted plaintext does not match length of original, "

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -458,7 +458,7 @@ START_TEST(test_cjose_jwe_import_export_compare)
             err.message, err.file, err.function, err.line);
 
     // re-export the jwe object
-    const char *cser = cjose_jwe_export(jwe, &err);
+    char *cser = cjose_jwe_export(jwe, &err);
     ck_assert_msg(NULL != cser,
             "re-export of imported JWE failed: "
             "%s, file: %s, function: %s, line: %ld", 

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -447,7 +447,7 @@ START_TEST(test_cjose_jwk_to_json_oct)
     jwk = cjose_jwk_create_oct_spec(k, klen, &err);
     cjose_get_dealloc()(k);
 
-    const char *json;
+    char *json;
     json = cjose_jwk_to_json(jwk, false, &err);
     ck_assert(NULL != json);
     ck_assert_str_eq("{\"kty\":\"oct\"}", json);
@@ -478,7 +478,7 @@ START_TEST(test_cjose_jwk_to_json_ec)
     cjose_get_dealloc()(spec.x);
     cjose_get_dealloc()(spec.y);
 
-    const char *json;
+    char *json;
     json = cjose_jwk_to_json(jwk, false, &err);
     ck_assert(NULL != json);
     ck_assert_str_eq(
@@ -533,7 +533,7 @@ START_TEST(test_cjose_jwk_to_json_rsa)
     cjose_get_dealloc()(spec.dq);
     cjose_get_dealloc()(spec.qi);
 
-    const char *json;
+    char *json;
     json = cjose_jwk_to_json(jwk, false, &err);
     ck_assert(NULL != json);
     ck_assert_str_eq(RSA_PUBLIC_JSON, json);
@@ -673,7 +673,7 @@ START_TEST(test_cjose_jwk_import_valid)
         ck_assert(NULL != left_json);
 
         // get json representation of "after" 
-        const char *jwk_str = cjose_jwk_to_json(jwk, true, &err);
+        char *jwk_str = cjose_jwk_to_json(jwk, true, &err);
         json_t *right_json = json_loads(jwk_str, 0, NULL);
         ck_assert(NULL != right_json);
 
@@ -852,7 +852,7 @@ START_TEST(test_cjose_jwk_import_no_zero_termination)
     ck_assert(NULL != left_json);
 
     // get json representation of "after" 
-    const char *jwk_str = cjose_jwk_to_json(jwk, true, &err);
+    char *jwk_str = cjose_jwk_to_json(jwk, true, &err);
     json_t *right_json = json_loads(jwk_str, 0, NULL);
     ck_assert(NULL != right_json);
 
@@ -896,7 +896,7 @@ START_TEST(test_cjose_jwk_import_with_base64url_padding)
     ck_assert(NULL != left_json);
 
     // get json representation of "actual" (i.e. reserialized original)
-    const char *jwk_str = cjose_jwk_to_json(jwk, true, &err);
+    char *jwk_str = cjose_jwk_to_json(jwk, true, &err);
     json_t *right_json = json_loads(jwk_str, 0, NULL);
     ck_assert(NULL != right_json);        
 
@@ -941,7 +941,7 @@ START_TEST(test_cjose_jwk_EC_import_with_priv_export_with_pub)
     ck_assert(NULL != left_json);
 
     // get json representation of "actual" (i.e. reserialized original)
-    const char *jwk_str = cjose_jwk_to_json(jwk, true, &err);
+    char *jwk_str = cjose_jwk_to_json(jwk, true, &err);
     json_t *right_json = json_loads(jwk_str, 0, NULL);
     ck_assert(NULL != right_json);        
 
@@ -1058,7 +1058,7 @@ START_TEST(test_cjose_jwk_get_and_set_kid)
     ck_assert(sizeof(JWK_BEFORE) == sizeof(JWK_AFTER));
 
     const char *kid = NULL;
-    const char *json = NULL;
+    char *json = NULL;
     for (int i = 0; JWK_BEFORE[i] != NULL; ++i)
     {
         // import the before state

--- a/test/check_jws.c
+++ b/test/check_jws.c
@@ -82,7 +82,7 @@ static void _self_sign_self_verify(
     ck_assert(hdr == cjose_jws_get_protected(jws1));
 
     // get the compact serialization of JWS
-    char *compact = NULL;
+    const char *compact = NULL;
     ck_assert_msg(
             cjose_jws_export(jws1, &compact, err),
             "cjose_jws_export failed: "

--- a/test/check_jws.c
+++ b/test/check_jws.c
@@ -111,8 +111,8 @@ static void _self_sign_self_verify(
 
     // confirm equal headers
     ck_assert(json_equal(
-        cjose_jws_get_protected(jws1),
-        cjose_jws_get_protected(jws2)));
+        (json_t *)cjose_jws_get_protected(jws1),
+        (json_t *)cjose_jws_get_protected(jws2)));
 
     // confirm plain2 == plain1
     ck_assert_msg(
@@ -929,7 +929,7 @@ START_TEST(test_cjose_jws_none)
             err.message, err.file, err.function, err.line);
 
     // try to sign the unsecured JWS
-    ck_assert_msg(!cjose_jws_sign(jwk, jws->hdr, PLAINTEXT, strlen(PLAINTEXT), &err),
+    ck_assert_msg(!cjose_jws_sign(jwk, (cjose_header_t *)jws->hdr, PLAINTEXT, strlen(PLAINTEXT), &err),
             "cjose_jws_sign succeeded for unsecured JWT");
 
     cjose_jws_release(jws);


### PR DESCRIPTION
I did packaging on a lot of platforms (CentOS 6/7, Debian Wheezy/Jessie/Stretch, Ubuntu Precise/Trusty/Vivid/Wily/Xenial) and found that:

a) Jansson 2.3 still works with cjose 0.4.0 (tested on stock Debian Wheezy).
b) some compilers (settings) are pickier than others wrt. casting

This PR addresses build/compile issues on all platforms mentioned.

FWIW: I would really like a 0.4.1 because of this...
