### PR TITLE
Fix all-zero content encryption key (CEK) for AES-CBC-HMAC JWE encryption

### DIFF
--- a/src/jwe.c
+++ b/src/jwe.c
@@ -455,11 +455,11 @@ static bool _cjose_jwe_set_cek_aes_cbc(cjose_jwe_t *jwe, const cjose_jwk_t *jwk,
     if (strcmp(enc, CJOSE_HDR_ENC_A256CBC_HS512) == 0)
         keysize = 64;
 
+    // if no JWK is provided, generate a random key
     if (NULL == jwk)
     {
-        // allocate memory for the CEK and fill with random bytes or 0's
         _cjose_release_cek(&jwe->cek, jwe->cek_len);
-        if (!_cjose_jwe_malloc(keysize, !random, &jwe->cek, err))
+        if (!_cjose_jwe_malloc(keysize, random, &jwe->cek, err))
         {
             return false;
         }

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -1197,6 +1197,63 @@ START_TEST(test_cjose_jwe_multiple_recipients)
 }
 END_TEST
 
+// regression test for the AES-CBC-HMAC content-encryption key (CEK): it must
+// be generated from fresh random bytes on every encryption. A previous bug
+// zero-filled it (inverted random flag); because AES key wrap is deterministic,
+// that produced a byte-identical encrypted_key on every encryption with the
+// same KEK. Encrypt the same plaintext twice and assert the encrypted_key (the
+// 2nd compact field) differs.
+static void _assert_cbc_cek_random(const char *alg, const char *enc, const char *jwk_str)
+{
+    cjose_err err;
+
+    cjose_jwk_t *jwk = cjose_jwk_import(jwk_str, strlen(jwk_str), &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
+
+    cjose_header_t *hdr = cjose_header_new(&err);
+    ck_assert_msg(NULL != hdr, "cjose_header_new failed: %s", err.message);
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, alg, &err));
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, enc, &err));
+
+    const char *plain = "Setec Astronomy";
+    char ek[2][512];
+
+    for (int i = 0; i < 2; i++)
+    {
+        cjose_jwe_t *jwe = cjose_jwe_encrypt(jwk, hdr, (const uint8_t *)plain, strlen(plain), &err);
+        ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed (%s/%s): %s", alg, enc, err.message);
+
+        char *cser = cjose_jwe_export(jwe, &err);
+        ck_assert_msg(NULL != cser, "cjose_jwe_export failed: %s", err.message);
+
+        // the encrypted_key is the 2nd of the 5 dot-separated compact parts
+        const char *d1 = strchr(cser, '.');
+        const char *d2 = (NULL != d1) ? strchr(d1 + 1, '.') : NULL;
+        ck_assert_msg(NULL != d1 && NULL != d2, "malformed compact serialization");
+        size_t n = (size_t)(d2 - (d1 + 1));
+        ck_assert_msg(n > 0 && n < sizeof(ek[i]), "unexpected encrypted_key length");
+        memcpy(ek[i], d1 + 1, n);
+        ek[i][n] = '\0';
+
+        cjose_get_dealloc()(cser);
+        cjose_jwe_release(jwe);
+    }
+
+    ck_assert_msg(0 != strcmp(ek[0], ek[1]),
+                  "AES-CBC-HMAC CEK is not random: identical encrypted_key across two encryptions (%s/%s)", alg, enc);
+
+    cjose_header_release(hdr);
+    cjose_jwk_release(jwk);
+}
+
+START_TEST(test_cjose_jwe_encrypt_cbc_cek_random)
+{
+    _assert_cbc_cek_random(CJOSE_HDR_ALG_A128KW, CJOSE_HDR_ENC_A128CBC_HS256, JWK_OCT_16);
+    _assert_cbc_cek_random(CJOSE_HDR_ALG_A192KW, CJOSE_HDR_ENC_A192CBC_HS384, JWK_OCT_24);
+    _assert_cbc_cek_random(CJOSE_HDR_ALG_A256KW, CJOSE_HDR_ENC_A256CBC_HS512, JWK_OCT_32);
+}
+END_TEST
+
 Suite *cjose_jwe_suite()
 {
     Suite *suite = suite_create("jwe");
@@ -1218,6 +1275,7 @@ Suite *cjose_jwe_suite()
     tcase_add_test(tc_jwe, test_cjose_jwe_import_invalid_serialization);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_bad_params);
     tcase_add_test(tc_jwe, test_cjose_jwe_multiple_recipients);
