### PR TITLE
jwk: fix leaks and unchecked results in RSA/EC key handling, wipe private key material

### DIFF
--- a/src/include/jwk_int.h
+++ b/src/include/jwk_int.h
@@ -29,7 +29,7 @@
 // key-specific function table
 typedef struct _key_fntable_int
 {
-    void (*free)(cjose_jwk_t *);
+    void (*free_func)(cjose_jwk_t *);
     bool (*public_json)(const cjose_jwk_t *, json_t *, cjose_err *err);
     bool (*private_json)(const cjose_jwk_t *, json_t *, cjose_err *err);
 } key_fntable;

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -1704,7 +1704,7 @@ static bool _cjose_jwk_evp_key_from_ec_key(const cjose_jwk_t *jwk, EVP_PKEY **ke
 
     // create a blank EVP_PKEY
     *key = EVP_PKEY_new();
-    if (NULL == key)
+    if (NULL == *key)
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _cjose_jwk_evp_key_from_ec_key_fail;

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -260,7 +260,11 @@ bool cjose_jwk_set_kid(cjose_jwk_t *jwk, const char *kid, size_t len, cjose_err 
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         return false;
     }
-    strncpy(jwk->kid, kid, len + 1);
+    // copy exactly len bytes from the caller-supplied (length-delimited, not
+    // necessarily NUL-terminated) kid and terminate ourselves; strncpy(len + 1)
+    // would read one byte past kid and could leave jwk->kid unterminated.
+    memcpy(jwk->kid, kid, len);
+    jwk->kid[len] = '\0';
     return true;
 }
 

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -1143,7 +1143,7 @@ static bool _RSA_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err 
     BIGNUM *rsa_n = NULL, *rsa_e = NULL, *rsa_d = NULL;
     _cjose_jwk_rsa_get(rsa, &rsa_n, &rsa_e, &rsa_d);
 
