### PR TITLE
jwe: fix leaks, NULL dereferences and undefined behaviour on the JWE paths

### DIFF
--- a/src/concatkdf.c
+++ b/src/concatkdf.c
@@ -66,10 +66,16 @@ bool cjose_concatkdf_create_otherinfo(const char *alg,
     uint8_t *apu = NULL, *apv = NULL;
     size_t apuLen = 0, apvLen = 0;
 
-    memset(err, 0, sizeof(cjose_err));
+    // err is optional and may be NULL, so only dereference it when provided.
+    // cjose_header_get() records an error only for an invalid header/attr; for a
+    // valid hdr and the constant APU/APV attrs an absent field just yields NULL.
+    if (NULL != err)
+    {
+        memset(err, 0, sizeof(cjose_err));
+    }
     const char *apuStr = cjose_header_get(hdr, CJOSE_HDR_APU, err);
     const char *apvStr = cjose_header_get(hdr, CJOSE_HDR_APV, err);
-    if (CJOSE_ERR_NONE != err->code)
+    if (NULL != err && CJOSE_ERR_NONE != err->code)
     {
         return false;
     }

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -2089,6 +2089,10 @@ uint8_t *cjose_jwe_decrypt_multi(cjose_jwe_t *jwe, cjose_key_locator key_locator
         {
             cek_len = jwe->cek_len;
             cek = cjose_get_alloc()(cek_len);
+            if (!cek) {
+               CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+               return NULL;
+            }
             memcpy(cek, jwe->cek, cek_len);
         }
         else

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -187,7 +187,7 @@ static size_t _keylen_from_enc(const char *alg)
 static bool _cjose_jwe_malloc(size_t bytes, bool random, uint8_t **buffer, cjose_err *err)
 {
     *buffer = (uint8_t *)cjose_get_alloc()(bytes);
-    if (NULL == *buffer)
+    if ((NULL == *buffer) && (bytes > 0))
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         return false;

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -1442,7 +1442,9 @@ static bool _cjose_jwe_decrypt_dat_aes_cbc(cjose_jwe_t *jwe, cjose_err *err)
 
     int p_len = (int)jwe->enc_ct.raw_len, f_len = 0;
     _cjose_cleanse_dealloc(jwe->dat, jwe->dat_len);
-    jwe->dat_len = p_len + AES_BLOCK_SIZE;
+    // size the buffer in size_t; p_len + AES_BLOCK_SIZE would overflow int when
+    // raw_len is near INT_MAX (raw_len is already bounded above)
+    jwe->dat_len = jwe->enc_ct.raw_len + AES_BLOCK_SIZE;
     if (!_cjose_jwe_malloc(jwe->dat_len, false, &jwe->dat, err))
     {
         goto _cjose_jwe_decrypt_dat_aes_cbc_fail;

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -1222,7 +1222,7 @@ static bool _cjose_jwe_encrypt_dat_aes_cbc(cjose_jwe_t *jwe, const uint8_t *plai
     uint8_t tag[EVP_MAX_MD_SIZE];
     if (_cjose_jwe_calc_auth_tag(enc, jwe, (unsigned char *)&tag, &tag_len, err) == false)
     {
-        return false;
+        goto _cjose_jwe_encrypt_dat_aes_cbc_fail;
     }
 
     // allocate buffer for the authentication tag

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -148,8 +148,7 @@ static bool _cjose_convert_to_base64(struct _cjose_jwe_int *jwe, cjose_err *err)
 {
 
     if (!_cjose_convert_part(&jwe->enc_header, err) || !_cjose_convert_part(&jwe->enc_iv, err)
-        || !_cjose_convert_part(&jwe->enc_iv, err) || !_cjose_convert_part(&jwe->enc_ct, err)
-        || !_cjose_convert_part(&jwe->enc_auth_tag, err))
+        || !_cjose_convert_part(&jwe->enc_ct, err) || !_cjose_convert_part(&jwe->enc_auth_tag, err))
     {
 
         return false;

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -832,6 +832,14 @@ static bool _cjose_jwe_decrypt_ek_ecdh_es(_jwe_int_recipient_t *recipient,
     uint8_t *derived = NULL;
     bool result = false;
 
+    // err is optional in the public API, but the logic below inspects
+    // err->code to distinguish an absent EPK header from a real failure;
+    // fall back to a local error object when the caller did not supply one
+    cjose_err local_err;
+    if (NULL == err)
+    {
+        err = &local_err;
+    }
     memset(err, 0, sizeof(cjose_err));
     char *epk_json = cjose_header_get_raw(jwe->hdr, CJOSE_HDR_EPK, err);
     if (NULL != epk_json)

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -1326,8 +1326,8 @@ static bool _cjose_jwe_decrypt_dat_a256gcm(cjose_jwe_t *jwe, cjose_err *err)
         goto _cjose_jwe_decrypt_dat_a256gcm_fail;
     }
 
-    // allocate buffer for the plaintext
-    cjose_get_dealloc()(jwe->dat);
+    // allocate buffer for the plaintext, wiping any previously decrypted data
+    _cjose_cleanse_dealloc(jwe->dat, jwe->dat_len);
     jwe->dat_len = jwe->enc_ct.raw_len;
     if (!_cjose_jwe_malloc(jwe->dat_len, false, &jwe->dat, err))
     {
@@ -1440,7 +1440,7 @@ static bool _cjose_jwe_decrypt_dat_aes_cbc(cjose_jwe_t *jwe, cjose_err *err)
     }
 
     int p_len = (int)jwe->enc_ct.raw_len, f_len = 0;
-    cjose_get_dealloc()(jwe->dat);
+    _cjose_cleanse_dealloc(jwe->dat, jwe->dat_len);
     jwe->dat_len = p_len + AES_BLOCK_SIZE;
     if (!_cjose_jwe_malloc(jwe->dat_len, false, &jwe->dat, err))
     {
@@ -1653,7 +1653,9 @@ void cjose_jwe_release(cjose_jwe_t *jwe)
 
     _cjose_release_cek(&jwe->cek, jwe->cek_len);
 
-    cjose_get_dealloc()(jwe->dat);
+    // jwe->dat holds decrypted plaintext when the caller has not taken
+    // ownership of it (e.g. after a failed decrypt); wipe it before release
+    _cjose_cleanse_dealloc(jwe->dat, jwe->dat_len);
     cjose_get_dealloc()(jwe);
 }
 

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -2106,6 +2106,12 @@ uint8_t *cjose_jwe_decrypt_multi(cjose_jwe_t *jwe, cjose_key_locator key_locator
         }
     }
 
+    if (NULL == jwe->cek)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto _cjose_jwe_decrypt_multi_fail;
+    }
+
     // decrypt JWE encrypted data
     if (!jwe->fns.decrypt_dat(jwe, err))
     {

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -2097,7 +2097,8 @@ uint8_t *cjose_jwe_decrypt_multi(cjose_jwe_t *jwe, cjose_key_locator key_locator
         }
         else
         {
-            if (cek_len != jwe->cek_len || memcmp(jwe->cek, cek, cek_len))
+            // constant-time compare: both operands are secret CEKs
+            if (cek_len != jwe->cek_len || cjose_const_memcmp(jwe->cek, cek, cek_len) != 0)
             {
                 CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
                 goto _cjose_jwe_decrypt_multi_fail;

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -201,8 +201,10 @@ static bool _cjose_jwe_malloc(size_t bytes, bool random, uint8_t **buffer, cjose
             return false;
         }
     }
-    else
+    else if (bytes > 0)
     {
+        // *buffer may be NULL for a zero-byte request (malloc(0)); passing NULL
+        // to memset is undefined even with a zero length, so skip it
         memset(*buffer, 0, bytes);
     }
     return true;

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -797,6 +797,13 @@ static bool _cjose_jwe_encrypt_ek_ecdh_es(_jwe_int_recipient_t *recipient,
 
     jwe->cek = derived;
     jwe->cek_len = keylen;
+
+    // empty string may have been allocated upon import
+    if (recipient->enc_key.raw != NULL)
+    {
+        cjose_get_dealloc()(recipient->enc_key.raw);
+    }
+
     recipient->enc_key.raw = NULL;
     recipient->enc_key.raw_len = 0;
     result = true;
@@ -878,6 +885,13 @@ static bool _cjose_jwe_decrypt_ek_ecdh_es(_jwe_int_recipient_t *recipient,
 
     jwe->cek = derived;
     jwe->cek_len = keylen;
+
+    // empty string may have been allocated upon import
+    if (recipient->enc_key.raw != NULL)
+    {
+        cjose_get_dealloc()(recipient->enc_key.raw);
+    }
+
     recipient->enc_key.raw = NULL;
     recipient->enc_key.raw_len = 0;
     result = true;

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -1423,7 +1423,7 @@ START_TEST(test_cjose_jwe_ecdh_es_null_err)
     cjose_header_t *hdr = cjose_header_new(NULL);
     ck_assert_msg(NULL != hdr, "cjose_header_new failed");
     ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_ECDH_ES, NULL));
-    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A128GCM, NULL));
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, NULL));
 
     // encrypt with a NULL err: must not crash in the ConcatKDF otherinfo path
     cjose_jwe_t *jwe = cjose_jwe_encrypt(jwk, hdr, (const uint8_t *)PLAINTEXT, strlen(PLAINTEXT), NULL);

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -99,6 +99,11 @@ static const cjose_jwk_t *cjose_multi_key_locator(cjose_jwe_t *jwe, cjose_header
     return NULL;
 }
 
+static const cjose_jwk_t *cjose_multi_key_locator_none(cjose_jwe_t *jwe, cjose_header_t *hdr, void *data)
+{
+    return NULL;
+}
+
 START_TEST(test_cjose_jwe_node_jose_encrypt_self_decrypt)
 {
     cjose_err err;
@@ -1314,7 +1319,13 @@ START_TEST(test_cjose_jwe_multiple_recipients)
                   err.message, err.file, err.function, err.line);
 
     size_t decoded_len;
-    uint8_t *decoded = cjose_jwe_decrypt_multi(jwe, cjose_multi_key_locator, rec, &decoded_len, &err);
+
+    CJOSE_ERROR(&err, CJOSE_ERR_NONE);
+    uint8_t *decoded = cjose_jwe_decrypt_multi(jwe, cjose_multi_key_locator_none, rec, &decoded_len, &err);
+    ck_assert_msg(NULL == decoded, "did not expect to decode with selected key");
+    ck_assert_msg(err.code == CJOSE_ERR_CRYPTO, "expected error to be set to CRYPTO");
+
+    decoded = cjose_jwe_decrypt_multi(jwe, cjose_multi_key_locator, rec, &decoded_len, &err);
     ck_assert_msg(NULL != decoded,
                   "failed to decrypt for multiple recipients: "
                   "%s, file: %s, function: %s, line: %ld",

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -1401,6 +1401,45 @@ START_TEST(test_cjose_jwe_encrypt_cbc_cek_random)
 }
 END_TEST
 
+// regression: ECDH-ES key agreement must not dereference a NULL cjose_err.
+// cjose_concatkdf_create_otherinfo() used to memset(err, ...) unconditionally,
+// crashing when the public JWE API was invoked with a NULL err argument.
+START_TEST(test_cjose_jwe_ecdh_es_null_err)
+{
+    cjose_jwk_t *jwk = cjose_jwk_import(JWK_EC, strlen(JWK_EC), NULL);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed for EC key");
+
+    cjose_header_t *hdr = cjose_header_new(NULL);
+    ck_assert_msg(NULL != hdr, "cjose_header_new failed");
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_ECDH_ES, NULL));
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A128GCM, NULL));
+
+    // encrypt with a NULL err: must not crash in the ConcatKDF otherinfo path
+    cjose_jwe_t *jwe = cjose_jwe_encrypt(jwk, hdr, (const uint8_t *)PLAINTEXT, strlen(PLAINTEXT), NULL);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt (ECDH-ES) failed with NULL err");
+
+    char *compact = cjose_jwe_export(jwe, NULL);
+    ck_assert_msg(NULL != compact, "cjose_jwe_export failed");
+
+    cjose_jwe_t *jwe2 = cjose_jwe_import(compact, strlen(compact), NULL);
+    ck_assert_msg(NULL != jwe2, "cjose_jwe_import failed");
+
+    // decrypt with a NULL err: again exercises the ConcatKDF path
+    size_t plain_len = 0;
+    uint8_t *plain = cjose_jwe_decrypt(jwe2, jwk, &plain_len, NULL);
+    ck_assert_msg(NULL != plain, "cjose_jwe_decrypt (ECDH-ES) failed with NULL err");
+    ck_assert(plain_len == strlen(PLAINTEXT));
+    ck_assert(strncmp(PLAINTEXT, (const char *)plain, plain_len) == 0);
+
+    cjose_get_dealloc()(plain);
+    cjose_get_dealloc()(compact);
+    cjose_jwe_release(jwe);
+    cjose_jwe_release(jwe2);
+    cjose_header_release(hdr);
+    cjose_jwk_release(jwk);
+}
+END_TEST
+
 Suite *cjose_jwe_suite(void)
 {
     Suite *suite = suite_create("jwe");
@@ -1425,6 +1464,7 @@ Suite *cjose_jwe_suite(void)
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_bad_params);
     tcase_add_test(tc_jwe, test_cjose_jwe_multiple_recipients);
     tcase_add_test(tc_jwe, test_cjose_jwe_encrypt_cbc_cek_random);
