### PR TITLE
 Define OPENSSL_API_COMPAT=0x10100000L in the default CFLAGS

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS =-std=gnu99 --pedantic -Wall -Werror -g -O2 -I$(top_builddir)/include
+AM_CFLAGS =-std=gnu99 --pedantic -Wall -Werror -g -O2 -DOPENSSL_API_COMPAT=0x10100000L -I$(top_builddir)/include
 
 lib_LTLIBRARIES=libcjose.la
 libcjose_la_CPPFLAGS= -I$(topdir)/include

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -358,7 +358,7 @@ target_alias = @target_alias@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
-AM_CFLAGS = -std=gnu99 --pedantic -Wall -Werror -g -O2 -I$(top_builddir)/include
+AM_CFLAGS = -std=gnu99 --pedantic -Wall -Werror -g -O2 -DOPENSSL_API_COMPAT=0x10100000L -I$(top_builddir)/include
 lib_LTLIBRARIES = libcjose.la
 libcjose_la_CPPFLAGS = -I$(topdir)/include
 libcjose_la_LDFLAGS = -lm


### PR DESCRIPTION
 Define OPENSSL_API_COMPAT=0x10100000L in the default CFLAGS so OpenSSL 3 deprecation warnings for legacy RSA APIs do not fail the build under -Werror.  Followup work will be to remove usage of deprecated features.