### PR TITLE
[step 3] json: compact JWS protected header, stable key order, scalar raw header values

### DIFF
--- a/src/header.c
+++ b/src/header.c
@@ -191,5 +191,5 @@ char *cjose_header_get_raw(cjose_header_t *header, const char *attr, cjose_err *
         return NULL;
     }
 
-    return json_dumps(value_obj, JSON_COMPACT);
+    return json_dumps(value_obj, JSON_COMPACT | JSON_PRESERVE_ORDER);
 }

--- a/src/header.c
+++ b/src/header.c
@@ -156,7 +156,10 @@ bool cjose_header_set_raw(cjose_header_t *header, const char *attr, const char *
     }
 
     json_error_t j_err;
-    json_t *value_obj = json_loads(value, 0, &j_err);
+    // JSON_DECODE_ANY: the documented contract accepts any valid JSON value,
+    // including a top-level scalar (e.g. RFC 7797 "b64":false), which jansson's
+    // default (RFC 4627) mode rejects
+    json_t *value_obj = json_loads(value, JSON_DECODE_ANY, &j_err);
     if (NULL == value_obj)
     {
         // unfortunately, it's not possible to tell whether the error is due
@@ -191,5 +194,7 @@ char *cjose_header_get_raw(cjose_header_t *header, const char *attr, cjose_err *
         return NULL;
     }
 
-    return json_dumps(value_obj, JSON_COMPACT | JSON_PRESERVE_ORDER);
+    // JSON_ENCODE_ANY so a top-level scalar value (see cjose_header_set_raw)
+    // round-trips instead of returning NULL
+    return json_dumps(value_obj, JSON_COMPACT | JSON_PRESERVE_ORDER | JSON_ENCODE_ANY);
 }

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -1812,7 +1812,7 @@ char *cjose_jwe_export_json(cjose_jwe_t *jwe, cjose_err *err)
         }
     }
 
-    char *json_str = json_dumps(form, 0);
+    char *json_str = json_dumps(form, JSON_PRESERVE_ORDER);
     if (NULL == json_str)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);

--- a/src/jws.c
+++ b/src/jws.c
@@ -54,7 +54,7 @@ static bool _cjose_jws_build_hdr(cjose_jws_t *jws, cjose_header_t *header, cjose
     json_incref(jws->hdr);
 
     // base64url encode the header
-    char *hdr_str = json_dumps(jws->hdr, JSON_ENCODE_ANY | JSON_PRESERVE_ORDER);
+    char *hdr_str = json_dumps(jws->hdr, JSON_ENCODE_ANY | JSON_PRESERVE_ORDER | JSON_COMPACT);
     if (NULL == hdr_str)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);

--- a/test/check_header.c
+++ b/test/check_header.c
@@ -103,6 +103,16 @@ START_TEST(test_cjose_header_set_get_raw)
 
     // cjose_header_get_raw returns a json_dumps() result owned by the caller
     cjose_get_dealloc()(epk_get);
+
+    // a top-level scalar JSON value (e.g. RFC 7797 "b64":false) must round-trip;
+    // jansson's default decode mode rejects these, JSON_DECODE_ANY accepts them
+    result = cjose_header_set_raw(header, "b64", "false", &err);
+    ck_assert_msg(result, "cjose_header_set_raw failed to set a scalar (boolean) value");
+
+    char *b64_get = cjose_header_get_raw(header, "b64", &err);
+    ck_assert_msg(NULL != b64_get && !strcmp(b64_get, "false"),
+                  "cjose_header_get_raw failed to round-trip a scalar value, found %s", ((b64_get) ? b64_get : "null"));
+    cjose_get_dealloc()(b64_get);
     cjose_header_release(header);
 }
 END_TEST


### PR DESCRIPTION
Step 3 of the plan in #142 (behaviour-visible changes that keep API and ABI compatibility), porting changes carried in the OpenIDC/cjose `version-0.6.2.x` branch. Ready for review; per the plan it is meant to merge after the 0.6.x release. No function signature, struct or symbol changes; what changes is the bytes produced by the JSON encoders.

### Changes

- `_cjose_jws_build_hdr()`: encode the JWS protected header with `JSON_COMPACT`. jansson's default output inserts a space after every `:` and `,`, which no other JOSE implementation does; the compact form shortens every JWS and matches what interop partners expect. Signatures are computed over the new encoding, so existing verifiers are unaffected. This is the JWS part of #100 by @rnapier, cherry-picked with authorship kept. (OpenIDC/cjose@5eaed94)
- `cjose_jwe_export_json()` and `cjose_header_get_raw()`: pass `JSON_PRESERVE_ORDER` so the emitted JSON keeps insertion order and serializations are comparable. jansson 2.8 and later preserve order unconditionally, so this only matters for older jansson. (OpenIDC/cjose@8342012, OpenIDC/cjose@dfd5835)
- `cjose_header_set_raw()` / `cjose_header_get_raw()`: decode with `JSON_DECODE_ANY` and encode with `JSON_ENCODE_ANY` so that a top-level scalar round-trips. The documented contract is "any valid JSON value", but jansson's default RFC 4627 mode rejected e.g. RFC 7797 `"b64": false` with `CJOSE_ERR_INVALID_ARG`. Test added. (OpenIDC/cjose@a1340b0)

### Testing

Built with CMake (`-pedantic -Wall -Werror`) on Linux with GCC 15, OpenSSL 3.5.5 and Jansson 2.14; `check_cjose` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
