### PR TITLE
[step 3] jwk/util: drop the meaningless const from cjose_jwk_EC_get_curve, fix doc contracts

### DIFF
--- a/include/cjose/jwk.h
+++ b/include/cjose/jwk.h
@@ -282,7 +282,7 @@ cjose_jwk_t *cjose_jwk_create_EC_spec(const cjose_jwk_ec_keyspec *spec, cjose_er
  *        information in the event of an error.
  * \returns The curve type
  */
-const cjose_jwk_ec_curve cjose_jwk_EC_get_curve(const cjose_jwk_t *jwk, cjose_err *err);
+cjose_jwk_ec_curve cjose_jwk_EC_get_curve(const cjose_jwk_t *jwk, cjose_err *err);
 
 /**
  * Creates a new symmetric octet JWK, using a secure random number generator.

--- a/include/cjose/util.h
+++ b/include/cjose/util.h
@@ -163,9 +163,10 @@ cjose_dealloc3_fn_t cjose_get_dealloc3(void);
  * \param a [in] The first octet string to compare
  * \param b [in] The second octet string to compare
  * \param size [in] The length to compare
- * \returns an  integer  less  than,  equal  to,  or
- *        greater than zero if the first n bytes of s1 is found, respectively, to
- *        be less than, to match, or be greater than the first n bytes of s2
+ * \returns zero if the first \p size bytes of \p a and \p b are equal, and a
+ *        non-zero value otherwise. Unlike memcmp the result is not ordered:
+ *        it wraps CRYPTO_memcmp, which only distinguishes equal from unequal
+ *        so that the comparison stays constant time.
  */
 int cjose_const_memcmp(const uint8_t *a, const uint8_t *b, const size_t size);
 

--- a/src/include/util_int.h
+++ b/src/include/util_int.h
@@ -18,6 +18,9 @@
 typedef SSIZE_T ssize_t;
 #endif
 
+// NOTE: unlike POSIX strndup this copies exactly len bytes (len < 0 means
+// strlen(str)); it does not stop at an embedded NUL, so len must not exceed
+// strlen(str) or the copy over-reads str.
 char *_cjose_strndup(const char *str, ssize_t len, cjose_err *err);
 json_t *_cjose_json_stringn(const char *value, size_t len, cjose_err *err);
 

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -1073,7 +1073,7 @@ create_EC_cleanup:
     return jwk;
 }
 
-const cjose_jwk_ec_curve cjose_jwk_EC_get_curve(const cjose_jwk_t *jwk, cjose_err *err)
+cjose_jwk_ec_curve cjose_jwk_EC_get_curve(const cjose_jwk_t *jwk, cjose_err *err)
 {
     if (NULL == jwk || CJOSE_JWK_KTY_EC != cjose_jwk_get_kty(jwk, err))
     {


### PR DESCRIPTION
Step 3 of the plan in #142 (API-visible changes that keep API and ABI compatibility), porting changes carried in the OpenIDC/cjose `version-0.6.2.x` branch. Ready for review; per the plan it is meant to merge after the 0.6.x release.

### Changes

- `cjose_jwk_EC_get_curve()`: drop the `const` qualifier from the `cjose_jwk_ec_curve` return type. A top-level qualifier on a return type is meaningless in C and is not part of the function type, so this is ABI-neutral and source-compatible; it silences `-Wignored-qualifiers` (`-Werror` builds with `-Wextra`, clang). (OpenIDC/cjose@d9a1716, by Shoichi Yamaguchi)
- Documentation: `cjose_const_memcmp()` wraps `CRYPTO_memcmp()`, which only reports equal or not equal, while its doc comment promised a memcmp-style ordered result. `_cjose_strndup()` copies exactly `len` bytes and does not stop at an embedded NUL, unlike POSIX `strndup`; say so at its declaration. (OpenIDC/cjose@f3d6477)

### Testing

Built with CMake (`-pedantic -Wall -Werror`) on Linux with GCC 15, OpenSSL 3.5.5 and Jansson 2.14; `check_cjose` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
