### PR TITLE
concatkdf: heap-allocate and wipe the per-block digest, fix the remaining-bytes underflow

### DIFF
--- a/src/concatkdf.c
+++ b/src/concatkdf.c
@@ -14,18 +14,11 @@
 #include <malloc.h>
 #else
 #include <arpa/inet.h>
-#include <alloca.h>
 #endif
 #include <openssl/evp.h>
 #include <string.h>
 #include <cjose/base64.h>
 #include <cjose/util.h>
-
-#ifdef _WIN32
-#define STACK_ALLOC _alloca
-#else
-#define STACK_ALLOC alloca
-#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 static uint8_t *_apply_uint32(const uint32_t value, uint8_t *buffer)

--- a/src/concatkdf.c
+++ b/src/concatkdf.c
@@ -141,27 +141,36 @@ uint8_t *cjose_concatkdf_derive(const size_t keylen,
         goto concatkdf_derive_finish;
     }
 
-    size_t offset = 0, amt = keylen;
+    size_t offset = 0;
     for (int idx = 1; N >= idx; idx++)
     {
         uint8_t counter[4];
         _apply_uint32(idx, counter);
 
-        uint8_t* hash = STACK_ALLOC(hashlen * sizeof(uint8_t));
-        if (1 != EVP_DigestInit_ex(ctx, dgst, NULL) ||
-            1 != EVP_DigestUpdate(ctx, counter, sizeof(counter)) ||
-            1 != EVP_DigestUpdate(ctx, ikm, ikmLen) ||
-            1 != EVP_DigestUpdate(ctx, otherinfo, otherinfoLen) ||
-            1 != EVP_DigestFinal_ex(ctx, hash, NULL))
+        uint8_t *hash = cjose_get_alloc()(hashlen * sizeof(uint8_t));
+        if (NULL == hash)
         {
+            CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+            goto concatkdf_derive_finish;
+        }
+
+        if (1 != EVP_DigestInit_ex(ctx, dgst, NULL) || 1 != EVP_DigestUpdate(ctx, counter, sizeof(counter))
+            || 1 != EVP_DigestUpdate(ctx, ikm, ikmLen) || 1 != EVP_DigestUpdate(ctx, otherinfo, otherinfoLen)
+            || 1 != EVP_DigestFinal_ex(ctx, hash, NULL))
+        {
+            _cjose_cleanse_dealloc(hash, hashlen);
             CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
             goto concatkdf_derive_finish;
         }
 
-        uint8_t *ptr = buffer + offset;
-        memcpy(ptr, hash, min_len(hashlen, amt));
+        // copy this digest block into the derived key; the final block may be
+        // shorter than hashlen. offset stays < keylen on every iteration, so the
+        // remaining count (keylen - offset) cannot underflow.
+        // hash holds derived key material; wipe it before returning to the allocator
+        size_t amt = keylen - offset;
+        memcpy(buffer + offset, hash, min_len(hashlen, amt));
+        _cjose_cleanse_dealloc(hash, hashlen);
         offset += hashlen;
-        amt -= hashlen;
     }
 
     derived = buffer;

--- a/src/concatkdf.c
+++ b/src/concatkdf.c
@@ -93,7 +93,8 @@ bool cjose_concatkdf_create_otherinfo(const char *alg,
     ptr = _apply_lendata((const uint8_t *)alg, algLen, ptr);
     ptr = _apply_lendata(apu, apuLen, ptr);
     ptr = _apply_lendata(apv, apvLen, ptr);
-    ptr = _apply_uint32(keylen, ptr);
+    // final write; the returned (end) pointer is intentionally not stored
+    _apply_uint32(keylen, ptr);
 
     *otherinfoLen = bufferLen;
     *otherinfo = buffer;

--- a/test/check_concatkdf.c
+++ b/test/check_concatkdf.c
@@ -99,6 +99,9 @@ START_TEST(test_cjose_concatkdf_otherinfo_noextra)
     ck_assert(_cmp_lendata(&actual, NULL, 0));          // APU
     ck_assert(_cmp_lendata(&actual, NULL, 0));          // APV
     ck_assert(_cmp_uint32(&actual, 256));               // KEYLEN
+
+    cjose_get_dealloc()(otherinfo);
+    cjose_header_release(hdr);
 }
 END_TEST
 
@@ -124,6 +127,9 @@ START_TEST(test_cjose_concatkdf_otherinfo_apuapv)
     ck_assert(_cmp_lendata(&actual, apu, apuLen));
     ck_assert(_cmp_lendata(&actual, apv, apvLen));
     ck_assert(_cmp_uint32(&actual, 32));
