### PR TITLE
test: compile against the documented minimum Check version (fixes #91)

### DIFF
--- a/test/check_concatkdf.c
+++ b/test/check_concatkdf.c
@@ -94,7 +94,7 @@ START_TEST(test_cjose_concatkdf_otherinfo_noextra)
     memset(&err, 0, sizeof(cjose_err));
     ck_assert(cjose_concatkdf_create_otherinfo(alg, 256, hdr, &otherinfo, &otherinfoLen, &err));
     actual = otherinfo;
-    ck_assert_uint_eq(otherinfoLen, 23);
+    ck_assert(otherinfoLen == 23);
     ck_assert(_cmp_lendata(&actual, alg, strlen(alg))); // ALG
     ck_assert(_cmp_lendata(&actual, NULL, 0));          // APU
     ck_assert(_cmp_lendata(&actual, NULL, 0));          // APV
@@ -122,7 +122,7 @@ START_TEST(test_cjose_concatkdf_otherinfo_apuapv)
     memset(&err, 0, sizeof(cjose_err));
     ck_assert(cjose_concatkdf_create_otherinfo(alg, 32, hdr, &otherinfo, &otherinfoLen, &err));
     actual = otherinfo;
-    ck_assert_uint_eq(otherinfoLen, 47);
+    ck_assert(otherinfoLen == 47);
     ck_assert(_cmp_lendata(&actual, alg, strlen(alg)));
     ck_assert(_cmp_lendata(&actual, apu, apuLen));
     ck_assert(_cmp_lendata(&actual, apv, apvLen));


### PR DESCRIPTION
Fixes #91.

`test/check_concatkdf.c` uses `ck_assert_uint_eq()` in two places. That macro only exists in Check 0.10.0 and later, while the README, `CMakeLists.txt` and `configure.ac` all declare Check >= 0.9.4 as the minimum, so the test binary fails to link against the documented minimum (the report in #91 was RHEL 7's check 0.9.9). Replace both with a plain `ck_assert(otherinfoLen == N)`, which keeps the declared minimum true.

This is the same two-line change the OpenIDC/cjose fork has carried since 2022 (OpenIDC/cjose@30ef07c, linked from #91), cherry-picked with its original commit. The alternative would be to raise the documented minimum to 0.10.0 in the three places; this seemed the smaller change.

### Testing

Built with CMake (`-pedantic -Wall -Werror`) on Linux with GCC 15, OpenSSL 3.5.5, Jansson 2.14 and Check 0.15.2; `check_cjose` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