+    tcase_add_test(tc_jwe, test_cjose_jwe_ecdh_es_null_err);
     suite_add_tcase(suite, tc_jwe);
 
     return suite;


### PR DESCRIPTION
Part of the step 1 series (bug and undefined-behaviour fixes only, no public API change) discussed in #142, porting fixes carried in the OpenIDC/cjose `version-0.6.2.x` branch. This PR collects the memory-safety and crash fixes on the JWE paths; the RSA key-unwrap hardening follows in a separate PR.

### Changes

- `_cjose_jwe_encrypt_dat_aes_cbc()`: the `EVP_CIPHER_CTX` was leaked when the authentication-tag computation failed (`return false` instead of the `goto` cleanup). (OpenIDC/cjose@fb9abd5)
- ECDH-ES encrypt/decrypt leaked the empty `enc_key.raw` buffer that `cjose_jwe_import()` allocates for the encrypted-key segment. (OpenIDC/cjose@1b2af41)
- `_cjose_jwe_decrypt_ek_ecdh_es()` and `cjose_concatkdf_create_otherinfo()` dereferenced the optional `err` argument unconditionally, so an ECDH-ES encrypt or decrypt through the public API with `err == NULL` crashed. Regression test `test_cjose_jwe_ecdh_es_null_err` added. (OpenIDC/cjose@4e7e518, OpenIDC/cjose@6d7d79d)
- `cjose_jwe_decrypt_multi()`: check the CEK copy allocation, compare the CEKs of successive recipients in constant time (`cjose_const_memcmp`) instead of `memcmp`, and fail with `CJOSE_ERR_CRYPTO` when no recipient produced a CEK instead of calling `decrypt_dat` with a NULL key. The last item is #89 by @veselov, cherry-picked with its test to keep the series self-contained; happy to drop it here if you would rather merge #89 directly. (OpenIDC/cjose@54d4494, OpenIDC/cjose@2dbafde, OpenIDC/cjose@8b9416e)
- Wipe the decrypted plaintext held in `jwe->dat` on release and before reuse, so unauthenticated plaintext left behind by a failed AES-GCM tag check does not linger in freed memory. (OpenIDC/cjose@2d93399)
- `_cjose_jwe_malloc()`: tolerate `malloc(0)` returning NULL and skip `memset(NULL, 0, 0)`, which is undefined behaviour even with a zero length. (OpenIDC/cjose@ff74c49, OpenIDC/cjose@9238f5c)
- `_cjose_jwe_decrypt_dat_aes_cbc()`: compute the plaintext buffer size in `size_t`. `p_len + AES_BLOCK_SIZE` was evaluated in `int`, and the preceding guard only rejects `raw_len > INT_MAX`, so a ciphertext within 16 bytes of `INT_MAX` overflowed the addition. (OpenIDC/cjose@23e392a)
- Drop a duplicated `enc_iv` conversion in `_cjose_convert_to_base64()`. (OpenIDC/cjose@f84368a)

### Testing

Built with CMake (`-pedantic -Wall -Werror`) on Linux with GCC 15, OpenSSL 3.5.5 and Jansson 2.14; `check_cjose` passes. `valgrind --leak-check=full` on the jwe suite (`CK_FORK=no CK_RUN_SUITE=jwe`) reports 0 errors and 0 bytes lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
