### PR TITLE
error/header/util: bounds-check cjose_err_message, check json_object_set_new, reject an empty crit list

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -18,16 +18,25 @@ const char *cjose_err_message(cjose_errcode code)
     const char *retval = NULL;
     if (CJOSE_ERR_CRYPTO == code)
     {
-        // for crypto errors, return the most recent openssl error as message
-        long err = ERR_get_error();
+        // for crypto errors, return the most recent openssl error as message;
+        // render it into a thread-local buffer since ERR_error_string with a
+        // NULL buffer returns a static buffer shared across threads
+        static __thread char buf[256];
+        unsigned long err = ERR_get_error();
         while (0 != err)
         {
-            retval = ERR_error_string(err, NULL);
+            ERR_error_string_n(err, buf, sizeof(buf));
+            retval = buf;
             err = ERR_get_error();
         }
     }
     if (NULL == retval)
     {
+        // the code is caller-supplied; don't index the table out of bounds
+        if ((size_t)code >= sizeof(_ERR_MSG_TABLE) / sizeof(_ERR_MSG_TABLE[0]))
+        {
+            return "unknown error";
+        }
         retval = _ERR_MSG_TABLE[code];
     }
     return retval;

--- a/src/error.c
+++ b/src/error.c
@@ -9,6 +9,18 @@
 #include <openssl/err.h>
 #include "cjose/error.h"
 
+// thread-local storage specifier: MSVC spells it __declspec(thread),
+// GCC/Clang use __thread, C11 has _Thread_local
+#if defined(_MSC_VER)
+#define CJOSE_THREAD_LOCAL __declspec(thread)
+#elif defined(__GNUC__) || defined(__clang__)
+#define CJOSE_THREAD_LOCAL __thread
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define CJOSE_THREAD_LOCAL _Thread_local
+#else
+#define CJOSE_THREAD_LOCAL
+#endif
+
 ////////////////////////////////////////////////////////////////////////////////
 static const char *_ERR_MSG_TABLE[] = { "no error", "invalid argument", "invalid state", "out of memory", "crypto error" };
 
@@ -21,7 +33,7 @@ const char *cjose_err_message(cjose_errcode code)
         // for crypto errors, return the most recent openssl error as message;
         // render it into a thread-local buffer since ERR_error_string with a
         // NULL buffer returns a static buffer shared across threads
-        static __thread char buf[256];
+        static CJOSE_THREAD_LOCAL char buf[256];
         unsigned long err = ERR_get_error();
         while (0 != err)
         {

--- a/src/header.c
+++ b/src/header.c
@@ -33,6 +33,13 @@ bool _cjose_header_validate_crit(cjose_header_t *header, const char *const *supp
         return false;
     }
 
+    // RFC 7515 section 4.1.11: if present, the "crit" list MUST NOT be empty
+    if (0 == json_array_size(crit))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
     size_t index = 0;
     json_t *entry = NULL;
     json_array_foreach(crit, index, entry)

--- a/src/header.c
+++ b/src/header.c
@@ -110,7 +110,13 @@ bool cjose_header_set(cjose_header_t *header, const char *attr, const char *valu
         return false;
     }
 
-    json_object_set_new((json_t *)header, attr, value_obj);
+    // json_object_set_new fails on OOM or an invalid attr key, and releases
+    // value_obj either way; don't report success with the attribute unset
+    if (0 != json_object_set_new((json_t *)header, attr, value_obj))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        return false;
+    }
 
     return true;
 }
@@ -152,7 +158,13 @@ bool cjose_header_set_raw(cjose_header_t *header, const char *attr, const char *
         return false;
     }
 
