### PR TITLE
jws: fix leaks and error handling on import/export, validate the ECDSA signature length

### DIFF
--- a/src/jws.c
+++ b/src/jws.c
@@ -136,7 +136,7 @@ static bool _cjose_jws_build_dat(cjose_jws_t *jws, const uint8_t *plaintext, siz
     // copy plaintext data
     jws->dat_len = plaintext_len;
     jws->dat = (uint8_t *)cjose_get_alloc()(jws->dat_len);
-    if (NULL == jws->dat)
+    if ((NULL == jws->dat) && (jws->dat_len > 0))
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         return false;

--- a/src/jws.c
+++ b/src/jws.c
@@ -288,7 +288,7 @@ static bool _cjose_jws_build_dig_hmac_sha(cjose_jws_t *jws, const cjose_jwk_t *j
 
     if (NULL != jws->dig)
     {
-        cjose_get_dealloc()(jws->dig);
+        _cjose_cleanse_dealloc(jws->dig, jws->dig_len);
         jws->dig = NULL;
     }
 

--- a/src/jws.c
+++ b/src/jws.c
@@ -843,6 +843,7 @@ cjose_jws_t *cjose_jws_import(const char *cser, size_t cser_len, cjose_err *err)
         if (NULL == alg_obj)
         {
             CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+            cjose_jws_release(jws);
             return NULL;
         }
         const char *alg = json_string_value(alg_obj);

--- a/src/jws.c
+++ b/src/jws.c
@@ -1061,13 +1061,26 @@ static bool _cjose_jws_verify_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
     EC_KEY *ec = keydata->key;
 
     ECDSA_SIG *ecdsa_sig = ECDSA_SIG_new();
+    if (ecdsa_sig == NULL)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto _cjose_jws_verify_sig_ec_cleanup;
+    }
     int key_len = jws->sig_len / 2;
 
 #if defined(CJOSE_OPENSSL_11X)
-    BIGNUM *pr = BN_new(), *ps = BN_new();
+    BIGNUM *pr = BN_new();
+    BIGNUM *ps = BN_new();
+    if (pr == NULL || ps == NULL)
+    {
+        BN_free(pr);
+        BN_free(ps);
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto _cjose_jws_verify_sig_ec_cleanup;
+    }
     BN_bin2bn(jws->sig, key_len, pr);
     BN_bin2bn(jws->sig + key_len, key_len, ps);
-    ECDSA_SIG_set0(ecdsa_sig, pr, ps);
+    ECDSA_SIG_set0(ecdsa_sig, pr, ps); // takes ownership of pr and ps
 #else
     BN_bin2bn(jws->sig, key_len, ecdsa_sig->r);
     BN_bin2bn(jws->sig + key_len, key_len, ecdsa_sig->s);

--- a/src/jws.c
+++ b/src/jws.c
@@ -188,8 +188,8 @@ static bool _cjose_jws_build_dig_sha(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
 
     if (NULL != jws->dig)
     {
-		_cjose_cleanse_dealloc(jws->dig, jws->dig_len);
-		jws->dig = NULL;
+        _cjose_cleanse_dealloc(jws->dig, jws->dig_len);
+        jws->dig = NULL;
     }
 
     // allocate buffer for digest
@@ -284,6 +284,12 @@ static bool _cjose_jws_build_dig_hmac_sha(cjose_jws_t *jws, const cjose_jwk_t *j
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto _cjose_jws_build_dig_hmac_sha_cleanup;
+    }
+
+    if (NULL != jws->dig)
+    {
+        cjose_get_dealloc()(jws->dig);
+        jws->dig = NULL;
     }
 
     // allocate buffer for digest

--- a/src/jws.c
+++ b/src/jws.c
@@ -792,10 +792,11 @@ cjose_jws_t *cjose_jws_import(const char *cser, size_t cser_len, cjose_err *err)
     }
     memset(jws, 0, sizeof(cjose_jws_t));
 
-    // find the indexes of the dots
-    int idx = 0;
-    int d[2] = { 0, 0 };
-    for (int i = 0; i < cser_len && idx < 2; ++i)
+    // find the indexes of the dots; use size_t to match cser_len, an int
+    // would truncate the offsets for an oversized serialization
+    size_t idx = 0;
+    size_t d[2] = { 0, 0 };
+    for (size_t i = 0; i < cser_len && idx < 2; ++i)
     {
         if (cser[i] == '.')
         {

--- a/src/jws.c
+++ b/src/jws.c
@@ -854,6 +854,10 @@ cjose_jws_t *cjose_jws_import(const char *cser, size_t cser_len, cjose_err *err)
             cjose_jws_release(jws);
             return NULL;
         }
+
+        // alg=none is accepted (parse-only): clear the validation error
+        // recorded above so a successful import does not leave err populated
+        CJOSE_ERROR(err, CJOSE_ERR_NONE);
     }
 
     // copy and b64u decode data segment

--- a/src/jws.c
+++ b/src/jws.c
@@ -12,7 +12,6 @@
 #include <cjose/util.h>
 
 #include <string.h>
-#include <assert.h>
 #include <openssl/evp.h>
 #include <openssl/crypto.h>
 #include <openssl/rsa.h>
@@ -640,8 +639,13 @@ static bool _cjose_jws_build_cser(cjose_jws_t *jws, cjose_err *err)
     // compute length of compact serialization
     jws->cser_len = jws->hdr_b64u_len + jws->dat_b64u_len + jws->sig_b64u_len + 3;
 
+    if (NULL != jws->cser)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_STATE);
+        return false;
+    }
+
     // allocate buffer for compact serialization
