### PR TITLE
jwe: pin the RSA-unwrapped CEK to the enc key size and validate the encrypted key segment

### DIFF
--- a/src/jwe.c
+++ b/src/jwe.c
@@ -684,26 +684,52 @@ static bool _cjose_jwe_decrypt_ek_rsa_padding(
         return false;
     }
 
-    // we don't know the size of the key to expect, but must be < RSA_size
+    // jwk must have the necessary private parts set
+    BIGNUM *rsa_n = NULL, *rsa_e = NULL, *rsa_d = NULL;
+    _cjose_jwk_rsa_get((RSA *)jwk->keydata, &rsa_n, &rsa_e, &rsa_d);
+    if (NULL == rsa_e || NULL == rsa_n || NULL == rsa_d)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
+    // pin the expected CEK length from the enc header; like the other
+    // decrypt_ek paths the RSA-decrypted key must match it exactly
     _cjose_release_cek(&jwe->cek, jwe->cek_len);
-    size_t buflen = RSA_size((RSA *)jwk->keydata);
-    if (!_cjose_jwe_malloc(buflen, false, &jwe->cek, err))
+    if (!jwe->fns.set_cek(jwe, NULL, false, err))
     {
         return false;
     }
 
-    // decrypt the CEK using RSA v1.5 or OAEP padding
-    int dlen = RSA_private_decrypt(recipient->enc_key.raw_len, recipient->enc_key.raw, jwe->cek, (RSA *)jwk->keydata, padding);
-    if (-1 == dlen)
+    // a valid RSA encrypted key segment is exactly the size of the modulus;
+    // reject other lengths before they reach RSA_private_decrypt
+    size_t buflen = RSA_size((RSA *)jwk->keydata);
+    if (recipient->enc_key.raw_len != buflen)
     {
-        _cjose_release_cek(&jwe->cek, buflen);
-        jwe->cek_len = 0;
-        
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
+    // decrypt into a scratch buffer; the recovered plaintext can be up to
+    // RSA_size bytes, larger than the pinned CEK buffer
+    uint8_t *buf = NULL;
+    if (!_cjose_jwe_malloc(buflen, false, &buf, err))
+    {
+        return false;
+    }
+
+    // decrypt the CEK using RSA v1.5 or OAEP padding and require that its
+    // length matches the CEK size dictated by the enc header (RFC 7518 sec 4.2/4.3)
+    int len = RSA_private_decrypt(recipient->enc_key.raw_len, recipient->enc_key.raw, buf, (RSA *)jwk->keydata, padding);
+    if (-1 == len || (size_t)len != jwe->cek_len)
+    {
+        _cjose_cleanse_dealloc(buf, buflen);
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         return false;
     }
 
-    jwe->cek_len = (size_t)dlen;
+    memcpy(jwe->cek, buf, jwe->cek_len);
+    _cjose_cleanse_dealloc(buf, buflen);
 
     return true;
 }

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -284,7 +284,7 @@ static bool _cjose_jwe_validate_enc(cjose_jwe_t *jwe, cjose_header_t *protected_
         jwe->fns.encrypt_dat = _cjose_jwe_encrypt_dat_a256gcm;
         jwe->fns.decrypt_dat = _cjose_jwe_decrypt_dat_a256gcm;
     }