-    json_object_set_new((json_t *)header, attr, value_obj);
+    // json_object_set_new fails on OOM or an invalid attr key, and releases
+    // value_obj either way; don't report success with the attribute unset
+    if (0 != json_object_set_new((json_t *)header, attr, value_obj))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        return false;
+    }
 
     return true;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -151,6 +151,7 @@ json_t *_cjose_json_stringn(const char *value, size_t len, cjose_err *err)
     result = json_string(s);
     if (!result)
     {
+        cjose_get_dealloc()(s);
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         return NULL;
     }

--- a/test/check_header.c
+++ b/test/check_header.c
@@ -81,10 +81,11 @@ START_TEST(test_cjose_header_set_get_raw)
 {
     cjose_err err;
     bool result;
-    const char *epk_get, *epk_set = "{\"kty\":\"EC\","
-                                    "\"crv\":\"P-256\","
-                                    "\"x\":\"_XNXAUbQMEboZR7uG-SqA8pQPWj-BCjaEx3LyXdX1lA\","
-                                    "\"y\":\"8o4GHhoWsWI40dK1LGGR7X9tCoOt-lcc5Sqw2yD8Gvw\"}";
+    char *epk_get;
+    const char *epk_set = "{\"kty\":\"EC\","
+                          "\"crv\":\"P-256\","
+                          "\"x\":\"_XNXAUbQMEboZR7uG-SqA8pQPWj-BCjaEx3LyXdX1lA\","
+                          "\"y\":\"8o4GHhoWsWI40dK1LGGR7X9tCoOt-lcc5Sqw2yD8Gvw\"}";
 
     cjose_header_t *header = cjose_header_new(&err);
     ck_assert_msg(NULL != header, "cjose_header_new failed");
@@ -99,6 +100,8 @@ START_TEST(test_cjose_header_set_get_raw)
                                              "expected: %s, found %s",
                   ((epk_set) ? epk_set : "null"), ((epk_get) ? epk_get : "null"));
 
+    // cjose_header_get_raw returns a json_dumps() result owned by the caller
+    cjose_get_dealloc()(epk_get);
     cjose_header_release(header);
 }
 END_TEST

--- a/test/check_header.c
+++ b/test/check_header.c
@@ -12,6 +12,7 @@
 #include <jansson.h>
 #include "include/jwk_int.h"
 #include "include/jwe_int.h"
+#include "include/header_int.h"
 #include <openssl/rsa.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
@@ -106,6 +107,44 @@ START_TEST(test_cjose_header_set_get_raw)
 }
 END_TEST
 
+// regression: RFC 7515 section 4.1.11 requires a "crit" list, if present, to
+// be non-empty; _cjose_header_validate_crit accepted an empty list
+START_TEST(test_cjose_header_validate_crit)
+{
+    cjose_err err;
+    static const char *const supported[] = { "alg", "cty" };
+    const size_t supported_len = sizeof(supported) / sizeof(supported[0]);
+
+    cjose_header_t *header = cjose_header_new(&err);
+    ck_assert_msg(NULL != header, "cjose_header_new failed");
+
+    // no "crit" header at all is fine
+    ck_assert(_cjose_header_validate_crit(header, supported, supported_len, &err));
+
+    // a supported extension is fine
+    ck_assert(cjose_header_set_raw(header, "crit", "[\"cty\"]", &err));
+    ck_assert(_cjose_header_validate_crit(header, supported, supported_len, &err));
+
+    // an unsupported extension is rejected
+    ck_assert(cjose_header_set_raw(header, "crit", "[\"exp\"]", &err));
+    ck_assert(!_cjose_header_validate_crit(header, supported, supported_len, &err));
+    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
+
+    // a non-array value is rejected
+    ck_assert(cjose_header_set(header, "crit", "cty", &err));
+    ck_assert(!_cjose_header_validate_crit(header, supported, supported_len, &err));
+    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
+
+    // an empty list is rejected (RFC 7515 section 4.1.11)
+    memset(&err, 0, sizeof(err));
+    ck_assert(cjose_header_set_raw(header, "crit", "[]", &err));
+    ck_assert(!_cjose_header_validate_crit(header, supported, supported_len, &err));
+    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
+
+    cjose_header_release(header);
+}
+END_TEST
+
 Suite *cjose_header_suite(void)
 {
     Suite *suite = suite_create("header");
@@ -115,6 +154,7 @@ Suite *cjose_header_suite(void)
     tcase_add_test(tc_header, test_cjose_header_retain_release);
     tcase_add_test(tc_header, test_cjose_header_set_get);
     tcase_add_test(tc_header, test_cjose_header_set_get_raw);
+    tcase_add_test(tc_header, test_cjose_header_validate_crit);
     suite_add_tcase(suite, tc_header);
 
     return suite;

--- a/test/check_util.c
+++ b/test/check_util.c
@@ -238,6 +238,19 @@ START_TEST(test_cjose_set_allocators_ex)
 }
 END_TEST
 
