### PR TITLE
Support FIPS-mode in cjose_jwk_derive_ecdh_ephemeral_key

### DIFF
--- a/include/cjose/jwk.h
+++ b/include/cjose/jwk.h
@@ -357,17 +357,27 @@ cjose_jwk_t *cjose_jwk_import_json(cjose_header_t *json, cjose_err *err);
  *
  * \param jwk_self [in] The caller's own EC key pair.
  * \param jwk_peer [in] The peer's EC public key.
+ * \param salt [in] An optional salt to apply to the HMAC calculation. Unless FIPS mode is required this can be empty.
+ * \param salt_len [in] The length of the optional salt.
  * \param err [out] An optional error object which can be used to get additional
  *        information in the event of an error.
  * \returns A new JWK representing the ephemeral key, or NULL in the event of
  *        and error.
  */
-cjose_jwk_t *cjose_jwk_derive_ecdh_ephemeral_key(const cjose_jwk_t *jwk_self, const cjose_jwk_t *jwk_peer, cjose_err *err);
+cjose_jwk_t *cjose_jwk_derive_ecdh_ephemeral_key(const cjose_jwk_t *jwk_self, 
+                                                 const cjose_jwk_t *jwk_peer, 
+                                                 const uint8_t *salt,
+                                                 size_t salt_len, 
+                                                 cjose_err *err);
 
 /**
  Deprecated.  Alias for cjose_jwk_derive_ecdh_ephemeral_key.
 */
-cjose_jwk_t *cjose_jwk_derive_ecdh_secret(const cjose_jwk_t *jwk_self, const cjose_jwk_t *jwk_peer, cjose_err *err);
+cjose_jwk_t *cjose_jwk_derive_ecdh_secret(const cjose_jwk_t *jwk_self, 
+                                          const cjose_jwk_t *jwk_peer, 
+                                          const uint8_t *salt,
+                                          size_t salt_len, 
+                                          cjose_err *err);
 
 #ifdef __cplusplus
 }