+
+    cjose_get_dealloc()(otherinfo);
+    cjose_header_release(hdr);
 }
 END_TEST
 
@@ -145,7 +151,8 @@ START_TEST(test_cjose_concatkdf_derive_simple)
     const char *alg
         = "A256GCM";
     const size_t keylen = 32;
-    cjose_concatkdf_create_otherinfo(alg, keylen, cjose_header_new(&err), &otherinfo, &otherinfoLen, &err);
+    cjose_header_t *hdr = cjose_header_new(&err);
+    cjose_concatkdf_create_otherinfo(alg, keylen, hdr, &otherinfo, &otherinfoLen, &err);
     derived = cjose_concatkdf_derive(keylen, ikm, ikmLen, otherinfo, otherinfoLen, &err);
     ck_assert(NULL != derived);
 
@@ -156,6 +163,10 @@ START_TEST(test_cjose_concatkdf_derive_simple)
         0xaa, 0xc0, 0x3c, 0xef, 0x87, 0x34, 0xbd, 0x20
     };
     ck_assert_bin_eq(derived, expected, keylen);
+
+    cjose_get_dealloc()(derived);
+    cjose_get_dealloc()(otherinfo);
+    cjose_header_release(hdr);
 }
 END_TEST
 
@@ -176,7 +187,8 @@ START_TEST(test_cjose_concatkdf_derive_ikm)
 
     const char *alg = "A256GCM";
     const size_t keylen = 32;
-    cjose_concatkdf_create_otherinfo(alg, keylen, cjose_header_new(&err), &otherinfo, &otherinfoLen, &err);
+    cjose_header_t *hdr = cjose_header_new(&err);
+    cjose_concatkdf_create_otherinfo(alg, keylen, hdr, &otherinfo, &otherinfoLen, &err);
     derived = cjose_concatkdf_derive(keylen, ikm, ikmLen, otherinfo, otherinfoLen, &err);
     ck_assert(NULL != derived);
 
@@ -187,6 +199,10 @@ START_TEST(test_cjose_concatkdf_derive_ikm)
         0x6a, 0x23, 0x12, 0x39, 0xd2, 0x33, 0x6e, 0x44
     };
     ck_assert_bin_eq(derived, expected, keylen);
+
+    cjose_get_dealloc()(derived);
+    cjose_get_dealloc()(otherinfo);
+    cjose_header_release(hdr);
 }
 END_TEST
 
@@ -221,6 +237,10 @@ START_TEST(test_cjose_concatkdf_derive_moreinfo)
         0x53, 0x81, 0xe0, 0x4a, 0x57, 0x1b, 0x58, 0x65
     };
     ck_assert_bin_eq(derived, expected, keylen);
+
+    cjose_get_dealloc()(derived);
+    cjose_get_dealloc()(otherinfo);
+    cjose_header_release(hdr);
 }
 END_TEST
 Suite *cjose_concatkdf_suite(void)


### PR DESCRIPTION
Part of the step 1 series (bug and undefined-behaviour fixes only, no public API change) discussed in #142, porting fixes carried in the OpenIDC/cjose `version-0.6.2.x` branch.

### Changes

- `cjose_concatkdf_derive()`: the per-iteration digest block was `alloca()`'d inside the loop (flagged by CodeQL; the stack grows with the derived key length because `alloca` memory is only reclaimed on function return), never checked, left holding derived key material after use, and the unsigned remaining-bytes counter was decremented past zero on the final block. The block is now allocated through the cjose allocator, checked, cleansed and released on every iteration, and the remaining count is computed as `keylen - offset` so it cannot underflow. (OpenIDC/cjose@868a0b0, OpenIDC/cjose@ad6edef, OpenIDC/cjose@33f5351, OpenIDC/cjose@f006df5)
- Drop the now-unused `alloca.h` include and `STACK_ALLOC` macro. (OpenIDC/cjose@eb81fbd, by Shoichi Yamaguchi)
- `cjose_concatkdf_create_otherinfo()`: drop the dead store after the final write. (OpenIDC/cjose@0395faf)
- Tests: release the headers, otherinfo buffers and derived keys that the concatkdf tests leaked, so the suite runs clean under valgrind. (OpenIDC/cjose@5ed25dd)

### Testing

Built with CMake (`-pedantic -Wall -Werror`) on Linux with GCC 15, OpenSSL 3.5.5 and Jansson 2.14; `check_cjose` passes. `valgrind --leak-check=full` on the concatkdf suite (`CK_FORK=no CK_RUN_SUITE=concatkdf`) reports 0 errors and 0 bytes lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