+// regression: cjose_err_message is public and must not index its message
+// table out of bounds for an out-of-enum error code
+START_TEST(test_cjose_err_message)
+{
+    ck_assert(NULL != cjose_err_message(CJOSE_ERR_NONE));
+    ck_assert(NULL != cjose_err_message(CJOSE_ERR_INVALID_ARG));
+    ck_assert(NULL != cjose_err_message(CJOSE_ERR_INVALID_STATE));
+    ck_assert(NULL != cjose_err_message(CJOSE_ERR_NO_MEMORY));
+    ck_assert(NULL != cjose_err_message(CJOSE_ERR_CRYPTO));
+    ck_assert_str_eq("unknown error", cjose_err_message((cjose_errcode)42));
+}
+END_TEST
+
 Suite *cjose_util_suite(void)
 {
     Suite *suite = suite_create("util");
@@ -245,6 +258,7 @@ Suite *cjose_util_suite(void)
     TCase *tc_util = tcase_create("core");
     tcase_add_test(tc_util, test_cjose_set_allocators);
     tcase_add_test(tc_util, test_cjose_set_allocators_ex);
+    tcase_add_test(tc_util, test_cjose_err_message);
     suite_add_tcase(suite, tc_util);
 
     return suite;


### PR DESCRIPTION
Part of the step 1 series (bug and undefined-behaviour fixes only, no public API change) discussed in #142, porting fixes carried in the OpenIDC/cjose `version-0.6.2.x` branch.

### Changes

- `cjose_err_message()` indexed the message table with the caller-supplied code without a bounds check, and for `CJOSE_ERR_CRYPTO` returned OpenSSL's shared static buffer (`ERR_error_string(err, NULL)`), which is not thread-safe. It now returns `"unknown error"` for an out-of-range code and renders the OpenSSL message into a thread-local buffer with `ERR_error_string_n()`; the `CJOSE_THREAD_LOCAL` specifier covers MSVC, GCC/Clang and C11. Test `test_cjose_err_message` added. (OpenIDC/cjose@e381f2c, OpenIDC/cjose@9b4c895)
- `cjose_header_set()` / `cjose_header_set_raw()` ignored the result of `json_object_set_new()`, reporting success with the attribute unset on OOM or an invalid key. (OpenIDC/cjose@9555a61)
- `_cjose_header_validate_crit()` accepted an empty `"crit"` list, which RFC 7515 section 4.1.11 forbids. Test `test_cjose_header_validate_crit` added. (OpenIDC/cjose@57f294b)
- `_cjose_json_stringn()` leaked the temporary string when `json_string()` failed. (OpenIDC/cjose@c0a8251)
- Tests: release the `cjose_header_get_raw()` result in the header test. (OpenIDC/cjose@5ed25dd)

### Testing

Built with CMake (`-pedantic -Wall -Werror`) on Linux with GCC 15, OpenSSL 3.5.5 and Jansson 2.14; `check_cjose` passes. `valgrind --leak-check=full` on the header and util suites reports 0 errors and 0 bytes lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
