### PR TITLE
[step 3] jwe: add cjose_jwe_encrypt_iv and cjose_jwe_encrypt_multi_iv for a caller-supplied IV

### DIFF
--- a/cmake/exports/cjose.def
+++ b/cmake/exports/cjose.def
@@ -55,7 +55,9 @@ EXPORTS
     cjose_jwe_decrypt
     cjose_jwe_decrypt_multi
     cjose_jwe_encrypt
+    cjose_jwe_encrypt_iv
     cjose_jwe_encrypt_multi
+    cjose_jwe_encrypt_multi_iv
     cjose_jwe_export
     cjose_jwe_export_json
     cjose_jwe_get_protected

--- a/cmake/exports/libcjose.symbols
+++ b/cmake/exports/libcjose.symbols
@@ -55,7 +55,9 @@ _cjose_header_set_raw
 _cjose_jwe_decrypt
 _cjose_jwe_decrypt_multi
 _cjose_jwe_encrypt
+_cjose_jwe_encrypt_iv
 _cjose_jwe_encrypt_multi
+_cjose_jwe_encrypt_multi_iv
 _cjose_jwe_export
 _cjose_jwe_export_json
 _cjose_jwe_get_protected

--- a/cmake/exports/libcjose.version
+++ b/cmake/exports/libcjose.version
@@ -58,7 +58,9 @@
         cjose_jwe_decrypt;
         cjose_jwe_decrypt_multi;
         cjose_jwe_encrypt;
+        cjose_jwe_encrypt_iv;
         cjose_jwe_encrypt_multi;
+        cjose_jwe_encrypt_multi_iv;
         cjose_jwe_export;
         cjose_jwe_export_json;
         cjose_jwe_get_protected;

