### PR TITLE
Add ES256K and secp256k1 support

### DIFF
--- a/include/cjose/header.h
+++ b/include/cjose/header.h
@@ -79,8 +79,9 @@ extern "C" {
 #define CJOSE_HDR_ALG_HS384 "HS384"
 #define CJOSE_HDR_ALG_HS512 "HS512"
 
-/** The JWS algorithm attribute values for ES256, ES384 and ES512. */
+/** The JWS algorithm attribute values for ES256, ES256K, ES384 and ES512. */
 #define CJOSE_HDR_ALG_ES256 "ES256"
+#define CJOSE_HDR_ALG_ES256K "ES256K"
 #define CJOSE_HDR_ALG_ES384 "ES384"
 #define CJOSE_HDR_ALG_ES512 "ES512"
 

--- a/include/cjose/jwk.h
+++ b/include/cjose/jwk.h
@@ -221,6 +221,8 @@ typedef enum
      * TODO: Remove this binary compatibility when moved to 1.0.x series.
      */
     CJOSE_JWK_EC_P_256 = 415,
+    /** SECG secp256k1 curve. */
+    CJOSE_JWK_EC_SECP_256K1 = 714,
     /** NIST P-384 Prime Curve (secp384r1). */
     CJOSE_JWK_EC_P_384 = 715,
     /** NIST P-521 Prime Curve (secp521r1). */

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -27,6 +27,7 @@
 // internal data structures
 
 static const char CJOSE_JWK_EC_P_256_STR[] = "P-256";
+static const char CJOSE_JWK_EC_SECP_256K1_STR[] = "secp256k1";
 static const char CJOSE_JWK_EC_P_384_STR[] = "P-384";
 static const char CJOSE_JWK_EC_P_521_STR[] = "P-521";
 static const char CJOSE_JWK_KTY_STR[] = "kty";
@@ -571,6 +572,8 @@ static inline int _ec_nid_for_curve(cjose_jwk_ec_curve crv)
     {
     case CJOSE_JWK_EC_P_256:
         return NID_X9_62_prime256v1;
+    case CJOSE_JWK_EC_SECP_256K1:
+        return NID_secp256k1;
     case CJOSE_JWK_EC_P_384:
         return NID_secp384r1;
     case CJOSE_JWK_EC_P_521:
@@ -587,6 +590,8 @@ static inline uint8_t _ec_size_for_curve(cjose_jwk_ec_curve crv, cjose_err *err)
     switch (crv)
     {
     case CJOSE_JWK_EC_P_256:
+        return 32;
+    case CJOSE_JWK_EC_SECP_256K1:
         return 32;
     case CJOSE_JWK_EC_P_384:
         return 48;
@@ -605,6 +610,8 @@ static inline const char *_ec_name_for_curve(cjose_jwk_ec_curve crv, cjose_err *
     {
     case CJOSE_JWK_EC_P_256:
         return CJOSE_JWK_EC_P_256_STR;
+    case CJOSE_JWK_EC_SECP_256K1:
+        return CJOSE_JWK_EC_SECP_256K1_STR;
     case CJOSE_JWK_EC_P_384:
         return CJOSE_JWK_EC_P_384_STR;
     case CJOSE_JWK_EC_P_521:
@@ -622,6 +629,10 @@ static inline bool _ec_curve_from_name(const char *name, cjose_jwk_ec_curve *crv
     if (strncmp(name, CJOSE_JWK_EC_P_256_STR, sizeof(CJOSE_JWK_EC_P_256_STR)) == 0)
     {
         *crv = CJOSE_JWK_EC_P_256;
+    }
+    else if (strncmp(name, CJOSE_JWK_EC_SECP_256K1_STR, sizeof(CJOSE_JWK_EC_SECP_256K1_STR)) == 0)
+    {
+        *crv = CJOSE_JWK_EC_SECP_256K1;
     }
     else if (strncmp(name, CJOSE_JWK_EC_P_384_STR, sizeof(CJOSE_JWK_EC_P_384_STR)) == 0)
     {
@@ -684,6 +695,9 @@ static cjose_jwk_t *_EC_new(cjose_jwk_ec_curve crv, EC_KEY *ec, cjose_err *err)
     switch (crv)
     {
     case CJOSE_JWK_EC_P_256:
+        jwk->keysize = 256;
+        break;
+    case CJOSE_JWK_EC_SECP_256K1:
         jwk->keysize = 256;
         break;
     case CJOSE_JWK_EC_P_384:

--- a/src/jws.c
+++ b/src/jws.c
@@ -44,6 +44,8 @@ static bool _cjose_jws_build_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, cj
 
 static bool _cjose_jws_verify_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err);
 
+static bool _cjose_jws_validate_ec_key(const char *alg, const cjose_jwk_t *jwk, cjose_err *err);
+
 static bool _cjose_jws_validate_verify_key(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -111,8 +113,8 @@ static bool _cjose_jws_validate_hdr(cjose_jws_t *jws, cjose_err *err)
         jws->fns.sign = _cjose_jws_build_sig_hmac_sha;
         jws->fns.verify = _cjose_jws_verify_sig_hmac_sha;
     }
-    else if ((strcmp(alg, CJOSE_HDR_ALG_ES256) == 0) || (strcmp(alg, CJOSE_HDR_ALG_ES384) == 0)
-             || (strcmp(alg, CJOSE_HDR_ALG_ES512) == 0))
+    else if ((strcmp(alg, CJOSE_HDR_ALG_ES256) == 0) || (strcmp(alg, CJOSE_HDR_ALG_ES256K) == 0)
+             || (strcmp(alg, CJOSE_HDR_ALG_ES384) == 0) || (strcmp(alg, CJOSE_HDR_ALG_ES512) == 0))
     {
         jws->fns.digest = _cjose_jws_build_dig_sha;
         jws->fns.sign = _cjose_jws_build_sig_ec;
@@ -167,7 +169,7 @@ static bool _cjose_jws_build_dig_sha(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
     // build digest using SHA-256/384/512 digest algorithm
     const EVP_MD *digest_alg = NULL;
     if ((strcmp(alg, CJOSE_HDR_ALG_RS256) == 0) || (strcmp(alg, CJOSE_HDR_ALG_PS256) == 0)
-        || (strcmp(alg, CJOSE_HDR_ALG_ES256) == 0))
+        || (strcmp(alg, CJOSE_HDR_ALG_ES256) == 0) || (strcmp(alg, CJOSE_HDR_ALG_ES256K) == 0))
         digest_alg = EVP_sha256();
     else if ((strcmp(alg, CJOSE_HDR_ALG_RS384) == 0) || (strcmp(alg, CJOSE_HDR_ALG_PS384) == 0)
              || (strcmp(alg, CJOSE_HDR_ALG_ES384) == 0))
@@ -551,10 +553,9 @@ static bool _cjose_jws_build_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, cj
 {
     bool retval = false;
 
-    // ensure jwk is EC
-    if (jwk->kty != CJOSE_JWK_KTY_EC)
+    const char *alg = json_string_value(json_object_get(jws->hdr, CJOSE_HDR_ALG));
+    if (!_cjose_jws_validate_ec_key(alg, jwk, err))
     {
-        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return false;
     }
 
@@ -572,6 +573,9 @@ static bool _cjose_jws_build_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, cj
     switch (keydata->crv)
     {
     case CJOSE_JWK_EC_P_256:
+        jws->sig_len = 32 * 2;
+        break;
+    case CJOSE_JWK_EC_SECP_256K1:
         jws->sig_len = 32 * 2;
         break;
     case CJOSE_JWK_EC_P_384:
@@ -1082,6 +1086,9 @@ static bool _cjose_jws_verify_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
     case CJOSE_JWK_EC_P_256:
         coordlen = 32;
         break;
+    case CJOSE_JWK_EC_SECP_256K1:
+        coordlen = 32;
+        break;
     case CJOSE_JWK_EC_P_384:
         coordlen = 48;
         break;
@@ -1141,6 +1148,28 @@ _cjose_jws_verify_sig_ec_cleanup:
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+static bool _cjose_jws_validate_ec_key(const char *alg, const cjose_jwk_t *jwk, cjose_err *err)
+{
+    if (jwk->kty != CJOSE_JWK_KTY_EC)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
+    ec_keydata *keydata = (ec_keydata *)jwk->keydata;
+
+    // RFC 8812 requires secp256k1 keys to be used only with ES256K and
+    // requires ES256K to use a secp256k1 key.
+    if ((strcmp(alg, CJOSE_HDR_ALG_ES256K) == 0) != (keydata->crv == CJOSE_JWK_EC_SECP_256K1))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 static bool _cjose_jws_validate_verify_key(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err)
 {
     json_t *alg_obj = json_object_get(jws->hdr, CJOSE_HDR_ALG);
@@ -1174,12 +1203,13 @@ static bool _cjose_jws_validate_verify_key(cjose_jws_t *jws, const cjose_jwk_t *
         return false;
     }
 
-    if (((0 == strcmp(alg, CJOSE_HDR_ALG_ES256)) || (0 == strcmp(alg, CJOSE_HDR_ALG_ES384))
-         || (0 == strcmp(alg, CJOSE_HDR_ALG_ES512)))
-        && jwk->kty != CJOSE_JWK_KTY_EC)
+    if ((0 == strcmp(alg, CJOSE_HDR_ALG_ES256)) || (0 == strcmp(alg, CJOSE_HDR_ALG_ES256K))
+        || (0 == strcmp(alg, CJOSE_HDR_ALG_ES384)) || (0 == strcmp(alg, CJOSE_HDR_ALG_ES512)))
     {
-        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-        return false;
+        if (!_cjose_jws_validate_ec_key(alg, jwk, err))
+        {
+            return false;
+        }
     }
 
     return true;

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -244,6 +244,62 @@ START_TEST(test_cjose_jwk_create_EC_P256_random)
 }
 END_TEST
 
+const char *EC_SECP_256K1_d = "rhYFsBPF9q3-uZThy7B3c4LDF_8wnozFUAEm5LLC4Zw";
+const char *EC_SECP_256K1_x = "dWCvM4fTdeM0KmloF57zxtBPXTOythHPMm1HCLrdd3A";
+const char *EC_SECP_256K1_y = "36uMVGM7hnw-N6GnjFcihWE3SkrhMLzzLCdPMXPEXlA";
+START_TEST(test_cjose_jwk_create_EC_secp256k1_spec)
+{
+    cjose_err err;
+    cjose_jwk_t *jwk = NULL;
+    cjose_jwk_ec_keyspec spec;
+
+    memset(&spec, 0, sizeof(cjose_jwk_ec_keyspec));
+    spec.crv = CJOSE_JWK_EC_SECP_256K1;
+    cjose_base64url_decode(EC_SECP_256K1_d, strlen(EC_SECP_256K1_d), &spec.d, &spec.dlen, &err);
+    cjose_base64url_decode(EC_SECP_256K1_x, strlen(EC_SECP_256K1_x), &spec.x, &spec.xlen, &err);
+    cjose_base64url_decode(EC_SECP_256K1_y, strlen(EC_SECP_256K1_y), &spec.y, &spec.ylen, &err);
+
+    jwk = cjose_jwk_create_EC_spec(&spec, &err);
+    ck_assert(NULL != jwk);
+    ck_assert(1 == jwk->retained);
+    ck_assert(CJOSE_JWK_KTY_EC == jwk->kty);
+    ck_assert(256 == jwk->keysize);
+    ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
+    ck_assert(NULL != jwk->keydata);
+    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+    ck_assert(CJOSE_JWK_EC_SECP_256K1 == cjose_jwk_EC_get_curve(jwk, &err));
+
+    char *json = cjose_jwk_to_json(jwk, true, &err);
+    ck_assert(NULL != json);
+    ck_assert(NULL != strstr(json, "\"crv\":\"secp256k1\""));
+
+    cjose_get_dealloc()(json);
+    cjose_get_dealloc()(spec.d);
+    cjose_get_dealloc()(spec.x);
+    cjose_get_dealloc()(spec.y);
+    cjose_jwk_release(jwk);
+}
+END_TEST
+
+START_TEST(test_cjose_jwk_create_EC_secp256k1_random)
+{
+    cjose_err err;
+    cjose_jwk_t *jwk = cjose_jwk_create_EC_random(CJOSE_JWK_EC_SECP_256K1, &err);
+
+    ck_assert(NULL != jwk);
+    ck_assert(CJOSE_JWK_KTY_EC == jwk->kty);
+    ck_assert(256 == cjose_jwk_get_keysize(jwk, &err));
+    ck_assert(CJOSE_JWK_EC_SECP_256K1 == cjose_jwk_EC_get_curve(jwk, &err));
+
+    char *json = cjose_jwk_to_json(jwk, true, &err);
+    ck_assert(NULL != json);
+    ck_assert(NULL != strstr(json, "\"crv\":\"secp256k1\""));
+
+    cjose_get_dealloc()(json);
+    cjose_jwk_release(jwk);
+}
+END_TEST
+
 const char *EC_384_d = "vpwFfxYfV7Ftm3fuidQsK-l_tGxqqnUUG6R5QZStJAeZy7qQiHAo7rZumFslws38";
 const char *EC_384_x = "ulIwcMpG6gbi9Bo_CeVFDIu7RT-AFxu5NRiH9Wm39lYQOAcZTlHJM8Tz4Fwbtu-0";
 const char *EC_384_y = "WOZtl6a6x_ukWquJbd_sF18zivwVq26HhJbnmwEKuab7zvZ3sGzOX7LJCHl4zmXa";
@@ -1526,6 +1582,8 @@ Suite *cjose_jwk_suite(void)
     tcase_add_test(tc_jwk, test_cjose_jwk_create_RSA_spec_weak_modulus);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_P256_spec);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_P256_random);
+    tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_secp256k1_spec);
+    tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_secp256k1_random);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_P384_spec);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_P384_random);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_P521_spec);

--- a/test/check_jws.c
+++ b/test/check_jws.c
@@ -54,6 +54,12 @@ static const char *JWK_COMMON_EC = "{ \"kty\":\"EC\","
                                    "\"y\":\"KbkZ7r_DQ-t67pnxPnFDHObTLBqn44BSjcqn0STUkaM\","
                                    "\"d\":\"RSSjcBQW_EBxm1gzYhejCdWtj3Id_GuwldwEgSuKCEM\" }";
 
+static const char *JWK_COMMON_EC_SECP_256K1 = "{ \"kty\":\"EC\","
+                                              "\"crv\":\"secp256k1\","
+                                              "\"x\":\"dWCvM4fTdeM0KmloF57zxtBPXTOythHPMm1HCLrdd3A\","
+                                              "\"y\":\"36uMVGM7hnw-N6GnjFcihWE3SkrhMLzzLCdPMXPEXlA\","
+                                              "\"d\":\"rhYFsBPF9q3-uZThy7B3c4LDF_8wnozFUAEm5LLC4Zw\" }";
+
 // a JWS encrypted with the above JWK_COMMON key
 static const char *JWS_COMMON
     = "eyAiYWxnIjogIlBTMjU2IiB9."
@@ -80,6 +86,8 @@ static const char *_self_get_jwk_by_alg(const char *alg)
     if ((strcmp(alg, CJOSE_HDR_ALG_HS256) == 0) || (strcmp(alg, CJOSE_HDR_ALG_HS384) == 0)
         || (strcmp(alg, CJOSE_HDR_ALG_HS512) == 0))
         return JWK_COMMON_OCT;
+    if (strcmp(alg, CJOSE_HDR_ALG_ES256K) == 0)
+        return JWK_COMMON_EC_SECP_256K1;
     if ((strcmp(alg, CJOSE_HDR_ALG_ES256) == 0) || (strcmp(alg, CJOSE_HDR_ALG_ES384) == 0)
         || (strcmp(alg, CJOSE_HDR_ALG_ES512) == 0))
         return JWK_COMMON_EC;
@@ -167,6 +175,7 @@ static void _self_sign_self_verify_all_algs(const uint8_t *plain, size_t plain_l
     _self_sign_self_verify(plain, plain_len, CJOSE_HDR_ALG_HS384, err);
     _self_sign_self_verify(plain, plain_len, CJOSE_HDR_ALG_HS512, err);
     _self_sign_self_verify(plain, plain_len, CJOSE_HDR_ALG_ES256, err);
+    _self_sign_self_verify(plain, plain_len, CJOSE_HDR_ALG_ES256K, err);
     _self_sign_self_verify(plain, plain_len, CJOSE_HDR_ALG_ES384, err);
     _self_sign_self_verify(plain, plain_len, CJOSE_HDR_ALG_ES512, err);
 }
@@ -177,6 +186,71 @@ START_TEST(test_cjose_jws_self_sign_self_verify)
     static const uint8_t plain[] = "If you reveal your secrets to the wind, you should not blame the "
                                    "wind for revealing them to the trees. — Kahlil Gibran";
     _self_sign_self_verify_all_algs(plain, sizeof(plain) - 1, &err);
+}
+END_TEST
+
+START_TEST(test_cjose_jws_verify_es256k)
+{
+    cjose_err err;
+    static const char *JWK = "{ \"kty\":\"EC\","
+                             "\"crv\":\"secp256k1\","
+                             "\"x\":\"dWCvM4fTdeM0KmloF57zxtBPXTOythHPMm1HCLrdd3A\","
+                             "\"y\":\"36uMVGM7hnw-N6GnjFcihWE3SkrhMLzzLCdPMXPEXlA\" }";
+    static const char *JWS = "eyJhbGciOiJFUzI1NksifQ."
+                             "RVMyNTZLIGludGVyb3BlcmFiaWxpdHkgdGVzdA."
+                             "AUxIItkz7WGblbT8WkRzeCTD_k30iOdSVPqEMBUC2qC8BxbrPVTzubweSB2lv27Dsf554vVSrqcwNfE4DHmfPA";
+
+    cjose_jwk_t *jwk = cjose_jwk_import(JWK, strlen(JWK), &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
+    ck_assert(CJOSE_JWK_EC_SECP_256K1 == cjose_jwk_EC_get_curve(jwk, &err));
+
+    cjose_jws_t *jws = cjose_jws_import(JWS, strlen(JWS), &err);
+    ck_assert_msg(NULL != jws, "cjose_jws_import failed: %s", err.message);
+    ck_assert_msg(cjose_jws_verify(jws, jwk, &err), "cjose_jws_verify failed: %s", err.message);
+
+    uint8_t *plaintext = NULL;
+    size_t plaintext_len = 0;
+    ck_assert(cjose_jws_get_plaintext(jws, &plaintext, &plaintext_len, &err));
+    ck_assert_int_eq(strlen("ES256K interoperability test"), plaintext_len);
+    ck_assert(0 == memcmp("ES256K interoperability test", plaintext, plaintext_len));
+
+    cjose_jws_release(jws);
+    cjose_jwk_release(jwk);
+}
+END_TEST
+
+START_TEST(test_cjose_jws_es256k_rejects_wrong_curve)
+{
+    cjose_err err;
+    static const char *JWS = "eyJhbGciOiJFUzI1NksifQ."
+                             "RVMyNTZLIGludGVyb3BlcmFiaWxpdHkgdGVzdA."
+                             "AUxIItkz7WGblbT8WkRzeCTD_k30iOdSVPqEMBUC2qC8BxbrPVTzubweSB2lv27Dsf554vVSrqcwNfE4DHmfPA";
+    cjose_jwk_t *p256 = cjose_jwk_import(JWK_COMMON_EC, strlen(JWK_COMMON_EC), &err);
+    cjose_jwk_t *secp256k1 = cjose_jwk_import(JWK_COMMON_EC_SECP_256K1, strlen(JWK_COMMON_EC_SECP_256K1), &err);
+    ck_assert(NULL != p256);
+    ck_assert(NULL != secp256k1);
+
+    cjose_header_t *header = cjose_header_new(&err);
+    ck_assert(NULL != header);
+    ck_assert(cjose_header_set(header, CJOSE_HDR_ALG, CJOSE_HDR_ALG_ES256K, &err));
+    cjose_jws_t *jws = cjose_jws_sign(p256, header, (const uint8_t *)"test", 4, &err);
+    ck_assert(NULL == jws);
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+
+    ck_assert(cjose_header_set(header, CJOSE_HDR_ALG, CJOSE_HDR_ALG_ES256, &err));
+    jws = cjose_jws_sign(secp256k1, header, (const uint8_t *)"test", 4, &err);
+    ck_assert(NULL == jws);
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+
+    jws = cjose_jws_import(JWS, strlen(JWS), &err);
+    ck_assert(NULL != jws);
+    ck_assert(!cjose_jws_verify(jws, p256, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+
+    cjose_header_release(header);
+    cjose_jws_release(jws);
+    cjose_jwk_release(secp256k1);
+    cjose_jwk_release(p256);
 }
 END_TEST
 
@@ -1121,6 +1195,8 @@ Suite *cjose_jws_suite(void)
     tcase_add_test(tc_jws, test_cjose_jws_verify_rs256);
     tcase_add_test(tc_jws, test_cjose_jws_verify_rs384);
     tcase_add_test(tc_jws, test_cjose_jws_verify_ec256);
+    tcase_add_test(tc_jws, test_cjose_jws_verify_es256k);
+    tcase_add_test(tc_jws, test_cjose_jws_es256k_rejects_wrong_curve);
     tcase_add_test(tc_jws, test_cjose_jws_sign_with_bad_header);
     tcase_add_test(tc_jws, test_cjose_jws_sign_with_bad_key);
     tcase_add_test(tc_jws, test_cjose_jws_sign_with_bad_content);


### PR DESCRIPTION
## Summary
Fixes #106

Adds support for the ES256K JWS algorithm and the secp256k1 elliptic curve.

The implementation follows RFC 8812:

- Adds the `CJOSE_HDR_ALG_ES256K` algorithm constant.
- Adds the `CJOSE_JWK_EC_SECP_256K1` curve enum.
- Supports secp256k1 JWK generation, import, and export.
- Supports ES256K signing and verification using ECDSA with SHA-256.
- Produces and validates the required 64-byte `R || S` signature format.
- Rejects ES256K with non-secp256k1 keys.
- Rejects secp256k1 keys used with other ECDSA algorithm identifiers.

## Testing

Added coverage for:

- secp256k1 key creation from explicit key material.
- Random secp256k1 key generation.
- JWK import and export.
- ES256K sign/verify round trips.
- Verification of an independently generated ES256K JWS.
- Rejection of incorrect algorithm/curve combinations.