### PR TITLE
Minor updates for conformance

### DIFF
--- a/src/base64.c
+++ b/src/base64.c
@@ -229,20 +229,20 @@ static inline bool _encode(const uint8_t *input, size_t inlen, char **output, si
 
 // interface functions
 
-bool cjose_base64_encode(const uint8_t *input, size_t inlen, char **output, size_t *outlen, cjose_err *err)
+bool cjose_base64_encode(const uint8_t *input, const size_t inlen, char **output, size_t *outlen, cjose_err *err)
 {
     return _encode(input, inlen, output, outlen, ALPHABET_B64, err);
 }
-bool cjose_base64url_encode(const uint8_t *input, size_t inlen, char **output, size_t *outlen, cjose_err *err)
+bool cjose_base64url_encode(const uint8_t *input, const size_t inlen, char **output, size_t *outlen, cjose_err *err)
 {
     return _encode(input, inlen, output, outlen, ALPHABET_B64U, err);
 }
 
-bool cjose_base64_decode(const char *input, size_t inlen, uint8_t **output, size_t *outlen, cjose_err *err)
+bool cjose_base64_decode(const char *input, const size_t inlen, uint8_t **output, size_t *outlen, cjose_err *err)
 {
     return _decode(input, inlen, output, outlen, false, err);
 }
-bool cjose_base64url_decode(const char *input, size_t inlen, uint8_t **output, size_t *outlen, cjose_err *err)
+bool cjose_base64url_decode(const char *input, const size_t inlen, uint8_t **output, size_t *outlen, cjose_err *err)
 {
     return _decode(input, inlen, output, outlen, true, err);
 }

--- a/src/include/concatkdf_int.h
+++ b/src/include/concatkdf_int.h
@@ -14,7 +14,7 @@
 #include <cjose/header.h>
 
 bool cjose_concatkdf_create_otherinfo(const char *alg,
-                                      size_t keylen,
+                                      const size_t keylen,
                                       cjose_header_t *hdr,
                                       uint8_t **otherinfo, size_t *otherinfoLen,
                                       cjose_err *err);

--- a/src/jws.c
+++ b/src/jws.c
@@ -59,10 +59,10 @@ static bool _cjose_jws_build_hdr(cjose_jws_t *jws, cjose_header_t *header, cjose
     }
     if (!cjose_base64url_encode((const uint8_t *)hdr_str, strlen(hdr_str), &jws->hdr_b64u, &jws->hdr_b64u_len, err))
     {
-        free(hdr_str);
+        cjose_get_dealloc()(hdr_str);
         return false;
     }
-    free(hdr_str);
+    cjose_get_dealloc()(hdr_str);
 
     return true;
 }


### PR DESCRIPTION
Minor updates for standards conformance issues (const qualifiers differ in .c and .h files) found when building with VS2017.
jws.c files are updated to use the cjose dealloc function instead of free so it points to the right function pointer when allocating memory functions through cjose_set_alloc_funcs() 