### PR TITLE
fix-build-warnings

### DIFF
--- a/test/check_base64.c
+++ b/test/check_base64.c
@@ -429,7 +429,7 @@ START_TEST(test_cjose_base64url_decode)
 }
 END_TEST
 
-Suite *cjose_base64_suite()
+Suite *cjose_base64_suite(void)
 {
     Suite *suite = suite_create("base64");
 

--- a/test/check_cjose.c
+++ b/test/check_cjose.c
@@ -8,14 +8,14 @@
 #include <openssl/err.h>
 #include <openssl/evp.h>
 
-Suite *cjose_suite()
+Suite *cjose_suite(void)
 {
     Suite *suite = suite_create("CJOSE");
 
     return suite;
 }
 
-int main()
+int main(void)
 {
     // initialize "OpenSSL" crypto
     ERR_load_crypto_strings();

--- a/test/check_cjose.h
+++ b/test/check_cjose.h
@@ -9,24 +9,24 @@
 
 #include <check.h>
 
-Suite *cjose_version_suite();
-Suite *cjose_util_suite();
-Suite *cjose_base64_suite();
-Suite *cjose_jwk_suite();
-Suite *cjose_jwe_suite();
-Suite *cjose_jws_suite();
-Suite *cjose_header_suite();
-Suite *cjose_utils_suite();
-Suite *cjose_concatkdf_suite();
+Suite *cjose_version_suite(void);
+Suite *cjose_util_suite(void);
+Suite *cjose_base64_suite(void);
+Suite *cjose_jwk_suite(void);
+Suite *cjose_jwe_suite(void);
+Suite *cjose_jws_suite(void);
+Suite *cjose_header_suite(void);
+Suite *cjose_utils_suite(void);
+Suite *cjose_concatkdf_suite(void);
 
 #define _ck_assert_bin(X, OP, Y, LEN)                                                                                            \
     do                                                                                                                           \
     {                                                                                                                            \
-        const uint8_t *_chk_x = (X);                                                                                             \
-        const uint8_t *_chk_y = (Y);                                                                                             \
-        const size_t _chk_len = (LEN);                                                                                           \
+        const void *_chk_x = (X);                                                                                                \
+        const void *_chk_y = (Y);                                                                                                \
+        const unsigned int _chk_len = (LEN);                                                                                     \
         ck_assert_msg(0 OP memcmp(_chk_x, _chk_y, _chk_len),                                                                     \
-                      "Assertion '" #X #OP #Y "' failed: " #LEN "==%z, " #X "==0x%zx, " #Y "==0x%zx",                           \
+                      "Assertion '" #X #OP #Y "' failed: " #LEN "==%u, " #X "==0x%p, " #Y "==0x%p",                           \
                       _chk_len, _chk_x, _chk_y);                                                                                 \
     } while (0);
 

--- a/test/check_concatkdf.c
+++ b/test/check_concatkdf.c
@@ -219,7 +219,7 @@ START_TEST(test_cjose_concatkdf_derive_moreinfo)
     ck_assert_bin_eq(derived, expected, keylen);
 }
 END_TEST
-Suite *cjose_concatkdf_suite()
+Suite *cjose_concatkdf_suite(void)
 {
     Suite *suite = suite_create("concatkdf");
 

--- a/test/check_header.c
+++ b/test/check_header.c
@@ -103,7 +103,7 @@ START_TEST(test_cjose_header_set_get_raw)
 }
 END_TEST
 
-Suite *cjose_header_suite()
+Suite *cjose_header_suite(void)
 {
     Suite *suite = suite_create("header");
 

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -1253,7 +1253,7 @@ START_TEST(test_cjose_jwe_multiple_recipients)
 
     cjose_err err;
 
-    cjose_jwe_recipient_t rec[2];
+    cjose_jwe_recipient_t rec[3];
 
     for (int i = 0; i < 2; i++)
     {
@@ -1389,7 +1389,7 @@ START_TEST(test_cjose_jwe_encrypt_cbc_cek_random)
 }
 END_TEST
 
-Suite *cjose_jwe_suite()
+Suite *cjose_jwe_suite(void)
 {
     Suite *suite = suite_create("jwe");
 

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -1496,7 +1496,7 @@ START_TEST(test_cjose_jwk_create_RSA_spec_weak_modulus)
 }
 END_TEST
 
-Suite *cjose_jwk_suite()
+Suite *cjose_jwk_suite(void)
 {
     Suite *suite = suite_create("jwk");
 

--- a/test/check_jws.c
+++ b/test/check_jws.c
@@ -255,7 +255,7 @@ START_TEST(test_cjose_jws_sign_with_bad_header)
     // create a JWS
     jws = cjose_jws_sign(jwk, hdr, plain, plain_len, &err);
     ck_assert_msg(NULL == jws, "cjose_jws_sign created with bad header");
-    ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_sign returned bad err.code (%zu:%s)", err.code, err.message);
+    ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_sign returned bad err.code (%i:%s)", err.code, err.message);
 
     cjose_header_release(hdr);
     cjose_jwk_release(jwk);
@@ -309,7 +309,7 @@ START_TEST(test_cjose_jws_sign_with_bad_key)
 
         jws = cjose_jws_sign(jwk, hdr, plain, plain_len, &err);
         ck_assert_msg(NULL == jws, "cjose_jws_sign created with bad key");
-        ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "%d cjose_jws_sign returned bad err.code (%zu:%s)", i, err.code,
+        ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "%d cjose_jws_sign returned bad err.code (%i:%s)", i, err.code,
                       err.message);
 
         cjose_jwk_release(jwk);
@@ -317,7 +317,7 @@ START_TEST(test_cjose_jws_sign_with_bad_key)
 
     jws = cjose_jws_sign(NULL, hdr, plain, plain_len, &err);
     ck_assert_msg(NULL == jws, "cjose_jws_sign created with bad key");
-    ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_sign returned bad err.code (%zu:%s)", err.code, err.message);
+    ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_sign returned bad err.code (%i:%s)", err.code, err.message);
 
     cjose_header_release(hdr);
 }
@@ -356,11 +356,11 @@ START_TEST(test_cjose_jws_sign_with_bad_content)
 
     jws = cjose_jws_sign(jwk, hdr, NULL, 1024, &err);
     ck_assert_msg(NULL == jws, "cjose_jws_sign created with NULL plaintext");
-    ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_sign returned bad err.code (%zu:%s)", err.code, err.message);
+    ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_sign returned bad err.code (%i:%s)", err.code, err.message);
 
     jws = cjose_jws_sign(jwk, hdr, NULL, 0, &err);
     ck_assert_msg(NULL == jws, "cjose_jws_sign created with NULL plaintext");
-    ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_sign returned bad err.code (%zu:%s)", err.code, err.message);
+    ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_sign returned bad err.code (%i:%s)", err.code, err.message);
 
     cjose_jwk_release(jwk);
     cjose_header_release(hdr);
@@ -432,7 +432,7 @@ START_TEST(test_cjose_jws_import_invalid_serialization)
     {
         cjose_jws_t *jws = cjose_jws_import(JWS_BAD[i], strlen(JWS_BAD[i]), &err);
         ck_assert_msg(NULL == jws, "cjose_jws_import of bad JWS succeeded");
-        ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_import returned wrong err.code (%zu:%s)", err.code,
+        ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_import returned wrong err.code (%i:%s)", err.code,
                       err.message);
     }
 }
