### PR TITLE
autotools: fix out-of-tree builds, add -no-undefined for Cygwin, set ACLOCAL_AMFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,8 @@
 SUBDIRS = . include src test doc platform
 EXTRA_DIST = CHANGELOG.md README.md LICENSE
 
+ACLOCAL_AMFLAGS = -I m4
+
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = cjose.pc
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -380,6 +380,7 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 SUBDIRS = . include src test doc platform
 EXTRA_DIST = CHANGELOG.md README.md LICENSE
+ACLOCAL_AMFLAGS = -I m4
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = cjose.pc
 all: all-recursive

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,7 @@ AM_CFLAGS =-std=gnu99 --pedantic -Wall -Werror -g -O2 -DOPENSSL_API_COMPAT=0x101
 
 lib_LTLIBRARIES=libcjose.la
 libcjose_la_CPPFLAGS= -I$(top_srcdir)/include
-libcjose_la_LDFLAGS= -lm
+libcjose_la_LDFLAGS= -no-undefined -lm
 libcjose_la_SOURCES=version.c \
 					util.c \
 					base64.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 AM_CFLAGS =-std=gnu99 --pedantic -Wall -Werror -g -O2 -DOPENSSL_API_COMPAT=0x10100000L -I$(top_builddir)/include
 
 lib_LTLIBRARIES=libcjose.la
-libcjose_la_CPPFLAGS= -I$(topdir)/include
+libcjose_la_CPPFLAGS= -I$(top_srcdir)/include
 libcjose_la_LDFLAGS= -lm
 libcjose_la_SOURCES=version.c \
 					util.c \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -362,8 +362,8 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AM_CFLAGS = -std=gnu99 --pedantic -Wall -Werror -g -O2 -DOPENSSL_API_COMPAT=0x10100000L -I$(top_builddir)/include
 lib_LTLIBRARIES = libcjose.la
-libcjose_la_CPPFLAGS = -I$(topdir)/include
-libcjose_la_LDFLAGS = -lm
+libcjose_la_CPPFLAGS = -I$(top_srcdir)/include
+libcjose_la_LDFLAGS = -no-undefined -lm
 libcjose_la_SOURCES = version.c \
 					util.c \
 					base64.c \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -7,7 +7,7 @@ TESTS = check_cjose
 
 check_PROGRAMS = $(TESTS)
 check_cjose_CFLAGS = @CHECK_CFLAGS@ -I$(top_builddir)/include \
-                     -I$(top_builddir)/src
+                     -I$(top_builddir)/src -I$(top_srcdir)/src
 check_cjose_LDADD = $(top_builddir)/src/libcjose.la @CHECK_LIBS@
 check_cjose_SOURCES = check_cjose.c \
                       check_version.c \

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -549,7 +549,7 @@ top_srcdir = @top_srcdir@
 @HAVE_CHECK_TRUE@AM_CPPFLAGS = -std=gnu99 --pedantic -Wall -g -O2 \
 @HAVE_CHECK_TRUE@	-I$(top_builddir)/include @CHECK_CFLAGS@
 @HAVE_CHECK_TRUE@check_cjose_CFLAGS = @CHECK_CFLAGS@ -I$(top_builddir)/include \
-@HAVE_CHECK_TRUE@                     -I$(top_builddir)/src
+@HAVE_CHECK_TRUE@                     -I$(top_builddir)/src -I$(top_srcdir)/src
 
 @HAVE_CHECK_TRUE@check_cjose_LDADD = $(top_builddir)/src/libcjose.la @CHECK_LIBS@
 @HAVE_CHECK_TRUE@check_cjose_SOURCES = check_cjose.c \


### PR DESCRIPTION
Build-system fixes carried in the OpenIDC/cjose `version-0.6.2.x` branch; no library code changes, so this belongs with the step 1 series from #142. It only touches the autotools build, which is still shipped next to CMake.

### Changes

- `src/Makefile.am`: `libcjose_la_CPPFLAGS` referenced `$(topdir)`, which automake never defines, so it expanded to `-I/include`. An in-tree build does not notice because `-I$(top_builddir)/include` happens to be the source directory, but with `srcdir != builddir` the tree's own public headers are not on the include path at all: the build fails with "No such file or directory" or, worse, silently compiles against whatever cjose headers are installed system-wide (on my machine that surfaced as `conflicting types for 'cjose_jwk_EC_get_curve'` against an installed copy). Use `$(top_srcdir)`. `test/Makefile.am` likewise gains `-I$(top_srcdir)/src` for the tests' internal-header includes. By Daisuke Fujimura (@fd00). (OpenIDC/cjose@35bcb55)
- `-no-undefined` in `libcjose_la_LDFLAGS`: libtool refuses to build a shared library on Cygwin/MinGW without it; it is a no-op elsewhere. By Daisuke Fujimura (@fd00). (OpenIDC/cjose@32a72df)
- `ACLOCAL_AMFLAGS = -I m4` in `Makefile.am`, matching `AC_CONFIG_MACRO_DIR([m4])` in `configure.ac`. `autoreconf -fi` on master prints `libtoolize: Consider adding '-I m4' to ACLOCAL_AMFLAGS in Makefile.am`; with this it runs clean.
- The tracked `Makefile.in` files carry the same three changes, applied by hand in the automake 1.16 style already used there (as #144 did) rather than regenerating the whole files with a newer automake. `autoreconf -fi` produces the identical lines.

### Testing

On this branch, in-tree `./configure && make && make check` and out-of-tree `mkdir build && cd build && ../configure && make && make check` both pass; on current master the out-of-tree build fails as described above. `autoreconf -fi` on a copy of the branch runs without warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
