### PR TITLE
Remove OpenSSL dependencies from public headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,8 +153,6 @@ set(CJOSE_PUBLIC_INCLUDES
     "$<BUILD_INTERFACE:${CJOSE_GENERATED_INCLUDE_DIR}/cjose>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
-set(CJOSE_INSTALL_TARGETS "")
-
 # ---------------------------------------------------------------------------
 # Static library
 # ---------------------------------------------------------------------------
@@ -171,7 +169,6 @@ if(CJOSE_BUILD_STATIC)
         set_target_properties(cjose_static PROPERTIES OUTPUT_NAME cjose)
     endif()
 
-    list(APPEND CJOSE_INSTALL_TARGETS cjose_static)
 endif()
 
 # ---------------------------------------------------------------------------
@@ -183,7 +180,7 @@ if(CJOSE_BUILD_SHARED)
     add_library(cjose::cjose ALIAS cjose_shared)
 
     target_include_directories(cjose_shared PUBLIC ${CJOSE_PUBLIC_INCLUDES})
-    target_link_libraries(cjose_shared PUBLIC OpenSSL::Crypto Jansson::Jansson ${CJOSE_PLATFORM_LIBRARIES})
+    target_link_libraries(cjose_shared PRIVATE OpenSSL::Crypto Jansson::Jansson ${CJOSE_PLATFORM_LIBRARIES})
 
     set_target_properties(cjose_shared PROPERTIES
         OUTPUT_NAME cjose
@@ -243,7 +240,6 @@ if(CJOSE_BUILD_SHARED)
             MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${PROJECT_VERSION})
     endif()
 
-    list(APPEND CJOSE_INSTALL_TARGETS cjose_shared)
 elseif(CJOSE_BUILD_STATIC)
     add_library(cjose::cjose ALIAS cjose_static)
 endif()
@@ -251,13 +247,21 @@ endif()
 # ---------------------------------------------------------------------------
 # Installation
 # ---------------------------------------------------------------------------
-install(TARGETS ${CJOSE_INSTALL_TARGETS}
-    EXPORT cjoseTargets
-    RUNTIME   DESTINATION "${CMAKE_INSTALL_BINDIR}"
-    LIBRARY   DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    ARCHIVE   DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    FRAMEWORK DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    INCLUDES  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+if(CJOSE_BUILD_SHARED)
+    install(TARGETS cjose_shared
+        EXPORT cjoseSharedTargets
+        RUNTIME   DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        LIBRARY   DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        FRAMEWORK DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        INCLUDES  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+endif()
+
+if(CJOSE_BUILD_STATIC)
+    install(TARGETS cjose_static
+        EXPORT cjoseStaticTargets
+        ARCHIVE  DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+endif()
 
 # Install the public headers (a framework also bundles its own copy).
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/cjose"
@@ -298,9 +302,19 @@ install(FILES
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindJansson.cmake"
     DESTINATION "${CJOSE_INSTALL_CMAKEDIR}")
 
-install(EXPORT cjoseTargets
-    NAMESPACE cjose::
-    DESTINATION "${CJOSE_INSTALL_CMAKEDIR}")
+if(CJOSE_BUILD_SHARED)
+    install(EXPORT cjoseSharedTargets
+        FILE cjoseSharedTargets.cmake
+        NAMESPACE cjose::
+        DESTINATION "${CJOSE_INSTALL_CMAKEDIR}")
+endif()
+
+if(CJOSE_BUILD_STATIC)
+    install(EXPORT cjoseStaticTargets
+        FILE cjoseStaticTargets.cmake
+        NAMESPACE cjose::
+        DESTINATION "${CJOSE_INSTALL_CMAKEDIR}")
+endif()
 
 # ---------------------------------------------------------------------------
 # Unit tests

--- a/README.md
+++ b/README.md
@@ -93,8 +93,15 @@ After installing, consume cjose from a CMake project via `find_package`:
 
 The `cjose::cjose` target aliases the shared/dynamic library when it is built,
 or the static library when `CJOSE_BUILD_SHARED=OFF`. The explicit
-`cjose::cjose_shared` and `cjose::cjose_static` targets are also available when
-their corresponding library types are built.
+`cjose::cjose_shared` target is also available when that library type is built.
+Using the shared library does not require the OpenSSL or Jansson development
+packages on the consuming system.
+
+Static consumers need cjose's private dependencies and can request them and the
+explicit static target with:
+
+    find_package(cjose REQUIRED COMPONENTS static)
+    target_link_libraries(myapp PRIVATE cjose::cjose_static)
 
 Alternatively, embed the sources directly with `add_subdirectory()` or
 `FetchContent`; the same CMake targets are provided.

--- a/cjose.pc.in
+++ b/cjose.pc.in
@@ -11,6 +11,6 @@ Name: cjose
 URL: https://github.com/cisco/cjose
 Description: JOSE implementation for C
 Version: @VERSION@
-Requires: jansson >= 2.3, libcrypto >= 1.0.1
 Cflags: -I${includedir}
 Libs: -L${libdir} -lcjose
+Libs.private: @LIBS@

--- a/cmake/cjose.pc.in
+++ b/cmake/cjose.pc.in
@@ -7,6 +7,6 @@ Name: cjose
 URL: https://github.com/cisco/cjose
 Description: JOSE implementation for C
 Version: @PROJECT_VERSION@
-Requires: jansson >= 2.3, libcrypto >= 1.0.1
 Cflags: -I${includedir}
 Libs: -L${libdir} -lcjose
+Libs.private: -ljansson -lcrypto

--- a/cmake/cjoseConfig.cmake.in
+++ b/cmake/cjoseConfig.cmake.in
@@ -2,13 +2,45 @@
 
 include(CMakeFindDependencyMacro)
 
-# Make the bundled FindJansson module available to consumers.
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+# The shared library's implementation dependencies are deliberately absent
+# from its consumer interface. Load it before considering the static library
+# so shared-library consumers do not need development packages for cjose's
+# private dependencies.
+set(cjose_shared_FOUND FALSE)
+set(cjose_static_FOUND FALSE)
 
-find_dependency(OpenSSL 1.0.1)
-find_dependency(Jansson 2.3)
+if(@CJOSE_BUILD_SHARED@)
+    include("${CMAKE_CURRENT_LIST_DIR}/cjoseSharedTargets.cmake")
+    set(cjose_shared_FOUND TRUE)
+endif()
 
-include("${CMAKE_CURRENT_LIST_DIR}/cjoseTargets.cmake")
+if(@CJOSE_BUILD_STATIC@)
+    # Static consumers must link cjose's implementation dependencies. Make
+    # those dependencies mandatory only when static is the sole installed
+    # variant or the caller explicitly requests the static component.
+    set(_cjose_require_static FALSE)
+    if(NOT @CJOSE_BUILD_SHARED@ OR "static" IN_LIST cjose_FIND_COMPONENTS)
+        set(_cjose_require_static TRUE)
+    endif()
+
+    # Make the bundled FindJansson module available while resolving the
+    # optional/required static target dependencies.
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+    if(_cjose_require_static)
+        find_dependency(OpenSSL 1.0.1)
+        find_dependency(Jansson 2.3)
+    else()
+        find_package(OpenSSL 1.0.1 QUIET)
+        find_package(Jansson 2.3 QUIET)
+    endif()
+
+    if(TARGET OpenSSL::Crypto AND TARGET Jansson::Jansson)
+        include("${CMAKE_CURRENT_LIST_DIR}/cjoseStaticTargets.cmake")
+        set(cjose_static_FOUND TRUE)
+    endif()
+
+    unset(_cjose_require_static)
+endif()
 
 if(TARGET cjose::cjose_shared)
     add_library(cjose::cjose ALIAS cjose::cjose_shared)

--- a/include/cjose/jwk.h
+++ b/include/cjose/jwk.h
@@ -17,7 +17,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
-#include <openssl/obj_mac.h>
 #include "cjose/error.h"
 #include "cjose/header.h"
 
@@ -215,12 +214,17 @@ cjose_jwk_t *cjose_jwk_create_RSA_spec(const cjose_jwk_rsa_keyspec *spec, cjose_
 /** Enumeration of supported Elliptic-Curve types */
 typedef enum
 {
-    /** NIST P-256 Prime Curve (secp256r1) */
-    CJOSE_JWK_EC_P_256 = NID_X9_62_prime256v1,
-    /** NIST P-384 Prime Curve (secp384r1) */
-    CJOSE_JWK_EC_P_384 = NID_secp384r1,
-    /** NIST P-521 Prime Curve (secp521r1) */
-    CJOSE_JWK_EC_P_521 = NID_secp521r1,
+    /** NIST P-256 Prime Curve (secp256r1).
+     *
+     * The explicit value preserves the ABI of earlier cjose releases without
+     * requiring OpenSSL's obj_mac.h in this public header.
+     * TODO: Remove this binary compatibility when moved to 1.0.x series.
+     */
+    CJOSE_JWK_EC_P_256 = 415,
+    /** NIST P-384 Prime Curve (secp384r1). */
+    CJOSE_JWK_EC_P_384 = 715,
+    /** NIST P-521 Prime Curve (secp521r1). */
+    CJOSE_JWK_EC_P_521 = 716,
     /** Invalid Curve */
     CJOSE_JWK_EC_INVALID = -1
 } cjose_jwk_ec_curve;

--- a/include/cjose/util.h
+++ b/include/cjose/util.h
@@ -18,14 +18,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include <openssl/rsa.h>
-
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#if OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)
-#define CJOSE_OPENSSL_11X
 #endif
 
 /**

--- a/src/include/util_int.h
+++ b/src/include/util_int.h
@@ -11,7 +11,12 @@
 #include <cjose/error.h>
 
 #include <jansson.h>
+#include <openssl/opensslv.h>
 #include <string.h>
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)
+#define CJOSE_OPENSSL_11X
+#endif
 
 #ifdef _WIN32
 #include <BaseTsd.h>

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -565,6 +565,23 @@ static bool _EC_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *
 
 static const key_fntable EC_FNTABLE = { _EC_free, _EC_public_fields, _EC_private_fields };
 
+static inline int _ec_nid_for_curve(cjose_jwk_ec_curve crv)
+{
+    switch (crv)
+    {
+    case CJOSE_JWK_EC_P_256:
+        return NID_X9_62_prime256v1;
+    case CJOSE_JWK_EC_P_384:
+        return NID_secp384r1;
+    case CJOSE_JWK_EC_P_521:
+        return NID_secp521r1;
+    case CJOSE_JWK_EC_INVALID:
+        return NID_undef;
+    }
+
+    return NID_undef;
+}
+
 static inline uint8_t _ec_size_for_curve(cjose_jwk_ec_curve crv, cjose_err *err)
 {
     switch (crv)
@@ -880,7 +897,7 @@ cjose_jwk_t *cjose_jwk_create_EC_random(cjose_jwk_ec_curve crv, cjose_err *err)
     cjose_jwk_t *jwk = NULL;
     EC_KEY *ec = NULL;
 
-    ec = EC_KEY_new_by_curve_name(crv);
+    ec = EC_KEY_new_by_curve_name(_ec_nid_for_curve(crv));
     if (!ec)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -940,7 +957,7 @@ cjose_jwk_t *cjose_jwk_create_EC_spec(const cjose_jwk_ec_keyspec *spec, cjose_er
         return NULL;
     }
 
-    ec = EC_KEY_new_by_curve_name(spec->crv);
+    ec = EC_KEY_new_by_curve_name(_ec_nid_for_curve(spec->crv));
     if (NULL == ec)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);


### PR DESCRIPTION
Removes OpenSSL includes from cjose’s public headers so shared-library consumers no longer need the OpenSSL development package.
- Preserves existing EC curve enum values for ABI compatibility.
- Moves OpenSSL version handling behind private headers.
- Keeps OpenSSL and Jansson dependencies private for shared CMake and pkg-config consumers.
- Retains transitive dependencies for static linking.
- Updates both CMake and legacy Autoconf packaging.