@@ -535,11 +535,11 @@ START_TEST(test_cjose_jws_verify_bad_params)
 
     // try to verify a NULL jws
     ck_assert_msg(!cjose_jws_verify(NULL, jwk, &err), "cjose_jws_verify succeeded with NULL jws");
-    ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_verify returned wrong err.code (%zu:%s)", err.code, err.message);
+    ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_verify returned wrong err.code (%i:%s)", err.code, err.message);
 
     // try to verify with a NULL jwk
     ck_assert_msg(!cjose_jws_verify(jws, NULL, &err), "cjose_jws_verify succeeded with NULL jwk");
-    ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_verify returned wrong err.code (%zu:%s)", err.code, err.message);
+    ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_verify returned wrong err.code (%i:%s)", err.code, err.message);
 
     // try to verify with bad/wrong/unsupported keys
     for (int i = 0; NULL != JWK_BAD[i]; ++i)
@@ -548,7 +548,7 @@ START_TEST(test_cjose_jws_verify_bad_params)
         ck_assert_msg(NULL != jwk_bad, "cjose_jwk_import failed");
 
         ck_assert_msg(!cjose_jws_verify(jws, NULL, &err), "cjose_jws_verify succeeded with bad jwk");
-        ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_verify returned wrong err.code (%zu:%s)", err.code,
+        ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_verify returned wrong err.code (%i:%s)", err.code,
                       err.message);
 
         cjose_jwk_release(jwk_bad);
@@ -689,7 +689,7 @@ START_TEST(test_cjose_jws_verify_rs256)
                   err.message, err.file, err.function, err.line);
 
     ck_assert_msg(!cjose_jws_verify(jws_ts, jwk, &err), "cjose_jws_verify succeeded with tampered signature");
