### PR TITLE
Prevent segmentation fault when using A256KW + A256GCM

### DIFF
--- a/src/include/jwe_int.h
+++ b/src/include/jwe_int.h
@@ -35,7 +35,7 @@ typedef struct _jwe_rec_fntable_int
 typedef struct _jwe_fntable_int
 {
 
-    bool (*set_cek)(cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err);
+    bool (*set_cek)(cjose_jwe_t *jwe, const cjose_jwk_t *jwk, bool prealloc, cjose_err *err);
 
     bool (*set_iv)(cjose_jwe_t *jwe, cjose_err *err);
 

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -201,6 +201,8 @@ static void _self_encrypt_self_decrypt(const char *plain1)
 
     _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_A256KW, CJOSE_HDR_ENC_A256CBC_HS512, JWK_OCT, plain1);
 
+    _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_A128KW, CJOSE_HDR_ENC_A256GCM, JWK_OCT, plain1);
+
     _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_ECDH_ES, CJOSE_HDR_ENC_A256GCM, JWK_EC, plain1);
 }
 


### PR DESCRIPTION
Fixes #66 

There was an abuse of a pointer in one place that tried to treat it as a boolean flag; the abuse had unintended side effects when certain algorithm choices were used in concert.

There are other inconsistencies within some of the AES-CBC flows, but this takes care of the most egregious.