### PR TITLE
Fix buffer overflow in test_cjose_jwe_multiple_recipients().

### DIFF
--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -1151,8 +1151,6 @@ START_TEST(test_cjose_jwe_multiple_recipients)
         rec[i].unprotected_header = unprotected;
     }
 
-    rec[2].jwk = NULL;
-
     cjose_header_t *protected_header = cjose_header_new(&err);
 
     ck_assert_msg(cjose_header_set(protected_header, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err),


### PR DESCRIPTION
The function allocates two cjose_jwe_recipient_t on the stack and then writes at index 2, which is out of bounds. The NULL pointer also seems unnecessary because cjose_jwe_encrypt_multi() takes a count as its argument.