### PR TITLE
Harden RSA-PSS Verification and Add Regression Tests

### DIFF
--- a/src/jws.c
+++ b/src/jws.c
@@ -905,7 +905,7 @@ static bool _cjose_jws_verify_sig_ps(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
 {
     bool retval = false;
     uint8_t *em = NULL;
-    size_t em_len = 0;
+    int em_len = 0;
 
     // ensure jwk is RSA
     if (jwk->kty != CJOSE_JWK_KTY_RSA)
@@ -940,15 +940,20 @@ static bool _cjose_jws_verify_sig_ps(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
 
     // allocate buffer for encoded message
     em_len = RSA_size((RSA *)jwk->keydata);
-    em = (uint8_t *)cjose_get_alloc()(em_len);
+    if (em_len <= 0 || jws->sig_len != (size_t)em_len)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        goto _cjose_jws_verify_sig_ps_cleanup;
+    }
+    em = (uint8_t *)cjose_get_alloc()((size_t)em_len);
     if (NULL == em)
     {
-        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         goto _cjose_jws_verify_sig_ps_cleanup;
     }
 
     // decrypt signature
-    if (RSA_public_decrypt(jws->sig_len, jws->sig, em, (RSA *)jwk->keydata, RSA_NO_PADDING) != em_len)
+    if (RSA_public_decrypt(em_len, jws->sig, em, (RSA *)jwk->keydata, RSA_NO_PADDING) != em_len)
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _cjose_jws_verify_sig_ps_cleanup;

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -453,7 +453,7 @@ START_TEST(test_cjose_jwe_self_encrypt_self_decrypt_many)
     // encrypt and decrypt a whole lot of randomly sized payloads
     for (int i = 0; i < 100; ++i)
     {
-        size_t len = random() % 1024;
+        size_t len = (size_t)(random() % 1024) + 1;
         uint8_t *plain = malloc(len);
         ck_assert_msg(RAND_bytes(plain, len) == 1, "RAND_bytes failed");
         plain[len - 1] = 0;

--- a/test/check_jws.c
+++ b/test/check_jws.c
@@ -63,6 +63,18 @@ static const char *JWS_COMMON
       "whF9FnGng7bmU8qjNPiXCWfQ-n74gopAVzd3KDJ5ai7q66voRc9pCKJVbsaIMHIqcl9OPiMdY5Hz3_PgBalR2632HOdpUlIMvnMOL3EQICvyBwxaYPbhMcCpEc3_"
       "4K-sywOGiCSp9KlaLcRq0knZtAT0ynJszaiOwfR-W18PEFLfGclpeR6e_gop9mq69t36wK7KRUjrQ";
 
+static cjose_alloc_fn_t _jws_saved_alloc = NULL;
+static size_t _jws_fail_alloc_size = 0;
+
+static void *_jws_fail_selected_alloc(size_t size)
+{
+    if (size == _jws_fail_alloc_size)
+    {
+        return NULL;
+    }
+    return _jws_saved_alloc(size);
+}
+
 static const char *_self_get_jwk_by_alg(const char *alg)
 {
     if ((strcmp(alg, CJOSE_HDR_ALG_HS256) == 0) || (strcmp(alg, CJOSE_HDR_ALG_HS384) == 0)
@@ -191,7 +203,7 @@ START_TEST(test_cjose_jws_self_sign_self_verify_many)
     // sign and verify a whole lot of randomly sized payloads
     for (int i = 0; i < 100; ++i)
     {
-        size_t len = random() % 1024;
+        size_t len = (size_t)(random() % 1024) + 1;
         uint8_t *plain = malloc(len);
         ck_assert_msg(RAND_bytes(plain, len) == 1, "RAND_bytes failed");
         plain[len - 1] = 0;
@@ -947,6 +959,62 @@ START_TEST(test_cjose_jws_none)
 }
 END_TEST
 
+START_TEST(test_cjose_jws_verify_ps_sig_bad_length)
+{
+    cjose_err err;
+    cjose_jwk_t *jwk = cjose_jwk_import(JWK_COMMON, strlen(JWK_COMMON), &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
+
+    // Removing two base64url characters shortens this 2048-bit RSA signature
+    // from the required 256 octets to 255 octets.
+    size_t compact_len = strlen(JWS_COMMON) - 2;
+    char *compact = (char *)cjose_get_alloc()(compact_len + 1);
+    ck_assert(NULL != compact);
+    memcpy(compact, JWS_COMMON, compact_len);
+    compact[compact_len] = '\0';
+
+    cjose_jws_t *jws = cjose_jws_import(compact, compact_len, &err);
+    ck_assert_msg(NULL != jws, "cjose_jws_import failed: %s", err.message);
+    ck_assert_int_eq(255, jws->sig_len);
+
+    ck_assert_msg(!cjose_jws_verify(jws, jwk, &err), "cjose_jws_verify accepted a short RSA-PSS signature");
+    ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "expected CJOSE_ERR_INVALID_ARG, got (%i:%s)", err.code, err.message);
+
+    cjose_jws_release(jws);
+    cjose_get_dealloc()(compact);
+    cjose_jwk_release(jwk);
+}
+END_TEST
+
+START_TEST(test_cjose_jws_verify_ps_alloc_failure)
+{
+    cjose_err err;
+    cjose_jwk_t *jwk = cjose_jwk_import(JWK_COMMON, strlen(JWK_COMMON), &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
+
+    cjose_jws_t *jws = cjose_jws_import(JWS_COMMON, strlen(JWS_COMMON), &err);
+    ck_assert_msg(NULL != jws, "cjose_jws_import failed: %s", err.message);
+
+    cjose_alloc_fn_t saved_alloc = cjose_get_alloc();
+    cjose_realloc_fn_t saved_realloc = cjose_get_realloc();
+    cjose_dealloc_fn_t saved_dealloc = cjose_get_dealloc();
+    _jws_saved_alloc = saved_alloc;
+    _jws_fail_alloc_size = jws->sig_len;
+    cjose_set_alloc_funcs(_jws_fail_selected_alloc, saved_realloc, saved_dealloc);
+
+    bool verified = cjose_jws_verify(jws, jwk, &err);
+    cjose_set_alloc_funcs(saved_alloc, saved_realloc, saved_dealloc);
+    _jws_saved_alloc = NULL;
+    _jws_fail_alloc_size = 0;
+
+    ck_assert_msg(!verified, "cjose_jws_verify succeeded when its encoded-message allocation failed");
+    ck_assert_msg(err.code == CJOSE_ERR_NO_MEMORY, "expected CJOSE_ERR_NO_MEMORY, got (%i:%s)", err.code, err.message);
+
+    cjose_jws_release(jws);
+    cjose_jwk_release(jwk);
+}
+END_TEST
+
 // regression: the JWS ECDSA signature must be exactly R || S for the key's
 // curve; _cjose_jws_verify_sig_ec used sig_len / 2 without a length check,
 // so a valid signature with a trailing octet appended still verified
@@ -1062,6 +1130,8 @@ Suite *cjose_jws_suite(void)
     tcase_add_test(tc_jws, test_cjose_jws_import_get_plain_after_verify);
     tcase_add_test(tc_jws, test_cjose_jws_verify_bad_params);
     tcase_add_test(tc_jws, test_cjose_jws_none);
+    tcase_add_test(tc_jws, test_cjose_jws_verify_ps_sig_bad_length);
+    tcase_add_test(tc_jws, test_cjose_jws_verify_ps_alloc_failure);
     tcase_add_test(tc_jws, test_cjose_jws_verify_ec_sig_bad_length);
     suite_add_tcase(suite, tc_jws);
 


### PR DESCRIPTION
- Validate RSA-PSS signature lengths before verification.
- Report allocation failures as `CJOSE_ERR_NO_MEMORY`.
- Prevent zero-length randomized test payloads from causing buffer underflow.
- Add regression tests for malformed `RSA-PSS` signatures and allocation failures.