-    if ((strcmp(enc, CJOSE_HDR_ENC_A128CBC_HS256) == 0) || (strcmp(enc, CJOSE_HDR_ENC_A192CBC_HS384) == 0)
+    else if ((strcmp(enc, CJOSE_HDR_ENC_A128CBC_HS256) == 0) || (strcmp(enc, CJOSE_HDR_ENC_A192CBC_HS384) == 0)
         || (strcmp(enc, CJOSE_HDR_ENC_A256CBC_HS512) == 0))
     {
         jwe->fns.set_cek = _cjose_jwe_set_cek_aes_cbc;

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -450,10 +450,17 @@ static bool _cjose_jwe_set_cek_aes_cbc(cjose_jwe_t *jwe, const cjose_jwk_t *jwk,
     size_t keysize = 0;
     if (strcmp(enc, CJOSE_HDR_ENC_A128CBC_HS256) == 0)
         keysize = 32;
-    if (strcmp(enc, CJOSE_HDR_ENC_A192CBC_HS384) == 0)
+    else if (strcmp(enc, CJOSE_HDR_ENC_A192CBC_HS384) == 0)
         keysize = 48;
-    if (strcmp(enc, CJOSE_HDR_ENC_A256CBC_HS512) == 0)
+    else if (strcmp(enc, CJOSE_HDR_ENC_A256CBC_HS512) == 0)
         keysize = 64;
+
+    // reject an unrecognized enc rather than proceeding with a zero-length CEK
+    if (0 == keysize)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
 
     // if no JWK is provided, generate a random key
     if (NULL == jwk)

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -1401,6 +1401,92 @@ START_TEST(test_cjose_jwe_encrypt_cbc_cek_random)
 }
 END_TEST
 
+// regression: an RSA-OAEP / RSA1_5 encrypted_key that unwraps to a CEK of the
+// wrong length for the enc algorithm must be rejected. The recovered length
+// used to be accepted as-is, so an encrypted_key wrapping the real CEK plus
+// trailing garbage still decrypted because the content cipher only read the
+// key-size prefix (RFC 7518 sections 4.2 and 4.3 require an exact match).
+START_TEST(test_cjose_jwe_decrypt_rsa_wrong_cek_length)
+{
+    cjose_err err;
+
+    cjose_jwk_t *jwk = cjose_jwk_import(JWK_RSA, strlen(JWK_RSA), &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
+
+    cjose_header_t *hdr = cjose_header_new(&err);
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_RSA_OAEP, &err));
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+
+    const char *plain = "Setec Astronomy";
+    cjose_jwe_t *jwe = cjose_jwe_encrypt(jwk, hdr, (const uint8_t *)plain, strlen(plain), &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed: %s", err.message);
+
+    char *compact = cjose_jwe_export(jwe, &err);
+    ck_assert_msg(NULL != compact, "cjose_jwe_export failed: %s", err.message);
+
+    char *first_dot = strchr(compact, '.');
+    ck_assert(NULL != first_dot);
+    char *second_dot = strchr(first_dot + 1, '.');
+    ck_assert(NULL != second_dot);
+
+    // recover the real 32-byte A256GCM CEK by unwrapping the encrypted_key
+    // segment with the private key
+    RSA *rsa = (RSA *)jwk->keydata;
+    int ek_len = RSA_size(rsa);
+    uint8_t *orig_ek = NULL;
+    size_t orig_ek_len = 0;
+    ck_assert(cjose_base64url_decode(first_dot + 1, second_dot - first_dot - 1, &orig_ek, &orig_ek_len, &err));
+    ck_assert_int_eq(ek_len, orig_ek_len);
+    uint8_t cek[256];
+    ck_assert_int_eq(32, RSA_private_decrypt(orig_ek_len, orig_ek, cek, rsa, RSA_PKCS1_OAEP_PADDING));
+
+    // RSA-OAEP-encrypt that CEK followed by 8 trailing bytes (40 bytes in
+    // total) with the same public key
+    uint8_t bad_cek[40];
+    memcpy(bad_cek, cek, 32);
+    memset(bad_cek + 32, 0x42, sizeof(bad_cek) - 32);
+    uint8_t *ek = (uint8_t *)malloc(ek_len);
+    ck_assert(NULL != ek);
+    ck_assert(RSA_public_encrypt(sizeof(bad_cek), bad_cek, ek, rsa, RSA_PKCS1_OAEP_PADDING) == ek_len);
+
+    char *ek_b64u = NULL;
+    size_t ek_b64u_len = 0;
+    ck_assert(cjose_base64url_encode(ek, ek_len, &ek_b64u, &ek_b64u_len, &err));
+
+    // splice the wrong-length encrypted CEK into the compact serialization
+
+    size_t header_len = first_dot - compact;
+    size_t tail_len = strlen(second_dot);
+    size_t tampered_len = header_len + 1 + ek_b64u_len + tail_len;
+    char *tampered = (char *)malloc(tampered_len + 1);
+    ck_assert(NULL != tampered);
+    memcpy(tampered, compact, header_len);
+    tampered[header_len] = '.';
+    memcpy(tampered + header_len + 1, ek_b64u, ek_b64u_len);
+    memcpy(tampered + header_len + 1 + ek_b64u_len, second_dot, tail_len);
+    tampered[tampered_len] = '\0';
+
+    // import must succeed; decryption must fail on the CEK length mismatch
+    cjose_jwe_t *jwe_bad = cjose_jwe_import(tampered, tampered_len, &err);
+    ck_assert_msg(NULL != jwe_bad, "cjose_jwe_import failed: %s", err.message);
+
+    size_t plain_len = 0;
+    uint8_t *decrypted = cjose_jwe_decrypt(jwe_bad, jwk, &plain_len, &err);
+    ck_assert_msg(NULL == decrypted, "cjose_jwe_decrypt accepted a 40-byte CEK for A256GCM");
+    ck_assert_msg(CJOSE_ERR_CRYPTO == err.code, "expected CJOSE_ERR_CRYPTO, got %d", err.code);
+
+    free(tampered);
+    free(ek);
+    cjose_get_dealloc()(orig_ek);
+    cjose_get_dealloc()(ek_b64u);
+    cjose_get_dealloc()(compact);
+    cjose_jwe_release(jwe_bad);
+    cjose_jwe_release(jwe);
+    cjose_header_release(hdr);
+    cjose_jwk_release(jwk);
+}
+END_TEST
+
 Suite *cjose_jwe_suite(void)
 {
     Suite *suite = suite_create("jwe");
@@ -1425,6 +1511,7 @@ Suite *cjose_jwe_suite(void)
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_bad_params);
     tcase_add_test(tc_jwe, test_cjose_jwe_multiple_recipients);
     tcase_add_test(tc_jwe, test_cjose_jwe_encrypt_cbc_cek_random);
+    tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_rsa_wrong_cek_length);
     suite_add_tcase(suite, tc_jwe);
 
     return suite;


### PR DESCRIPTION
Part of the step 1 series (bug and undefined-behaviour fixes only, no public API change) discussed in #142, porting fixes carried in the OpenIDC/cjose `version-0.6.2.x` branch. Split out from #146 because it restructures one function rather than patching leaks; both touch `src/jwe.c` in different places, so whichever lands second needs a trivial rebase.

### Changes

- `_cjose_jwe_decrypt_ek_rsa_padding()` accepted whatever `RSA_private_decrypt()` returned as the content encryption key: it did not require the JWK to carry a private exponent, passed an `encrypted_key` segment of any length to the RSA primitive, and set `cek_len` to whatever length came back. A CEK that does not match the size the `enc` algorithm requires was therefore accepted: too short and the content cipher silently zero-pads it, too long and it is silently truncated, so an `encrypted_key` wrapping the real key plus trailing garbage still decrypts. RFC 7518 sections 4.2 and 4.3 require the unwrapped CEK to be exactly the `enc` key size, and the AES-KW and ECDH-ES paths already enforce that. The function now requires `n`, `e` and `d`, pins the expected CEK length from the `enc` header via `set_cek()`, rejects an `encrypted_key` segment that is not exactly `RSA_size()` bytes before it reaches `RSA_private_decrypt()`, decrypts into a scratch buffer, rejects a recovered length that differs from the pinned size, and wipes the scratch buffer on every path. This supersedes the `cek_len` reset added in a9bb847 for the failure case. (OpenIDC/cjose@dc14728, OpenIDC/cjose@5971997, OpenIDC/cjose@0754ab9)
- Regression test `test_cjose_jwe_decrypt_rsa_wrong_cek_length`: unwraps the real 32-byte A256GCM CEK, re-wraps it with eight trailing bytes, splices that into the JWE and checks that decryption fails with `CJOSE_ERR_CRYPTO`. On master it fails with "cjose_jwe_decrypt accepted a 40-byte CEK for A256GCM".
- `_cjose_jwe_validate_enc()` and `_cjose_jwe_set_cek_aes_cbc()`: make the `enc` dispatch mutually exclusive and fail with `CJOSE_ERR_INVALID_ARG` when no key size was selected instead of continuing with a zero-length CEK. Defensive; not reachable with the current dispatch table. (OpenIDC/cjose@abe460c, OpenIDC/cjose@f006df5)

### Testing

Built with CMake (`-pedantic -Wall -Werror`) on Linux with GCC 15, OpenSSL 3.5.5 and Jansson 2.14; `check_cjose` passes. `valgrind --leak-check=full` on the jwe suite (`CK_FORK=no CK_RUN_SUITE=jwe`) reports the same 103 bytes in 103 blocks as current master (the empty ECDH-ES `encrypted_key` buffer allocated on import, fixed in #146) and nothing new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
