### PR TITLE
chore: re-enable all encryption tests

### DIFF
--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -189,7 +189,6 @@ static void _self_encrypt_self_decrypt_with_key(const char *alg, const char *enc
 
 static void _self_encrypt_self_decrypt(const char *plain1)
 {
-    /*
     _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_RSA_OAEP, CJOSE_HDR_ENC_A256GCM, JWK_RSA, plain1);
 
     _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_RSA1_5, CJOSE_HDR_ENC_A256GCM, JWK_RSA, plain1);
@@ -201,7 +200,6 @@ static void _self_encrypt_self_decrypt(const char *plain1)
     _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_A192KW, CJOSE_HDR_ENC_A192CBC_HS384, JWK_OCT, plain1);
 
     _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_A256KW, CJOSE_HDR_ENC_A256CBC_HS512, JWK_OCT, plain1);
-    //*/
 
     _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_ECDH_ES, CJOSE_HDR_ENC_A256GCM, JWK_EC, plain1);
 }
@@ -1138,8 +1136,6 @@ Suite *cjose_jwe_suite()
 
     TCase *tc_jwe = tcase_create("core");
     tcase_set_timeout(tc_jwe, 120.0);
-    tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt);
-    /*
     tcase_add_test(tc_jwe, test_cjose_jwe_node_jose_encrypt_self_decrypt);
     tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt);
     tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt_short);
@@ -1155,7 +1151,6 @@ Suite *cjose_jwe_suite()
     tcase_add_test(tc_jwe, test_cjose_jwe_import_invalid_serialization);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_bad_params);
     tcase_add_test(tc_jwe, test_cjose_jwe_multiple_recipients);
-    //*/
     suite_add_tcase(suite, tc_jwe);
 
     return suite;


### PR DESCRIPTION
tests mistakenly left disabled while working through ECDH-ES.