### PR TITLE
LibreSSL support.

### DIFF
--- a/include/cjose/util.h
+++ b/include/cjose/util.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-#define CJOSE_OPENSSL_11X OPENSSL_VERSION_NUMBER >= 0x10100005L
+#define CJOSE_OPENSSL_11X OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)
 
 /**
  * Macro to explicitly mark a parameter unused, and usable across multiple


### PR DESCRIPTION
With this small change, cjose works well with [LibreSSL](https://www.libressl.org).  All tests pass on OpenBSD 6.1 with bundled LibreSSL and macOS 10.13 with LibreSSL 2.5.5 installed via brew.