### PR TITLE
Add NULL terminator to the end of the buffer.

### DIFF
--- a/src/base64.c
+++ b/src/base64.c
@@ -139,6 +139,8 @@ static inline bool _decode(const char *input, size_t inlen, uint8_t **output, si
         buffer[pos++] = (packed >> 16) & 0xff;
     }
 
+    buffer[pos] = '\0';
+
     *output = buffer;
     *outlen = pos;
     assert(*outlen <= rlen);


### PR DESCRIPTION
I added a NULL terminator to the end of the buffer so that other functions expecting the NULL terminator would see it. Not having the NULL terminator was causing issues with JSON deserialization for some JWEs we where working with.