### PR TITLE
preserve key order in order to be able to compare serialized JWTs

### DIFF
--- a/src/jwe.c
+++ b/src/jwe.c
@@ -1640,7 +1640,7 @@ char *cjose_jwe_export_json(cjose_jwe_t *jwe, cjose_err *err)
         }
     }
 
-    char *json_str = json_dumps(form, 0);
+    char *json_str = json_dumps(form, JSON_PRESERVE_ORDER);
     if (NULL == json_str)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);


### PR DESCRIPTION
`_cjose_test_json_serial` in `check_jwe` would fail with older versions of
Jansson that don't have the JSON_PRESERVE_ORDER flag set by default

this would happen e.g. on Ubuntu Xenial