+    tcase_add_test(tc_jwe, test_cjose_jwe_encrypt_cbc_cek_random);
     suite_add_tcase(suite, tc_jwe);
 
     return suite;


### PR DESCRIPTION
### Summary
When encrypting a JWE with an AES-CBC-HMAC content-encryption algorithm
(`A128CBC-HS256`, `A192CBC-HS384`, `A256CBC-HS512`) and a key-management
algorithm that generates a fresh content-encryption key (CEK), the CEK is
**all zero bytes** instead of being randomly generated. The produced JWE is
therefore encrypted and authenticated under a fixed, publicly known key.

### Impact
For affected JWEs both confidentiality and integrity are lost:
- the AES-CBC key is a known constant (zeros), so the ciphertext can be
  decrypted by anyone, and
- the HMAC key is the same constant, so the authentication tag can be
  recomputed and the content forged.

This affects the **encryption** side (JWEs produced by cjose). Existing
ciphertexts produced with an affected algorithm pair should be treated as
compromised.

### Affected configurations
Triggered only when both hold at encryption time:
- `enc` is one of `A128CBC-HS256`, `A192CBC-HS384`, `A256CBC-HS512`, and
- `alg` is one of `A128KW`, `A192KW`, `A256KW`, `RSA-OAEP`, `RSA1_5` (any alg
  that asks cjose to generate a random CEK).

**Not affected:** `dir` (CEK comes from the JWK), all AES-GCM `enc` values,
`ECDH-ES` (CEK is derived via Concat-KDF), and the decryption path.

### Root cause
`_cjose_jwe_set_cek_aes_cbc()` allocated the CEK with the `random` flag
inverted:

```c
/* before */
if (!_cjose_jwe_malloc(keysize, !random, &jwe->cek, err))   /* note: !random */
```

`_cjose_jwe_malloc(..., random=true, ...)` fills the buffer via `RAND_bytes`,
while `random=false` zero-fills it. On the encryption path the caller passes
`random = true`, so `!random` zero-fills the CEK. The sibling AES-GCM helper
`_cjose_jwe_set_cek_aes_gcm()` correctly passes `random`, which is why GCM is
unaffected. The defect dates back to #68 ("Better support for AES-CBC-HMAC
with other key management algs").

### Fix
Pass `random` directly so the CEK is generated from `RAND_bytes`:

```c
/* after */
if (!_cjose_jwe_malloc(keysize, random, &jwe->cek, err))
```

### Testing
Adds `test_cjose_jwe_encrypt_cbc_cek_random` to `test/check_jwe.c`: it encrypts
the same plaintext twice for each AES-CBC-HMAC variant and asserts the
`encrypted_key` differs. Because AES Key Wrap is deterministic, a fixed CEK
yields a byte-identical `encrypted_key` — so this test fails before the fix and
passes after it. Full suite passes (`Checks: 77, Failures: 0, Errors: 0`).

> Note: this tree predates OpenSSL 3.x support, so building against OpenSSL 3
> with `-Werror` fails on unrelated deprecation warnings in `jwk.c`. I verified
> the build/tests with `CFLAGS=-DOPENSSL_API_COMPAT=0x10000000L`; no source
> change to that effect is included here.

### References
The same issue was found and fixed in the maintained fork (OpenIDC/cjose,
v0.6.2.6) and is tracked in security advisory
[GHSA-f6wf-pqg3-6wqq](https://github.com/OpenIDC/cjose/security/advisories/GHSA-f6wf-pqg3-6wqq).