--- a/include/cjose/jwk.h
+++ b/include/cjose/jwk.h
@@ -26,7 +26,8 @@ extern "C" {
 #endif
 
 /** Enumeration of supported JSON Web Key (JWK) types */
-typedef enum {
+typedef enum
+{
     /** RSA Public (or Private) Key */
     CJOSE_JWK_KTY_RSA = 1,
     /** Elliptic Curve Public (or Private) Key */
@@ -212,7 +213,8 @@ cjose_jwk_t *cjose_jwk_create_RSA_random(size_t keysize, const uint8_t *e, size_
 cjose_jwk_t *cjose_jwk_create_RSA_spec(const cjose_jwk_rsa_keyspec *spec, cjose_err *err);
 
 /** Enumeration of supported Elliptic-Curve types */
-typedef enum {
+typedef enum
+{
     /** NIST P-256 Prime Curve (secp256r1) */
     CJOSE_JWK_EC_P_256 = NID_X9_62_prime256v1,
     /** NIST P-384 Prime Curve (secp384r1) */
@@ -364,20 +366,14 @@ cjose_jwk_t *cjose_jwk_import_json(cjose_header_t *json, cjose_err *err);
  * \returns A new JWK representing the ephemeral key, or NULL in the event of
  *        and error.
  */
-cjose_jwk_t *cjose_jwk_derive_ecdh_ephemeral_key(const cjose_jwk_t *jwk_self, 
-                                                 const cjose_jwk_t *jwk_peer, 
-                                                 const uint8_t *salt,
-                                                 size_t salt_len, 
-                                                 cjose_err *err);
+cjose_jwk_t *cjose_jwk_derive_ecdh_ephemeral_key(
+    const cjose_jwk_t *jwk_self, const cjose_jwk_t *jwk_peer, const uint8_t *salt, size_t salt_len, cjose_err *err);
 
 /**
  Deprecated.  Alias for cjose_jwk_derive_ecdh_ephemeral_key.
 */
-cjose_jwk_t *cjose_jwk_derive_ecdh_secret(const cjose_jwk_t *jwk_self, 
-                                          const cjose_jwk_t *jwk_peer, 
-                                          const uint8_t *salt,
-                                          size_t salt_len, 
-                                          cjose_err *err);
+cjose_jwk_t *cjose_jwk_derive_ecdh_secret(
+    const cjose_jwk_t *jwk_self, const cjose_jwk_t *jwk_peer, const uint8_t *salt, size_t salt_len, cjose_err *err);
 
 #ifdef __cplusplus
 }

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -1695,20 +1695,14 @@ _cjose_jwk_evp_key_from_ec_key_fail:
     return false;
 }
 
-cjose_jwk_t *cjose_jwk_derive_ecdh_secret(const cjose_jwk_t *jwk_self, 
-                                          const cjose_jwk_t *jwk_peer, 
-                                          const uint8_t *salt,
-                                          size_t salt_len,
-                                          cjose_err *err)
+cjose_jwk_t *cjose_jwk_derive_ecdh_secret(
+    const cjose_jwk_t *jwk_self, const cjose_jwk_t *jwk_peer, const uint8_t *salt, size_t salt_len, cjose_err *err)
 {
     return cjose_jwk_derive_ecdh_ephemeral_key(jwk_self, jwk_peer, salt, salt_len, err);
 }
 
-cjose_jwk_t *cjose_jwk_derive_ecdh_ephemeral_key(const cjose_jwk_t *jwk_self, 
-                                                 const cjose_jwk_t *jwk_peer, 
-                                                 const uint8_t *salt,
-                                                 size_t salt_len,
-                                                 cjose_err *err)
+cjose_jwk_t *cjose_jwk_derive_ecdh_ephemeral_key(
+    const cjose_jwk_t *jwk_self, const cjose_jwk_t *jwk_peer, const uint8_t *salt, size_t salt_len, cjose_err *err)
 {
     uint8_t *secret = NULL;
     size_t secret_len = 0;
@@ -1724,8 +1718,7 @@ cjose_jwk_t *cjose_jwk_derive_ecdh_ephemeral_key(const cjose_jwk_t *jwk_self,
     // HKDF of the DH shared secret (SHA256, no info, 256 bit expand)
     ephemeral_key_len = 32;
     ephemeral_key = (uint8_t *)cjose_get_alloc()(ephemeral_key_len);
-    if (!cjose_jwk_hkdf(EVP_sha256(), salt, salt_len, (uint8_t *)"", 0, secret, secret_len, ephemeral_key, ephemeral_key_len,
-                        err))
+    if (!cjose_jwk_hkdf(EVP_sha256(), salt, salt_len, (uint8_t *)"", 0, secret, secret_len, ephemeral_key, ephemeral_key_len, err))
     {
         goto _cjose_jwk_derive_shared_secret_fail;
     }
@@ -1755,11 +1748,8 @@ _cjose_jwk_derive_shared_secret_fail:
     return NULL;
 }
 
-bool cjose_jwk_derive_ecdh_bits(const cjose_jwk_t *jwk_self,
-                                const cjose_jwk_t *jwk_peer,
-                                uint8_t **output,
-                                size_t *output_len,
-                                cjose_err *err)
+bool cjose_jwk_derive_ecdh_bits(
+    const cjose_jwk_t *jwk_self, const cjose_jwk_t *jwk_peer, uint8_t **output, size_t *output_len, cjose_err *err)
 {
     EVP_PKEY_CTX *ctx = NULL;
     EVP_PKEY *pkey_self = NULL;
@@ -1873,7 +1863,7 @@ bool cjose_jwk_hkdf(const EVP_MD *md,
     // HKDF-Extract, HMAC-SHA256(salt, IKM) -> PRK
     unsigned int prk_len;
     unsigned char prk[EVP_MAX_MD_SIZE];
-    if(NULL == HMAC(md, salt, salt_len, ikm, ikm_len, prk, &prk_len))
+    if (NULL == HMAC(md, salt, salt_len, ikm, ikm_len, prk, &prk_len))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return false;
@@ -1881,7 +1871,7 @@ bool cjose_jwk_hkdf(const EVP_MD *md,
 
     // HKDF-Expand, HMAC-SHA256(PRK,0x01) -> OKM
     const unsigned char t[] = { 0x01 };
-    if(NULL == HMAC(md, prk, prk_len, t, sizeof(t), okm, NULL))
+    if (NULL == HMAC(md, prk, prk_len, t, sizeof(t), okm, NULL))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return false;

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -1865,7 +1865,7 @@ bool cjose_jwk_hkdf(const EVP_MD *md,
     unsigned char prk[EVP_MAX_MD_SIZE];
     if (NULL == HMAC(md, salt, salt_len, ikm, ikm_len, prk, &prk_len))
     {
-        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         return false;
     }
 
@@ -1873,7 +1873,7 @@ bool cjose_jwk_hkdf(const EVP_MD *md,
     const unsigned char t[] = { 0x01 };
     if (NULL == HMAC(md, prk, prk_len, t, sizeof(t), okm, NULL))
     {
-        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         return false;
     }
 


### PR DESCRIPTION
Adding an optional salt parameter to cjose_jwk_derive_ecdh_ephemeral_key

In OpenSSL FIPS-mode, calling the HMAC API with an empty salt results in an error.
In order to maintain current behaviour, pass in an empty string as a salt.
Also missing in this code was checking the return value from the call to HMAC.