-    BIGNUM *rsa_p = NULL, *rsa_q;
+    BIGNUM *rsa_p = NULL, *rsa_q = NULL;
     _cjose_jwk_rsa_get_factors(rsa, &rsa_p, &rsa_q);
 
     BIGNUM *rsa_dmp1 = NULL, *rsa_dmq1 = NULL, *rsa_iqmp = NULL;

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -1749,6 +1749,11 @@ cjose_jwk_t *cjose_jwk_derive_ecdh_ephemeral_key(
     // HKDF of the DH shared secret (SHA256, no info, 256 bit expand)
     ephemeral_key_len = 32;
     ephemeral_key = (uint8_t *)cjose_get_alloc()(ephemeral_key_len);
+    if (NULL == ephemeral_key)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        goto _cjose_jwk_derive_shared_secret_fail;
+    }
     if (!cjose_jwk_hkdf(EVP_sha256(), salt, salt_len, (uint8_t *)"", 0, secret, secret_len, ephemeral_key, ephemeral_key_len, err))
     {
         goto _cjose_jwk_derive_shared_secret_fail;

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -201,7 +201,10 @@ bool _cjose_jwk_rsa_set_crt(
 
 const char *cjose_jwk_name_for_kty(cjose_jwk_kty_t kty, cjose_err *err)
 {
-    if (0 == kty || CJOSE_JWK_KTY_OCT < kty)
+    // reject anything outside [CJOSE_JWK_KTY_RSA, CJOSE_JWK_KTY_OCT]; a value
+    // below RSA (e.g. a negative sentinel, if the enum is signed) would index
+    // JWK_KTY_NAMES out of bounds
+    if (kty < CJOSE_JWK_KTY_RSA || CJOSE_JWK_KTY_OCT < kty)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return NULL;

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -856,15 +856,13 @@ static bool _EC_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *
     json_object_set(json, "d", field);
     json_decref(field);
     field = NULL;
-    cjose_get_dealloc()(b64u);
-    b64u = NULL;
 
     result = true;
 
 _ec_to_string_cleanup:
     // buffer and b64u hold the raw / base64url-encoded private key 'd';
-    // wipe them before release (b64u is also leaked here without this on
-    // the _cjose_json_stringn failure path)
+    // wipe them before release on the success path as well as the
+    // _cjose_json_stringn failure path (where b64u would otherwise leak)
     _cjose_cleanse_dealloc(buffer, numsize);
     _cjose_cleanse_dealloc(b64u, len);
 

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -11,7 +11,6 @@
 #include <cjose/base64.h>
 #include <cjose/util.h>
 
-#include <assert.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
@@ -245,8 +244,10 @@ bool cjose_jwk_release(cjose_jwk_t *jwk)
         jwk->kid = NULL;
 
         // assumes freefunc is set
-        assert(NULL != jwk->fns->free_func);
-        jwk->fns->free_func(jwk);
+        if (NULL != jwk->fns->free_func)
+        {
+            jwk->fns->free_func(jwk);
+        }
         jwk = NULL;
     }
 

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -15,7 +15,6 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
 #include <stdio.h>
 
 #include <openssl/bn.h>
@@ -1415,7 +1414,9 @@ _decode_json_object_base64url_attribute(json_t *jwk_json, const char *key, uint8
         for (end = str + strlen(str) - 1; *end == '=' && end > str; --end)
             ;
         size_t unpadded_len = end + 1 - str - ((*end == '=') ? 1 : 0);
-        size_t expected_len = (size_t)ceil(4 * ((float)*buflen / 3));
+        // number of unpadded base64url characters for *buflen bytes,
+        // i.e. ceil(4 * buflen / 3) computed with integer arithmetic
+        size_t expected_len = (4 * (*buflen) + 2) / 3;
 
         if (expected_len != unpadded_len)
         {

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -1384,6 +1384,9 @@ static cjose_jwk_t *_cjose_jwk_import_EC(json_t *jwk_json, cjose_err *err)
     uint8_t *x_buffer = NULL;
     uint8_t *y_buffer = NULL;
     uint8_t *d_buffer = NULL;
+    size_t x_buflen = 0;
+    size_t y_buflen = 0;
+    size_t d_buflen = 0;
 
     // get the value of the crv attribute
     const char *crv_str = _get_json_object_string_attribute(jwk_json, CJOSE_JWK_CRV_STR, err);
@@ -1402,7 +1405,7 @@ static cjose_jwk_t *_cjose_jwk_import_EC(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of the x coordinate
-    size_t x_buflen = (size_t)_ec_size_for_curve(crv, err);
+    x_buflen = (size_t)_ec_size_for_curve(crv, err);
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_X_STR, &x_buffer, &x_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1410,7 +1413,7 @@ static cjose_jwk_t *_cjose_jwk_import_EC(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of the y coordinate
-    size_t y_buflen = (size_t)_ec_size_for_curve(crv, err);
+    y_buflen = (size_t)_ec_size_for_curve(crv, err);
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_Y_STR, &y_buffer, &y_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1418,7 +1421,7 @@ static cjose_jwk_t *_cjose_jwk_import_EC(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of the private key d
-    size_t d_buflen = (size_t)_ec_size_for_curve(crv, err);
+    d_buflen = (size_t)_ec_size_for_curve(crv, err);
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_D_STR, &d_buffer, &d_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1468,9 +1471,16 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     uint8_t *dp_buffer = NULL;
     uint8_t *dq_buffer = NULL;
     uint8_t *qi_buffer = NULL;
+    size_t n_buflen = 0;
+    size_t e_buflen = 0;
+    size_t d_buflen = 0;
+    size_t p_buflen = 0;
+    size_t q_buflen = 0;
+    size_t dp_buflen = 0;
+    size_t dq_buflen = 0;
+    size_t qi_buflen = 0;
 
     // get the decoded value of n (buflen = 0 means no particular expected len)
-    size_t n_buflen = 0;
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_N_STR, &n_buffer, &n_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1478,7 +1488,6 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of e
-    size_t e_buflen = 0;
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_E_STR, &e_buffer, &e_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1486,7 +1495,6 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of d
-    size_t d_buflen = 0;
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_D_STR, &d_buffer, &d_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1494,7 +1502,6 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of p
-    size_t p_buflen = 0;
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_P_STR, &p_buffer, &p_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1502,7 +1509,6 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of q
-    size_t q_buflen = 0;
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_Q_STR, &q_buffer, &q_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1510,7 +1516,6 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of dp
-    size_t dp_buflen = 0;
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_DP_STR, &dp_buffer, &dp_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1518,7 +1523,6 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of dq
-    size_t dq_buflen = 0;
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_DQ_STR, &dq_buffer, &dq_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1526,7 +1530,6 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of qi
-    size_t qi_buflen = 0;
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_QI_STR, &qi_buffer, &qi_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -461,7 +461,8 @@ static bool _oct_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err 
     }
 
     field = _cjose_json_stringn(k, klen, err);
-    cjose_get_dealloc()(k);
+    // k holds the base64url-encoded symmetric key; wipe it before release
+    _cjose_cleanse_dealloc(k, klen);
     k = NULL;
     if (!field)
     {

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -807,10 +807,11 @@ static bool _EC_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *
     result = true;
 
 _ec_to_string_cleanup:
-    if (buffer)
-    {
-        cjose_get_dealloc()(buffer);
-    }
+    // buffer and b64u hold the raw / base64url-encoded private key 'd';
+    // wipe them before release (b64u is also leaked here without this on
+    // the _cjose_json_stringn failure path)
+    _cjose_cleanse_dealloc(buffer, numsize);
+    _cjose_cleanse_dealloc(b64u, len);
 
     return result;
 }
@@ -1103,16 +1104,12 @@ static inline bool _RSA_json_field(BIGNUM *param, const char *name, json_t *json
     result = true;
 
 RSA_json_field_cleanup:
-    if (b64u)
-    {
-        cjose_get_dealloc()(b64u);
-        b64u = NULL;
-    }
-    if (data)
-    {
-        cjose_get_dealloc()(data);
-        data = NULL;
-    }
+    // data / b64u may hold a private key component (d, p, q, dp, dq, qi);
+    // wipe them before release (harmless for the public n and e)
+    _cjose_cleanse_dealloc(b64u, b64ulen);
+    b64u = NULL;
+    _cjose_cleanse_dealloc(data, datalen);
+    data = NULL;
 
     return result;
 }
@@ -1447,9 +1444,10 @@ import_EC_cleanup:
     {
         cjose_get_dealloc()(y_buffer);
     }
+    // d is the private key -> wipe the decoded copy before release
     if (NULL != d_buffer)
     {
-        cjose_get_dealloc()(d_buffer);
+        _cjose_cleanse_dealloc(d_buffer, d_buflen);
     }
 
     return jwk;
@@ -1555,14 +1553,15 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     jwk = cjose_jwk_create_RSA_spec(&rsa_keyspec, err);
 
 import_RSA_cleanup:
+    // n and e are public; the remaining decoded components are private -> wipe
     cjose_get_dealloc()(n_buffer);
     cjose_get_dealloc()(e_buffer);
-    cjose_get_dealloc()(d_buffer);
-    cjose_get_dealloc()(p_buffer);
-    cjose_get_dealloc()(q_buffer);
-    cjose_get_dealloc()(dp_buffer);
-    cjose_get_dealloc()(dq_buffer);
-    cjose_get_dealloc()(qi_buffer);
+    _cjose_cleanse_dealloc(d_buffer, d_buflen);
+    _cjose_cleanse_dealloc(p_buffer, p_buflen);
+    _cjose_cleanse_dealloc(q_buffer, q_buflen);
+    _cjose_cleanse_dealloc(dp_buffer, dp_buflen);
+    _cjose_cleanse_dealloc(dq_buffer, dq_buflen);
+    _cjose_cleanse_dealloc(qi_buffer, qi_buflen);
 
     return jwk;
 }
@@ -1584,10 +1583,8 @@ static cjose_jwk_t *_cjose_jwk_import_oct(json_t *jwk_json, cjose_err *err)
     jwk = cjose_jwk_create_oct_spec(k_buffer, k_buflen, err);
 
 import_oct_cleanup:
-    if (NULL != k_buffer)
-    {
-        cjose_get_dealloc()(k_buffer);
-    }
+    // k is secret symmetric key material -> wipe the decoded copy
+    _cjose_cleanse_dealloc(k_buffer, k_buflen);
 
     return jwk;
 }

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -99,7 +99,7 @@ void _cjose_jwk_rsa_get_factors(RSA *rsa, BIGNUM **p, BIGNUM **q)
 #endif
 }
 
-void _cjose_jwk_rsa_set_factors(RSA *rsa, uint8_t *p, size_t p_len, uint8_t *q, size_t q_len)
+bool _cjose_jwk_rsa_set_factors(RSA *rsa, uint8_t *p, size_t p_len, uint8_t *q, size_t q_len)
 {
     BIGNUM *rsa_p = NULL, *rsa_q = NULL;
 
@@ -108,12 +108,31 @@ void _cjose_jwk_rsa_set_factors(RSA *rsa, uint8_t *p, size_t p_len, uint8_t *q, 
     if (q && q_len > 0)
         rsa_q = BN_bin2bn(q, q_len, NULL);
 
+    // no factors supplied: a valid (n, e, d)-only private key
+    if (NULL == rsa_p && NULL == rsa_q)
+        return true;
+
+    // p and q are required together; reject (and free) an incomplete pair
+    // instead of leaking the BIGNUM the setter refuses to take ownership of
+    if (NULL == rsa_p || NULL == rsa_q)
+    {
+        BN_free(rsa_p);
+        BN_free(rsa_q);
+        return false;
+    }
+
 #if defined(CJOSE_OPENSSL_11X)
-    RSA_set0_factors(rsa, rsa_p, rsa_q);
+    if (1 != RSA_set0_factors(rsa, rsa_p, rsa_q))
+    {
+        BN_free(rsa_p);
+        BN_free(rsa_q);
+        return false;
+    }
 #else
     rsa->p = rsa_p;
     rsa->q = rsa_q;
 #endif
+    return true;
 }
 
 void _cjose_jwk_rsa_get_crt(RSA *rsa, BIGNUM **dmp1, BIGNUM **dmq1, BIGNUM **iqmp)
@@ -127,7 +146,7 @@ void _cjose_jwk_rsa_get_crt(RSA *rsa, BIGNUM **dmp1, BIGNUM **dmq1, BIGNUM **iqm
 #endif
 }
 
-void _cjose_jwk_rsa_set_crt(
+bool _cjose_jwk_rsa_set_crt(
     RSA *rsa, uint8_t *dmp1, size_t dmp1_len, uint8_t *dmq1, size_t dmq1_len, uint8_t *iqmp, size_t iqmp_len)
 {
     BIGNUM *rsa_dmp1 = NULL, *rsa_dmq1 = NULL, *rsa_iqmp = NULL;
@@ -139,13 +158,34 @@ void _cjose_jwk_rsa_set_crt(
     if (iqmp && iqmp_len > 0)
         rsa_iqmp = BN_bin2bn(iqmp, iqmp_len, NULL);
 
+    // no CRT params supplied: nothing to set
+    if (NULL == rsa_dmp1 && NULL == rsa_dmq1 && NULL == rsa_iqmp)
+        return true;
+
+    // the CRT params are required together; reject (and free) an incomplete
+    // set instead of leaking the BIGNUMs the setter refuses to take ownership of
+    if (NULL == rsa_dmp1 || NULL == rsa_dmq1 || NULL == rsa_iqmp)
+    {
+        BN_free(rsa_dmp1);
+        BN_free(rsa_dmq1);
+        BN_free(rsa_iqmp);
+        return false;
+    }
+
 #if defined(CJOSE_OPENSSL_11X)
-    RSA_set0_crt_params(rsa, rsa_dmp1, rsa_dmq1, rsa_iqmp);
+    if (1 != RSA_set0_crt_params(rsa, rsa_dmp1, rsa_dmq1, rsa_iqmp))
+    {
+        BN_free(rsa_dmp1);
+        BN_free(rsa_dmq1);
+        BN_free(rsa_iqmp);
+        return false;
+    }
 #else
     rsa->dmp1 = rsa_dmp1;
     rsa->dmq1 = rsa_dmq1;
     rsa->iqmp = rsa_iqmp;
 #endif
+    return true;
 }
 
 // interface functions -- Generic
@@ -1280,8 +1320,12 @@ cjose_jwk_t *cjose_jwk_create_RSA_spec(const cjose_jwk_rsa_keyspec *spec, cjose_
             CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
             goto create_RSA_spec_failed;
         }
-        _cjose_jwk_rsa_set_factors(rsa, spec->p, spec->plen, spec->q, spec->qlen);
-        _cjose_jwk_rsa_set_crt(rsa, spec->dp, spec->dplen, spec->dq, spec->dqlen, spec->qi, spec->qilen);
+        if (!_cjose_jwk_rsa_set_factors(rsa, spec->p, spec->plen, spec->q, spec->qlen)
+            || !_cjose_jwk_rsa_set_crt(rsa, spec->dp, spec->dplen, spec->dq, spec->dqlen, spec->qi, spec->qilen))
+        {
+            CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+            goto create_RSA_spec_failed;
+        }
     }
     else if (hasPub)
     {

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -80,7 +80,16 @@ bool _cjose_jwk_rsa_set(RSA *rsa, uint8_t *n, size_t n_len, uint8_t *e, size_t e
         rsa_d = BN_bin2bn(d, d_len, NULL);
 
 #if defined(CJOSE_OPENSSL_11X)
-    return RSA_set0_key(rsa, rsa_n, rsa_e, rsa_d) == 1;
+    if (1 != RSA_set0_key(rsa, rsa_n, rsa_e, rsa_d))
+    {
+        // the setter takes ownership only on success; free the BIGNUMs it
+        // refused (e.g. if a BN_bin2bn above failed) rather than leaking them
+        BN_free(rsa_n);
+        BN_free(rsa_e);
+        BN_free(rsa_d);
+        return false;
+    }
+    return true;
 #else
     rsa->n = rsa_n;
     rsa->e = rsa_e;
@@ -1088,6 +1097,9 @@ static inline cjose_jwk_t *_RSA_new(RSA *rsa, cjose_err *err)
     cjose_jwk_t *jwk = cjose_get_alloc()(sizeof(cjose_jwk_t));
     if (!jwk)
     {
+        // _RSA_new owns rsa on every path; free it here so the callers that
+        // `return _RSA_new(rsa, err)` do not leak it on allocation failure
+        RSA_free(rsa);
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         return NULL;
     }

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -194,8 +194,8 @@ bool cjose_jwk_release(cjose_jwk_t *jwk)
         jwk->kid = NULL;
 
         // assumes freefunc is set
-        assert(NULL != jwk->fns->free);
-        jwk->fns->free(jwk);
+        assert(NULL != jwk->fns->free_func);
+        jwk->fns->free_func(jwk);
         jwk = NULL;
     }
 

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -1118,6 +1118,25 @@ START_TEST(test_cjose_jwk_import_invalid)
         "\"e\": \"AQAB\", "
         "\"kid\": \"05F24DC3-59F4-4AC5-9849-F2F5EA8A6F3E\" }",
 
+        // RSA 2048 private key with an incomplete factor set (only 'p',
+        // missing 'q'/'dp'/'dq'/'qi'); must be rejected rather than silently
+        // dropping and leaking the supplied factor
+        "{ \"kty\": \"RSA\", "
+        "\"e\": \"AQAB\", "
+        "\"n\": "
+        "\"zSNO12-ydrm-bheszVm2ZvycKrSV2CN0xqQHPxB4yT8MFlWfopMA2Imt4EkILfPfZPeUYV6lElCjoY_4GBtQOy_"
+        "e4RvDSMC0pqt5X4e6mjQvLsaAClkBmhhCYd-Vn9XIC3rSeAmBpSJDuwq_RTweXSG0hb_bn5FHf1Bl_"
+        "ekEBUsm0Xq4p6N5DjC0ImNP74G0qxBVJzu07qsCJzYpifYYoEYkwIY7S4jqyHv55wiuMt89VTl37y8VFR3ll6RPiPFa4Raiminw5wKNJEmrGEukabibspiC0Xv"
+        "WEMXj_zk0YnVTGAGdZeDPwnjYY6JUOJ9KgcYkiQYb9SXetsjSbyheZw\", "
+        "\"d\": "
+        "\"bixuZapp0PYFXp98gXWTT1CQlycR61lvmFf0RFyWYo9n8H7gE7KcG7AmIHVY3UVDT7jgikMIqQOCPn1SI7BXsNIPBBujEGnfHDywHSyKfdNVG-"
+        "wkTGptP9OTo3kvpP5uSCwY6btBU-1JLyWggJC_RgmaKNNYIyUlny0Q-gOx0x0I-6ipWyLQVdKZBkw6erSODM244sPU9qEmyzVW7Nbmo5PKC1U4w-"
+        "Dt4nBe19TIUHG-ggN_UDRauljbegIIcnEWWeXdJZDdPUHgmIRa2ODN0mfSKl1CB4LJ2eyKlmddGLFiHys44OVwA8LVzrodUixIQP6wQ02AUwlaYU_"
+        "BWLEVoQ\", "
+        "\"p\": "
+        "\"9GRrzfmxrL_WgSKXexO6uc2hWh-lV9bPfBU735uHUFBS2_OOUjtQSYSqm-HK2ND1EIlPZBEEu9ccdshaEVYx79eP5fRnpF8EKEo1W-eeinmn7pQsfR-"
+        "6kFzkKmdBVhUyfpZvWtNuIwNZLu-HEvF2eIVVauQtJCPnjeYFbDyveqk\" }",
+
         // empty object
         "{}",
 

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -859,6 +859,7 @@ START_TEST(test_cjose_jwk_import_json_invalid)
         ck_assert_msg(NULL == jwk, "expected NULL, received a cjose_jwk_t");
         ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
         cjose_jwk_release(jwk);
+        json_decref(left_json);
     }
 }
 END_TEST


### PR DESCRIPTION
Part of the step 1 series (bug and undefined-behaviour fixes only, no public API change) discussed in #142, porting fixes carried in the OpenIDC/cjose `version-0.6.2.x` branch.

### Changes

- `_cjose_jwk_rsa_set()`: free the BIGNUMs when `RSA_set0_key()` refuses them (the setter only takes ownership on success). `_cjose_jwk_rsa_set_factors()` / `_cjose_jwk_rsa_set_crt()` now return `bool`, reject an incomplete factor or CRT parameter set and free the BIGNUMs instead of leaking them, and `cjose_jwk_create_RSA_spec()` checks their results. `_RSA_new()` frees the `RSA` when the JWK allocation fails. (OpenIDC/cjose@8000537, OpenIDC/cjose@f3cf129)
- `_cjose_jwk_evp_key_from_ec_key()` NULL-checked `key` instead of `*key` (typo); `cjose_jwk_derive_ecdh_ephemeral_key()` did not check the ephemeral key allocation; `_RSA_private_fields()` left `rsa_q` uninitialized. (OpenIDC/cjose@690d426, OpenIDC/cjose@1c022cb, OpenIDC/cjose@ce26265)
- `cjose_jwk_set_kid()` used `strncpy(kid, len + 1)`, which reads one byte past a length-delimited, not necessarily NUL-terminated `kid`; copy exactly `len` bytes and terminate. (OpenIDC/cjose@cd1649d)
- `cjose_jwk_name_for_kty()` bounds-checks `kty` from below as well as from above. (OpenIDC/cjose@61b59a6)
- Cleanse decoded and encoded private key material on import and export: RSA `d/p/q/dp/dq/qi`, EC `d` (also fixing a leak of the encoded `d` on the `_cjose_json_stringn()` failure path) and oct `k`. (OpenIDC/cjose@1a419a8, OpenIDC/cjose@59b16c9)
- `_decode_json_object_base64url_attribute()`: compute the expected base64url length with integer arithmetic instead of `ceil()` on a `float`, dropping the `<math.h>` dependency. (OpenIDC/cjose@17a6f8a)
- Initialize the decoded buffer lengths up front in the EC/RSA import paths (clang `-Werror`), by @kraj. (OpenIDC/cjose@aca8acb)
- Replace the `assert()` on the key free function with a NULL check (#123) and rename the internal `key_fntable.free` member to `free_func` so it cannot collide with a `free` macro from debug allocators (#109). (OpenIDC/cjose@5736ee3, OpenIDC/cjose@cca0a2d)
- Tests: release the JSON objects loaded by the invalid-JWK import test. (OpenIDC/cjose@5ed25dd)

### Testing

Built with CMake (`-pedantic -Wall -Werror`) on Linux with GCC 15, OpenSSL 3.5.5 and Jansson 2.14; `check_cjose` passes. `valgrind --leak-check=full` on the jwk suite (`CK_FORK=no CK_RUN_SUITE=jwk`) reports 0 errors and 0 bytes lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