-    assert(NULL == jws->cser);
     jws->cser = (char *)cjose_get_alloc()(jws->cser_len);
     if (NULL == jws->cser)
     {

--- a/src/jws.c
+++ b/src/jws.c
@@ -756,7 +756,7 @@ bool cjose_jws_export(cjose_jws_t *jws, const char **compact, cjose_err *err)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-static bool _cjose_jws_strcpy(char **dst, const char *src, int len, cjose_err *err)
+static bool _cjose_jws_strcpy(char **dst, const char *src, size_t len, cjose_err *err)
 {
     *dst = (char *)cjose_get_alloc()(len + 1);
     if (NULL == *dst)

--- a/src/jws.c
+++ b/src/jws.c
@@ -627,6 +627,7 @@ static bool _cjose_jws_build_cser(cjose_jws_t *jws, cjose_err *err)
     // both sign and import should be setting these - but check just in case
     if (NULL == jws->hdr_b64u || NULL == jws->dat_b64u || NULL == jws->sig_b64u)
     {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_STATE);
         return false;
     }
 
@@ -748,7 +749,10 @@ bool cjose_jws_export(cjose_jws_t *jws, const char **compact, cjose_err *err)
 
     if (NULL == jws->cser)
     {
-        _cjose_jws_build_cser(jws, err);
+        if (!_cjose_jws_build_cser(jws, err))
+        {
+            return false;
+        }
     }
 
     *compact = jws->cser;

--- a/src/jws.c
+++ b/src/jws.c
@@ -1066,6 +1066,32 @@ static bool _cjose_jws_verify_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
     ec_keydata *keydata = (ec_keydata *)jwk->keydata;
     EC_KEY *ec = keydata->key;
 
+    // the JWS ECDSA signature is the fixed-length concatenation R || S, each
+    // the curve's coordinate size (RFC 7518 section 3.4); reject any other
+    // length before splitting it so a non-canonical signature (e.g. a trailing
+    // byte dropped by the sig_len/2 split) cannot verify
+    size_t coordlen = 0;
+    switch (keydata->crv)
+    {
+    case CJOSE_JWK_EC_P_256:
+        coordlen = 32;
+        break;
+    case CJOSE_JWK_EC_P_384:
+        coordlen = 48;
+        break;
+    case CJOSE_JWK_EC_P_521:
+        coordlen = 66;
+        break;
+    case CJOSE_JWK_EC_INVALID:
+        coordlen = 0;
+        break;
+    }
+    if (0 == coordlen || jws->sig_len != coordlen * 2)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
     ECDSA_SIG *ecdsa_sig = ECDSA_SIG_new();
     if (ecdsa_sig == NULL)
     {

--- a/test/check_jws.c
+++ b/test/check_jws.c
@@ -947,6 +947,98 @@ START_TEST(test_cjose_jws_none)
 }
 END_TEST
 
+// regression: the JWS ECDSA signature must be exactly R || S for the key's
+// curve; _cjose_jws_verify_sig_ec used sig_len / 2 without a length check,
+// so a valid signature with a trailing octet appended still verified
+START_TEST(test_cjose_jws_verify_ec_sig_bad_length)
+{
+    cjose_err err;
+
+    // a valid ES256 (P-256) JWS and its verification key; per RFC 7518 sec 3.4
+    // the signature is the fixed-length concatenation R || S (32 + 32 = 64 octets)
+    static const char *JWS = "eyJhbGciOiJFUzI1NiIsImtpZCI6Img0aDkzIn0."
+                             "eyJzdWIiOiJqb2UiLCJhdWQiOiJhY19vaWNfY2xpZW50IiwianRpIjoiZGV0blVpU2FTS0lpSUFvdHZ0ZzV3VyIsImlzcyI6Imh0d"
+                             "HBzOlwvXC9sb2NhbGhvc3Q6OTAzMSIsImlhdCI6MTQ2OTAzMDk1MCwiZXhwIjoxNDY5MDMxMjUwLCJub25jZSI6Im8zNU8wMi1WM0"
+                             "poSXJ1SkdHSlZVOGpUUGg2LUhKUTgzWEpmQXBZTGtrZHcifQ.o9bb_yW6-h9lPser01eYoK-VMlJoUabKFQ9tT_"
+                             "KdgMHlqRqTa4isqFqXllViDdUIQoHGMMP7Qms565YKSCS3iA";
+
+    static const char *JWK = "{ \"kty\": \"EC\","
+                             "\"kid\": \"h4h93\","
+                             "\"use\": \"sig\","
+                             "\"x\": \"qcZ8jiBDygzf1XMWNN3jS7qT3DDslHOYvaa6XHMxShw\","
+                             "\"y\": \"vMcP1OkZsSNaFN6MHrdApLdtLPWo8RnNflgP3DAbcfY\","
+                             "\"crv\": \"P-256\" }";
+
+    cjose_jwk_t *jwk = cjose_jwk_import(JWK, strlen(JWK), &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
+
+    // sanity: the untampered JWS verifies
+    cjose_jws_t *jws_ok = cjose_jws_import(JWS, strlen(JWS), &err);
+    ck_assert_msg(NULL != jws_ok, "cjose_jws_import failed: %s", err.message);
+    ck_assert_msg(cjose_jws_verify(jws_ok, jwk, &err), "cjose_jws_verify failed on valid JWS: %s", err.message);
+    cjose_jws_release(jws_ok);
+
+    // split the compact serialization into the signing input (header.payload.)
+    // and the base64url-encoded signature
+    const char *last_dot = strrchr(JWS, '.');
+    ck_assert(NULL != last_dot);
+    size_t prefix_len = (last_dot - JWS) + 1; // include the trailing '.'
+    const char *sig_b64u = last_dot + 1;
+
+    // recover the raw 64-octet signature
+    uint8_t *sig_raw = NULL;
+    size_t sig_raw_len = 0;
+    ck_assert(cjose_base64url_decode(sig_b64u, strlen(sig_b64u), &sig_raw, &sig_raw_len, &err));
+    ck_assert_int_eq(64, sig_raw_len);
+
+    // for both an over-length (65) and an under-length (63) signature, rebuild
+    // the serialization and confirm verification rejects it up front with
+    // CJOSE_ERR_INVALID_ARG. The over-length case is the malleability the fix
+    // closes: previously sig_len/2 dropped the trailing octet and the valid
+    // first 64 octets still verified.
+    size_t bad_lens[] = { sig_raw_len + 1, sig_raw_len - 1 };
+    for (size_t i = 0; i < sizeof(bad_lens) / sizeof(bad_lens[0]); i++)
+    {
+        size_t bad_len = bad_lens[i];
+
+        uint8_t *bad_raw = (uint8_t *)cjose_get_alloc()(bad_len);
+        ck_assert(NULL != bad_raw);
+        memcpy(bad_raw, sig_raw, (bad_len < sig_raw_len) ? bad_len : sig_raw_len);
+        if (bad_len > sig_raw_len)
+        {
+            bad_raw[sig_raw_len] = 0x00; // append a trailing octet
+        }
+
+        char *bad_sig_b64u = NULL;
+        size_t bad_sig_b64u_len = 0;
+        ck_assert(cjose_base64url_encode(bad_raw, bad_len, &bad_sig_b64u, &bad_sig_b64u_len, &err));
+
+        // assemble header.payload. + tampered signature
+        size_t cser_len = prefix_len + bad_sig_b64u_len;
+        char *cser = (char *)cjose_get_alloc()(cser_len + 1);
+        ck_assert(NULL != cser);
+        memcpy(cser, JWS, prefix_len);
+        memcpy(cser + prefix_len, bad_sig_b64u, bad_sig_b64u_len);
+        cser[cser_len] = '\0';
+
+        cjose_jws_t *jws_bad = cjose_jws_import(cser, cser_len, &err);
+        ck_assert_msg(NULL != jws_bad, "cjose_jws_import failed for bad-length sig: %s", err.message);
+
+        ck_assert_msg(!cjose_jws_verify(jws_bad, jwk, &err), "cjose_jws_verify accepted a %lu-octet EC signature",
+                      (unsigned long)bad_len);
+        ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "expected CJOSE_ERR_INVALID_ARG, got (%i:%s)", err.code, err.message);
+
+        cjose_jws_release(jws_bad);
+        cjose_get_dealloc()(cser);
+        cjose_get_dealloc()(bad_sig_b64u);
+        cjose_get_dealloc()(bad_raw);
+    }
+
+    cjose_get_dealloc()(sig_raw);
+    cjose_jwk_release(jwk);
+}
+END_TEST
+
 Suite *cjose_jws_suite(void)
 {
     Suite *suite = suite_create("jws");
@@ -970,6 +1062,7 @@ Suite *cjose_jws_suite(void)
     tcase_add_test(tc_jws, test_cjose_jws_import_get_plain_after_verify);
     tcase_add_test(tc_jws, test_cjose_jws_verify_bad_params);
     tcase_add_test(tc_jws, test_cjose_jws_none);
+    tcase_add_test(tc_jws, test_cjose_jws_verify_ec_sig_bad_length);
     suite_add_tcase(suite, tc_jws);
 
     return suite;


### PR DESCRIPTION
Part of the step 1 series (bug and undefined-behaviour fixes only, no public API change) discussed in #142, porting fixes carried in the OpenIDC/cjose `version-0.6.2.x` branch.

### Changes

- `cjose_jws_import()` leaked the JWS when the `alg` header was missing (OpenIDC/cjose@9f2e618, by @mkauf), and left `err` populated after a successful `alg: "none"` import (OpenIDC/cjose@82b21fb).
- `_cjose_jws_build_dig_hmac_sha()` leaked the previous digest when a JWS object was reused for verification; the digest is now cleansed and released before reallocation, as `_cjose_jws_build_dig_sha()` already does. This is #117 by @traeak, cherry-picked here with the cleansing on top to keep the series self-contained; happy to drop it if you would rather merge #117 directly. (OpenIDC/cjose@537f5fe, OpenIDC/cjose@6f76391)
- `cjose_jws_export()` ignored a `_cjose_jws_build_cser()` failure and returned success with a NULL serialization. (OpenIDC/cjose@5590ee4)
- `cjose_jws_import()` scanned for the separator dots with `int` offsets and `_cjose_jws_strcpy()` took an `int` length, truncating for an oversized serialization; both use `size_t` now. (OpenIDC/cjose@2fef0f8, OpenIDC/cjose@9922c3f)
- `_cjose_jws_verify_sig_ec()` split the signature at `sig_len / 2` without checking its length, so a valid ES256 signature with an extra octet appended still verified. The length is now pinned to twice the curve's coordinate size (RFC 7518 section 3.4) and the `ECDSA_SIG_new()` / `BN_new()` results are checked. Regression test `test_cjose_jws_verify_ec_sig_bad_length` added. (OpenIDC/cjose@5f42fe8, OpenIDC/cjose@f006df5)
- `_cjose_jws_build_cser()`: replace the `assert()` with an error return (#123). (OpenIDC/cjose@5736ee3)
- `_cjose_jws_build_dat()`: tolerate `malloc(0)` returning NULL for an empty payload. (OpenIDC/cjose@ff74c49)

### Testing

Built with CMake (`-pedantic -Wall -Werror`) on Linux with GCC 15, OpenSSL 3.5.5 and Jansson 2.14; `check_cjose` passes. `valgrind --leak-check=full` on the jws suite (`CK_FORK=no CK_RUN_SUITE=jws`) reports 0 errors and 0 bytes lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