-    ck_assert_msg(err.code == CJOSE_ERR_CRYPTO, "cjose_jws_verify returned wrong err.code (%zu:%s)", err.code, err.message);
+    ck_assert_msg(err.code == CJOSE_ERR_CRYPTO, "cjose_jws_verify returned wrong err.code (%i:%s)", err.code, err.message);
     cjose_jws_release(jws_ts);
 
     static const char *JWS_TAMPERED_CONTENT
@@ -705,7 +705,7 @@ START_TEST(test_cjose_jws_verify_rs256)
                   err.message, err.file, err.function, err.line);
 
     ck_assert_msg(!cjose_jws_verify(jws_tc, jwk, &err), "cjose_jws_verify succeeded with tampered content");
-    ck_assert_msg(err.code == CJOSE_ERR_CRYPTO, "cjose_jws_verify returned wrong err.code (%zu:%s)", err.code, err.message);
+    ck_assert_msg(err.code == CJOSE_ERR_CRYPTO, "cjose_jws_verify returned wrong err.code (%i:%s)", err.code, err.message);
 
     cjose_jws_release(jws_tc);
     cjose_jwk_release(jwk);
@@ -835,7 +835,7 @@ START_TEST(test_cjose_jws_verify_ec256)
                   err.message, err.file, err.function, err.line);
 
     ck_assert_msg(!cjose_jws_verify(jws_ts, jwk, &err), "cjose_jws_verify succeeded with tampered signature");
-    ck_assert_msg(err.code == CJOSE_ERR_CRYPTO, "cjose_jws_verify returned wrong err.code (%zu:%s)", err.code, err.message);
+    ck_assert_msg(err.code == CJOSE_ERR_CRYPTO, "cjose_jws_verify returned wrong err.code (%i:%s)", err.code, err.message);
     cjose_jws_release(jws_ts);
 
     static const char *JWS_TAMPERED_CONTENT
@@ -850,7 +850,7 @@ START_TEST(test_cjose_jws_verify_ec256)
                   err.message, err.file, err.function, err.line);
 
     ck_assert_msg(!cjose_jws_verify(jws_tc, jwk, &err), "cjose_jws_verify succeeded with tampered content");
-    ck_assert_msg(err.code == CJOSE_ERR_CRYPTO, "cjose_jws_verify returned wrong err.code (%zu:%s)", err.code, err.message);
+    ck_assert_msg(err.code == CJOSE_ERR_CRYPTO, "cjose_jws_verify returned wrong err.code (%i:%s)", err.code, err.message);
 
     cjose_jws_release(jws_tc);
     cjose_jwk_release(jwk);
@@ -921,7 +921,7 @@ START_TEST(test_cjose_jws_none)
 }
 END_TEST
 
-Suite *cjose_jws_suite()
+Suite *cjose_jws_suite(void)
 {
     Suite *suite = suite_create("jws");
 

--- a/test/check_util.c
+++ b/test/check_util.c
@@ -30,7 +30,7 @@ static void test_dealloc(void *ptr)
     free(ptr);
 }
 
-static void test_alloc_reset()
+static void test_alloc_reset(void)
 {
     _test_alloc_in_amt = 0;
     _test_alloc_in_ptr = _test_alloc_out_ptr = NULL;
@@ -110,7 +110,7 @@ static void *_test_alloc3_in_ptr;
 static const char *_test_alloc3_in_file;
 static int _test_alloc3_in_line;
 static void *_test_alloc3_out_ptr;
-static void test_alloc3_reset()
+static void test_alloc3_reset(void)
 {
     test_alloc_reset();
     _test_alloc3_in_amt = 0;
@@ -238,7 +238,7 @@ START_TEST(test_cjose_set_allocators_ex)
 }
 END_TEST
 
-Suite *cjose_util_suite()
+Suite *cjose_util_suite(void)
 {
     Suite *suite = suite_create("util");
 

--- a/test/check_version.c
+++ b/test/check_version.c
@@ -19,7 +19,7 @@ START_TEST(test_cjose_version_fn)
 }
 END_TEST
 
-Suite *cjose_version_suite()
+Suite *cjose_version_suite(void)
 {
     Suite *suite = suite_create("version");
 


### PR DESCRIPTION
 This update fixes the macOS/Clang build warnings that were causing the test build to fail under stricter warning settings.

  Changes made:
  - Converted no-argument C declarations/definitions from `()` to `(void)` in the test suite, including `cjose_*_suite`, `cjose_suite`, `main`, and
  allocator reset helpers.
  - Fixed test assertion format strings that used `%zu` for `cjose_err.code`, which is an `int`/enum-style value.
  - Fixed the binary assertion helper format string and pointer argument types.
  - Corrected the JWE multiple-recipient test array size so the sentinel slot is in bounds.