--- a/include/cjose/jwe.h
+++ b/include/cjose/jwe.h
@@ -65,6 +65,35 @@ cjose_jwe_t *
 cjose_jwe_encrypt(const cjose_jwk_t *jwk, cjose_header_t *header, const uint8_t *plaintext, size_t plaintext_len, cjose_err *err);
 
 /**
+ * Creates a new JWE by encrypting the given plaintext within the given header
+ * and JWK, with a caller-supplied initialization vector.
+ *
+ * If the header provided indicates an algorithm requiring an asymmetric key
+ * (e.g. RSA-OAEP), the provided JWK must be asymmetric (e.g. RSA or EC).
+ *
+ * If the header provided indicates an algorithm requiring a symmetric key
+ * (e.g. (dir), the provided JWK must be symmetric (e.g. oct).
+ *
+ * \param jwk [in] the key to use for encrypting the JWE.
+ * \param protected_header [in] additional header values to include in the JWE protected header.
+ * \param iv [in] the initialization vector for encrypting the JWE payload. If NULL, an IV will be automatically generated.
+ *        The IV is copied.
+ * \param iv_len [in] the length of the initialization vector, or 0 if iv is NULL.
+ * \param plaintext [in] the plaintext to be encrypted in the JWE payload.
+ * \param plaintext_len [in] the length of the plaintext.
+ * \param err [out] An optional error object which can be used to get additional
+ *        information in the event of an error.
+ * \returns a newly generated JWE with the given plaintext as the payload.
+ */
+cjose_jwe_t *cjose_jwe_encrypt_iv(const cjose_jwk_t *jwk,
+                                  cjose_header_t *header,
+                                  const uint8_t *iv,
+                                  size_t iv_len,
+                                  const uint8_t *plaintext,
+                                  size_t plaintext_len,
+                                  cjose_err *err);
+
+/**
  * Creates a new JWE by encrypting the given plaintext with multiple keys.
  * \see ::cjose_jwe_encrypt for key requirements.
  * \param recipients [in] array of recipient objects. Each element must have the
@@ -75,7 +104,7 @@ cjose_jwe_encrypt(const cjose_jwk_t *jwk, cjose_header_t *header, const uint8_t 
  *        recipients there is.
  * \param protected_header [in] additional header values to include in the JWE protected header. The header
  *        is retained by JWE and should be released by the caller if no longer needed.
- * \param unprotected_header [in] additional header values to include in the shared JWE unprotected header,
+ * \param shared_unprotected_header [in] additional header values to include in the shared JWE unprotected header,
  *        can be NULL. The header is retained by JWE and should be released by the caller if no longer needed.
  * \param plaintext [in] the plaintext to be encrypted in the JWE payload.
  * \param plaintext_len [in] the length of the plaintext.
@@ -90,6 +119,40 @@ cjose_jwe_t *cjose_jwe_encrypt_multi(const cjose_jwe_recipient_t * recipients,
                                     const uint8_t *plaintext,
                                     size_t plaintext_len,
                                     cjose_err *err);
+
+/**
+ * Creates a new JWE by encrypting the given plaintext with multiple keys and a
+ * caller-supplied initialization vector.
+ * \see ::cjose_jwe_encrypt for key requirements.
+ * \see ::cjose_jwe_encrypt_multi to automatically generate an IV.
+ * \param recipients [in] array of recipient objects. Each element must have the
+ *        key of the recipient, and may have optional (not NULL) unprotected header.
+ *        Unprotected header is retained by this function, and can be safely released by the
+ *        caller if no longer needed. The key is only used within the scope of this function.
+ * \param recipient_count effective length of the recipients array, specifying how many
+ *        recipients there is.
+ * \param protected_header [in] additional header values to include in the JWE protected header. The header
+ *        is retained by JWE and should be released by the caller if no longer needed.
+ * \param shared_unprotected_header [in] additional header values to include in the shared JWE unprotected header,
+ *        can be NULL. The header is retained by JWE and should be released by the caller if no longer needed.
+ * \param iv [in] the initialization vector for encrypting the JWE payload. If NULL, an IV will be automatically generated.
+ *        The IV is copied.
+ * \param iv_len [in] the length of the initialization vector, or 0 if iv is NULL.
+ * \param plaintext [in] the plaintext to be encrypted in the JWE payload.
+ * \param plaintext_len [in] the length of the plaintext.
+ * \param err [out] An optional error object which can be used to get additional
+ *        information in the event of an error.
+ * \returns a newly generated JWE with the given plaintext as the payload.
+ */
+cjose_jwe_t *cjose_jwe_encrypt_multi_iv(const cjose_jwe_recipient_t *recipients,
+                                        size_t recipient_count,
+                                        cjose_header_t *protected_header,
+                                        cjose_header_t *shared_unprotected_header,
+                                        const uint8_t *iv,
+                                        size_t iv_len,
+                                        const uint8_t *plaintext,
+                                        size_t plaintext_len,
+                                        cjose_err *err);
 
 /**
  * Creates a compact serialization of the given JWE object.

--- a/include/cjose/jwe.h
+++ b/include/cjose/jwe.h
@@ -77,7 +77,10 @@ cjose_jwe_encrypt(const cjose_jwk_t *jwk, cjose_header_t *header, const uint8_t 
  * \param jwk [in] the key to use for encrypting the JWE.
  * \param protected_header [in] additional header values to include in the JWE protected header.
  * \param iv [in] the initialization vector for encrypting the JWE payload. If NULL, an IV will be automatically generated.
- *        The IV is copied.
+ *        The IV is copied. It must have the length the content encryption algorithm requires: 12 octets for
+ *        the AES GCM algorithms and 16 octets for the AES CBC HMAC algorithms. The caller is responsible for
+ *        never using the same IV twice with the same key; for AES GCM a repeated (key, IV) pair breaks both
+ *        confidentiality and integrity. Prefer the variant without an IV unless a specific IV is required.
  * \param iv_len [in] the length of the initialization vector, or 0 if iv is NULL.
  * \param plaintext [in] the plaintext to be encrypted in the JWE payload.
  * \param plaintext_len [in] the length of the plaintext.
@@ -136,7 +139,10 @@ cjose_jwe_t *cjose_jwe_encrypt_multi(const cjose_jwe_recipient_t * recipients,
  * \param shared_unprotected_header [in] additional header values to include in the shared JWE unprotected header,
  *        can be NULL. The header is retained by JWE and should be released by the caller if no longer needed.
  * \param iv [in] the initialization vector for encrypting the JWE payload. If NULL, an IV will be automatically generated.
- *        The IV is copied.
+ *        The IV is copied. It must have the length the content encryption algorithm requires: 12 octets for
+ *        the AES GCM algorithms and 16 octets for the AES CBC HMAC algorithms. The caller is responsible for
+ *        never using the same IV twice with the same key; for AES GCM a repeated (key, IV) pair breaks both
+ *        confidentiality and integrity. Prefer the variant without an IV unless a specific IV is required.
  * \param iv_len [in] the length of the initialization vector, or 0 if iv is NULL.
  * \param plaintext [in] the plaintext to be encrypted in the JWE payload.
  * \param plaintext_len [in] the length of the plaintext.

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -184,6 +184,26 @@ static size_t _keylen_from_enc(const char *alg)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+static size_t _ivlen_from_enc(const char *enc)
+{
+    size_t ivlen = 0;
+
+    if (0 == strcmp(enc, CJOSE_HDR_ENC_A256GCM))
+    {
+        // AES GCM uses a 96-bit IV
+        ivlen = 12;
+    }
+    else if ((0 == strcmp(enc, CJOSE_HDR_ENC_A128CBC_HS256)) || (0 == strcmp(enc, CJOSE_HDR_ENC_A192CBC_HS384))
+             || (0 == strcmp(enc, CJOSE_HDR_ENC_A256CBC_HS512)))
+    {
+        // AES CBC uses a block-sized IV
+        ivlen = AES_BLOCK_SIZE;
+    }
+
+    return ivlen;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 static bool _cjose_jwe_malloc(size_t bytes, bool random, uint8_t **buffer, cjose_err *err)
 {
     *buffer = (uint8_t *)cjose_get_alloc()(bytes);
@@ -1669,6 +1689,17 @@ cjose_jwe_t *cjose_jwe_encrypt_multi_iv(const cjose_jwe_recipient_t *recipients,
     }
     else
     {
+        // the caller-supplied IV must have the length the content encryption
+        // algorithm requires; a short buffer would otherwise be over-read by
+        // EVP_EncryptInit_ex, which reads a fixed number of IV bytes
+        const char *enc = cjose_header_get(protected_header, CJOSE_HDR_ENC, err);
+        if (NULL == enc || iv_len != _ivlen_from_enc(enc))
+        {
+            CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+            cjose_jwe_release(jwe);
+            return NULL;
+        }
+
         cjose_get_dealloc()(jwe->enc_iv.raw);
         jwe->enc_iv.raw_len = iv_len;
         if (!_cjose_jwe_malloc(jwe->enc_iv.raw_len, false, &jwe->enc_iv.raw, err))

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -1548,8 +1548,13 @@ static bool _cjose_jwe_validate_decrypt_key(_jwe_int_recipient_t *recipient,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-cjose_jwe_t *cjose_jwe_encrypt(
-    const cjose_jwk_t *jwk, cjose_header_t *protected_header, const uint8_t *plaintext, size_t plaintext_len, cjose_err *err)
+cjose_jwe_t *cjose_jwe_encrypt_iv(const cjose_jwk_t *jwk,
+                                  cjose_header_t *protected_header,
+                                  const uint8_t *iv,
+                                  size_t iv_len,
+                                  const uint8_t *plaintext,
+                                  size_t plaintext_len,
+                                  cjose_err *err)
 {
 
     cjose_jwe_recipient_t rec = {
@@ -1557,17 +1562,26 @@ cjose_jwe_t *cjose_jwe_encrypt(
         .unprotected_header = NULL
     };
 
-    return cjose_jwe_encrypt_multi(&rec, 1, protected_header, NULL, plaintext, plaintext_len, err);
+    return cjose_jwe_encrypt_multi_iv(&rec, 1, protected_header, NULL, iv, iv_len, plaintext, plaintext_len, err);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-cjose_jwe_t *cjose_jwe_encrypt_multi(const cjose_jwe_recipient_t * recipients,
-                                    size_t recipient_count,
-                                    cjose_header_t *protected_header,
-                                    cjose_header_t *shared_unprotected_header,
-                                    const uint8_t *plaintext,
-                                    size_t plaintext_len,
-                                    cjose_err *err)
+cjose_jwe_t *cjose_jwe_encrypt(
+    const cjose_jwk_t *jwk, cjose_header_t *protected_header, const uint8_t *plaintext, size_t plaintext_len, cjose_err *err)
+{
+    return cjose_jwe_encrypt_iv(jwk, protected_header, NULL, 0, plaintext, plaintext_len, err);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+cjose_jwe_t *cjose_jwe_encrypt_multi_iv(const cjose_jwe_recipient_t *recipients,
+                                        size_t recipient_count,
+                                        cjose_header_t *protected_header,
+                                        cjose_header_t *shared_unprotected_header,
+                                        const uint8_t *iv,
+                                        size_t iv_len,
+                                        const uint8_t *plaintext,
+                                        size_t plaintext_len,
+                                        cjose_err *err)
 {
     cjose_jwe_t *jwe = NULL;
 
@@ -1645,10 +1659,24 @@ cjose_jwe_t *cjose_jwe_encrypt_multi(const cjose_jwe_recipient_t * recipients,
     }
 
     // build JWE initialization vector
-    if (!jwe->fns.set_iv(jwe, err))
+    if (iv == NULL)
     {
-        cjose_jwe_release(jwe);
-        return NULL;
+        if (!jwe->fns.set_iv(jwe, err))
+        {
+            cjose_jwe_release(jwe);
+            return NULL;
+        }
+    }
+    else
+    {
+        cjose_get_dealloc()(jwe->enc_iv.raw);
+        jwe->enc_iv.raw_len = iv_len;
+        if (!_cjose_jwe_malloc(jwe->enc_iv.raw_len, false, &jwe->enc_iv.raw, err))
+        {
+            cjose_jwe_release(jwe);
+            return NULL;
+        }
+        memcpy(jwe->enc_iv.raw, iv, iv_len);
     }
 
     // build JWE encrypted data and authentication tag
@@ -1661,6 +1689,19 @@ cjose_jwe_t *cjose_jwe_encrypt_multi(const cjose_jwe_recipient_t * recipients,
     _cjose_release_cek(&jwe->cek, jwe->cek_len);
 
     return jwe;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+cjose_jwe_t *cjose_jwe_encrypt_multi(const cjose_jwe_recipient_t *recipients,
+                                     size_t recipient_count,
+                                     cjose_header_t *protected_header,
+                                     cjose_header_t *shared_unprotected_header,
+                                     const uint8_t *plaintext,
+                                     size_t plaintext_len,
+                                     cjose_err *err)
+{
+    return cjose_jwe_encrypt_multi_iv(recipients, recipient_count, protected_header, shared_unprotected_header, NULL, 0, plaintext,
+                                      plaintext_len, err);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -368,6 +368,40 @@ START_TEST(test_cjose_jwe_self_encrypt_self_decrypt_iv)
 }
 END_TEST
 
+static void _encrypt_with_bad_iv_length(const char *alg, const char *enc, const char *key, size_t iv_len)
+{
+    cjose_err err;
+
+    cjose_jwk_t *jwk = cjose_jwk_import(key, strlen(key), &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
+
+    cjose_header_t *hdr = cjose_header_new(&err);
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, alg, &err));
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, enc, &err));
+
+    uint8_t iv[64];
+    ck_assert(iv_len <= sizeof(iv));
+    memset(iv, 0xA5, sizeof(iv));
+
+    cjose_jwe_t *jwe = cjose_jwe_encrypt_iv(jwk, hdr, iv, iv_len, (const uint8_t *)PLAINTEXT, strlen(PLAINTEXT), &err);
+    ck_assert_msg(NULL == jwe, "cjose_jwe_encrypt_iv succeeded with a %lu-byte IV for enc %s", (unsigned long)iv_len, enc);
+    ck_assert_msg(CJOSE_ERR_INVALID_ARG == err.code, "expected CJOSE_ERR_INVALID_ARG, got %d for enc %s", err.code, enc);
+
+    cjose_header_release(hdr);
+    cjose_jwk_release(jwk);
+}
+
+// a caller-supplied IV of the wrong length for the content encryption
+// algorithm must be rejected up front
+START_TEST(test_cjose_jwe_encrypt_iv_bad_length)
+{
+    _encrypt_with_bad_iv_length(CJOSE_HDR_ALG_DIR, CJOSE_HDR_ENC_A256GCM, JWK_OCT_32, 8);
+    _encrypt_with_bad_iv_length(CJOSE_HDR_ALG_DIR, CJOSE_HDR_ENC_A256GCM, JWK_OCT_32, 16);
+    _encrypt_with_bad_iv_length(CJOSE_HDR_ALG_DIR, CJOSE_HDR_ENC_A128CBC_HS256, JWK_OCT_32, 8);
+    _encrypt_with_bad_iv_length(CJOSE_HDR_ALG_DIR, CJOSE_HDR_ENC_A128CBC_HS256, JWK_OCT_32, 12);
+}
+END_TEST
+
 START_TEST(test_cjose_jwe_self_encrypt_self_decrypt_short)
 {
     static const uint8_t plain[] = "Setec Astronomy";
@@ -1731,6 +1765,7 @@ Suite *cjose_jwe_suite(void)
     tcase_add_test(tc_jwe, test_cjose_jwe_node_jose_encrypt_self_decrypt);
     tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt);
     tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt_iv);
+    tcase_add_test(tc_jwe, test_cjose_jwe_encrypt_iv_bad_length);
     tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt_short);
     tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt_empty);
     tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt_large);

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -251,6 +251,123 @@ START_TEST(test_cjose_jwe_self_encrypt_self_decrypt)
 }
 END_TEST
 
+static void _self_encrypt_self_decrypt_with_key_iv(
+    const char *alg, const char *enc, const char *key, size_t iv_len, const uint8_t *plain1, size_t plain1_len)
+{
+    cjose_err err;
+
+    cjose_jwk_t *jwk = cjose_jwk_import(key, strlen(key), &err);
+    ck_assert_msg(NULL != jwk,
+                  "cjose_jwk_import failed: "
+                  "%s, file: %s, function: %s, line: %ld",
+                  err.message, err.file, err.function, err.line);
+
+    // set header for JWE
+    cjose_header_t *hdr = cjose_header_new(&err);
+    ck_assert_msg(cjose_header_set(hdr, CJOSE_HDR_ALG, alg, &err),
+                  "cjose_header_set failed: "
+                  "%s, file: %s, function: %s, line: %ld",
+                  err.message, err.file, err.function, err.line);
+
+    ck_assert_msg(cjose_header_set(hdr, CJOSE_HDR_ENC, enc, &err),
+                  "cjose_header_set failed: "
+                  "%s, file: %s, function: %s, line: %ld",
+                  err.message, err.file, err.function, err.line);
+
+    // generate a random IV
+    uint8_t *iv = (uint8_t *)malloc(iv_len);
+    ck_assert(NULL != iv);
+    ck_assert_msg(RAND_bytes(iv, iv_len) == 1, "RAND_bytes failed");
+
+    // create the JWE with the supplied IV
+    cjose_jwe_t *jwe1 = cjose_jwe_encrypt_iv(jwk, hdr, iv, iv_len, plain1, plain1_len, &err);
+    ck_assert_msg(NULL != jwe1, "cjose_jwe_encrypt_iv failed: %s, file: %s, function: %s, line: %ld", err.message, err.file,
+                  err.function, err.line);
+
+    // the IV must have been used as-is
+    ck_assert_msg(jwe1->enc_iv.raw_len == iv_len && memcmp(jwe1->enc_iv.raw, iv, iv_len) == 0,
+                  "cjose_jwe_encrypt_iv did not use the supplied IV for algo %s, method %s", alg, enc);
+
+    // get the compact serialization of JWE
+    char *compact = cjose_jwe_export(jwe1, &err);
+    ck_assert_msg(NULL != compact, "cjose_jwe_export failed: %s, file: %s, function: %s, line: %ld", err.message, err.file,
+                  err.function, err.line);
+
+    // deserialize the compact representation to a new JWE
+    cjose_jwe_t *jwe2 = cjose_jwe_import(compact, strlen(compact), &err);
+    ck_assert_msg(NULL != jwe2,
+                  "cjose_jwe_import failed for algo %s, method %s: "
+                  "%s, file: %s, function: %s, line: %ld",
+                  alg, enc, err.message, err.file, err.function, err.line);
+
+    // get the decrypted plaintext
+    uint8_t *plain2 = NULL;
+    size_t plain2_len = 0;
+    plain2 = cjose_jwe_decrypt(jwe2, jwk, &plain2_len, &err);
+    ck_assert_msg(NULL != plain2,
+                  "cjose_jwe_decrypt failed: "
+                  "%s, file: %s, function: %s, line: %ld",
+                  err.message, err.file, err.function, err.line);
+
+    // confirm plain2 == plain1
+    ck_assert(json_equal((json_t *)cjose_jwe_get_protected(jwe1), (json_t *)cjose_jwe_get_protected(jwe2)));
+    ck_assert_msg(plain2_len == plain1_len,
+                  "length of decrypted plaintext does not match length of original, "
+                  "expected: %lu, found: %lu",
+                  (unsigned long)plain1_len, (unsigned long)plain2_len);
+    ck_assert_msg(memcmp(plain1, plain2, plain2_len) == 0, "decrypted plaintext does not match encrypted plaintext");
+
+    cjose_get_dealloc()(plain2);
+    cjose_header_release(hdr);
+    free(iv);
+    cjose_jwe_release(jwe1);
+    cjose_jwe_release(jwe2);
+    cjose_jwk_release(jwk);
+    cjose_get_dealloc()(compact);
+}
+
+static void _self_encrypt_self_decrypt_iv(const uint8_t *plain1, size_t plain1_len)
+{
+    _self_encrypt_self_decrypt_with_key_iv(CJOSE_HDR_ALG_RSA_OAEP, CJOSE_HDR_ENC_A256GCM, JWK_RSA, 12, plain1, plain1_len);
+
+    _self_encrypt_self_decrypt_with_key_iv(CJOSE_HDR_ALG_DIR, CJOSE_HDR_ENC_A256GCM, JWK_OCT_32, 12, plain1, plain1_len);
+
+    _self_encrypt_self_decrypt_with_key_iv(CJOSE_HDR_ALG_DIR, CJOSE_HDR_ENC_A128CBC_HS256, JWK_OCT_32, 16, plain1, plain1_len);
+
+    _self_encrypt_self_decrypt_with_key_iv(CJOSE_HDR_ALG_DIR, CJOSE_HDR_ENC_A192CBC_HS384, JWK_OCT_48, 16, plain1, plain1_len);
+
+    _self_encrypt_self_decrypt_with_key_iv(CJOSE_HDR_ALG_DIR, CJOSE_HDR_ENC_A256CBC_HS512, JWK_OCT_64, 16, plain1, plain1_len);
+
+    _self_encrypt_self_decrypt_with_key_iv(CJOSE_HDR_ALG_A128KW, CJOSE_HDR_ENC_A128CBC_HS256, JWK_OCT_16, 16, plain1, plain1_len);
+
+    _self_encrypt_self_decrypt_with_key_iv(CJOSE_HDR_ALG_A192KW, CJOSE_HDR_ENC_A192CBC_HS384, JWK_OCT_24, 16, plain1, plain1_len);
+
+    _self_encrypt_self_decrypt_with_key_iv(CJOSE_HDR_ALG_A256KW, CJOSE_HDR_ENC_A256CBC_HS512, JWK_OCT_32, 16, plain1, plain1_len);
+
+    _self_encrypt_self_decrypt_with_key_iv(CJOSE_HDR_ALG_A128KW, CJOSE_HDR_ENC_A256GCM, JWK_OCT_16, 12, plain1, plain1_len);
+
+    _self_encrypt_self_decrypt_with_key_iv(CJOSE_HDR_ALG_ECDH_ES, CJOSE_HDR_ENC_A256GCM, JWK_EC, 12, plain1, plain1_len);
+}
+
+START_TEST(test_cjose_jwe_self_encrypt_self_decrypt_iv)
+{
+    static const uint8_t plain[]
+        = "Sed ut perspiciatis unde omnis iste natus error sit voluptatem "
+          "doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo "
+          "veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo "
+          "ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed "
+          "consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. "
+          "porro quisquam est, qui dolorem ipsum quia dolor sit amet, "
+          "adipisci velit, sed quia non numquam eius modi tempora incidunt ut "
+          "dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, "
+          "nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut "
+          "ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in "
+          "voluptate velit esse quam nihil molestiae consequatur, vel illum qui "
+          "eum fugiat quo voluptas nulla pariatur?";
+    _self_encrypt_self_decrypt_iv(plain, sizeof(plain) - 1);
+}
+END_TEST
+
 START_TEST(test_cjose_jwe_self_encrypt_self_decrypt_short)
 {
     static const uint8_t plain[] = "Setec Astronomy";
@@ -1613,6 +1730,7 @@ Suite *cjose_jwe_suite(void)
     tcase_set_timeout(tc_jwe, 120.0);
     tcase_add_test(tc_jwe, test_cjose_jwe_node_jose_encrypt_self_decrypt);
     tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt);
+    tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt_iv);
     tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt_short);
     tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt_empty);
     tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt_large);


### PR DESCRIPTION
Step 3 of the plan in #142 (API additions that keep API and ABI compatibility), porting a feature carried in the OpenIDC/cjose `version-0.6.2.x` branch since 2019. Ready for review; per the plan it is meant to merge after the 0.6.x release.

### Changes

- New public functions `cjose_jwe_encrypt_iv()` and `cjose_jwe_encrypt_multi_iv()` that take a caller-supplied initialization vector; `cjose_jwe_encrypt()` and `cjose_jwe_encrypt_multi()` become thin wrappers that pass `NULL` (generate the IV as before). This is #102 by @rnapier, cherry-picked with authorship kept and adapted to current master and to the CMake export lists (`cmake/exports/*`, two additive symbols). It exists so that callers can produce deterministic output for test vectors and interop checks. (OpenIDC/cjose@033d1f0)
- The supplied IV length is validated against the `enc` algorithm (12 octets for AES GCM, 16 for AES CBC HMAC) and rejected with `CJOSE_ERR_INVALID_ARG`; without that check a short buffer is over-read by `EVP_EncryptInit_ex()`. The doc comments spell out the length requirement and the IV-reuse caveat. (OpenIDC/cjose@68705a0)
- Tests: `test_cjose_jwe_self_encrypt_self_decrypt_iv` round-trips every alg/enc combination with a random caller-supplied IV and checks the IV was used verbatim; `test_cjose_jwe_encrypt_iv_bad_length` covers the rejection.
- Doc fix: the `cjose_jwe_encrypt_multi()` comment named the shared header parameter `unprotected_header`; it is `shared_unprotected_header`.

### Compatibility

Additive only: two new exported functions, no change to any existing signature, struct or symbol.

### Testing

Built with CMake (`-pedantic -Wall -Werror`) on Linux with GCC 15, OpenSSL 3.5.5 and Jansson 2.14; `check_cjose` passes; `nm -D` confirms both new symbols are exported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
