### PR TITLE
Encode JWS as compact JSON

### DIFF
--- a/src/jwe.c
+++ b/src/jwe.c
@@ -206,7 +206,7 @@ static bool _cjose_jwe_malloc(size_t bytes, bool random, uint8_t **buffer, cjose
 static bool _cjose_jwe_build_hdr(cjose_jwe_t *jwe, cjose_err *err)
 {
     // serialize the header
-    char *hdr_str = json_dumps(jwe->hdr, JSON_ENCODE_ANY | JSON_PRESERVE_ORDER);
+    char *hdr_str = json_dumps(jwe->hdr, JSON_ENCODE_ANY | JSON_PRESERVE_ORDER | JSON_COMPACT);
     if (NULL == hdr_str)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);

--- a/src/jws.c
+++ b/src/jws.c
@@ -51,7 +51,7 @@ static bool _cjose_jws_build_hdr(cjose_jws_t *jws, cjose_header_t *header, cjose
     json_incref(jws->hdr);
 
     // base64url encode the header
-    char *hdr_str = json_dumps(jws->hdr, JSON_ENCODE_ANY | JSON_PRESERVE_ORDER);
+    char *hdr_str = json_dumps(jws->hdr, JSON_ENCODE_ANY | JSON_PRESERVE_ORDER | JSON_COMPACT);
     if (NULL == hdr_str)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);


### PR DESCRIPTION
Currently, the JOSE header is encoded with unnecessary spaces. This makes the compact serialization larger than it needs to be. This requests compact JSON from Jansson.

Note that I have not run clang-format on this (see #98), but have run tests.