### PR TITLE
jws: check the key type before the HMAC digest step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Notes #
 
+<a name="unreleased"></a>
+## [Unreleased](https://github.com/cisco/cjose/0.7.0..master)
+
+### Fix
+
+* Check the key type before the HMAC digest step: cjose_jws_sign with an HS256, HS384 or HS512 header and an EC or RSA key ran the HMAC over the key structure and past the end of its allocation before failing with CJOSE_ERR_INVALID_ARG
+
 <a name="0.7.0"></a>
 ## [0.7.0](https://github.com/cisco/cjose/0.6.3..0.7.0)  (2026-09-09)
 

--- a/src/jws.c
+++ b/src/jws.c
@@ -253,6 +253,13 @@ static bool _cjose_jws_build_dig_hmac_sha(cjose_jws_t *jws, const cjose_jwk_t *j
     bool retval = false;
     HMAC_CTX *ctx = NULL;
 
+    // ensure jwk is OCT: only then is keydata the raw key material
+    if (jwk->kty != CJOSE_JWK_KTY_OCT)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
     // make sure we have an alg header
     json_t *alg_obj = json_object_get(jws->hdr, CJOSE_HDR_ALG);
     if (NULL == alg_obj)

--- a/test/check_jws.c
+++ b/test/check_jws.c
@@ -392,6 +392,43 @@ START_TEST(test_cjose_jws_sign_with_bad_key)
 }
 END_TEST
 
+START_TEST(test_cjose_jws_sign_hmac_with_non_oct_key)
+{
+    cjose_err err;
+    static const uint8_t plain[] = "The mind is everything. What you think you become.";
+    size_t plain_len = sizeof(plain) - 1;
+
+    // HS256/HS384/HS512 take an oct key; for any other key type keydata is a
+    // key structure, not raw key material, and must not be fed to the HMAC.
+    // Before the fix the digest step ran the HMAC over keysize/8 octets of
+    // jwk->keydata and only the signing step rejected the key type: an
+    // over-read of the (much smaller) EC or RSA key structure that valgrind
+    // flags. The P-521 key reads 65 octets from a 16 octet allocation.
+    cjose_jwk_t *keys[3] = { NULL, NULL, NULL };
+    keys[0] = cjose_jwk_import(JWK_COMMON_EC, strlen(JWK_COMMON_EC), &err);
+    keys[1] = cjose_jwk_create_EC_random(CJOSE_JWK_EC_P_521, &err);
+    keys[2] = cjose_jwk_import(JWK_COMMON, strlen(JWK_COMMON), &err); // RSA
+    static const char *ALGS[] = { CJOSE_HDR_ALG_HS256, CJOSE_HDR_ALG_HS384, CJOSE_HDR_ALG_HS512 };
+
+    cjose_header_t *hdr = cjose_header_new(&err);
+    ck_assert(NULL != hdr);
+    for (size_t k = 0; k < sizeof(keys) / sizeof(keys[0]); k++)
+    {
+        ck_assert_msg(NULL != keys[k], "creating key %zu failed: %s", k, err.message);
+        for (size_t a = 0; a < sizeof(ALGS) / sizeof(ALGS[0]); a++)
+        {
+            ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, ALGS[a], &err));
+            cjose_jws_t *jws = cjose_jws_sign(keys[k], hdr, plain, plain_len, &err);
+            ck_assert_msg(NULL == jws, "cjose_jws_sign [%s] accepted a non-oct key (key %zu)", ALGS[a], k);
+            ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jws_sign [%s] returned wrong err.code (%u:%s)", ALGS[a],
+                          err.code, err.message);
+        }
+        cjose_jwk_release(keys[k]);
+    }
+    cjose_header_release(hdr);
+}
+END_TEST
+
 START_TEST(test_cjose_jws_sign_with_bad_content)
 {
     cjose_err err;
@@ -1199,6 +1236,7 @@ Suite *cjose_jws_suite(void)
     tcase_add_test(tc_jws, test_cjose_jws_es256k_rejects_wrong_curve);
     tcase_add_test(tc_jws, test_cjose_jws_sign_with_bad_header);
     tcase_add_test(tc_jws, test_cjose_jws_sign_with_bad_key);
+    tcase_add_test(tc_jws, test_cjose_jws_sign_hmac_with_non_oct_key);
     tcase_add_test(tc_jws, test_cjose_jws_sign_with_bad_content);
     tcase_add_test(tc_jws, test_cjose_jws_import_export_compare);
     tcase_add_test(tc_jws, test_cjose_jws_import_invalid_serialization);


### PR DESCRIPTION
## Summary

`_cjose_jws_build_dig_hmac_sha()` handed `jwk->keydata` to `HMAC_Init_ex()` as `keysize / 8` octets of key material for any key type; the key type was only checked afterwards in `_cjose_jws_build_sig_hmac_sha()`. For an EC or RSA key `keydata` is a (much smaller) key structure, so `cjose_jws_sign()` with an `HS256`/`HS384`/`HS512` header and such a key computed an HMAC over the structure and past the end of its allocation before failing. The call did return `CJOSE_ERR_INVALID_ARG`, so the visible behaviour does not change.

The fix rejects a non-oct key at the start of the digest step, as the other digest and signing steps already do for their key types. CHANGELOG.md gets an "Unreleased" entry.

## Regression test

`test_cjose_jws_sign_hmac_with_non_oct_key` signs with an EC P-256 key, an EC P-521 key (65 octets read from a 16 octet allocation) and an RSA key under the three HS algorithms. It passes on master as well, because the error code was already right, but on master it fails under valgrind (as the CI Valgrind step runs it): 26 errors from 10 contexts in the `jws` suite, all invalid reads under `HMAC_Init_ex`. With the fix valgrind is clean.

Verified locally: build with `-Wall -Werror`, full `check_cjose` run, `CK_FORK=no valgrind --leak-check=full --error-exitcode=1` on the `jws` suite, and the `clang-format` target produces no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
