### PR TITLE
Add the OKP key type (RFC 8037) and the Ed25519 and Ed448 signing algorithms (RFC 9864)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 <a name="unreleased"></a>
 ## [Unreleased](https://github.com/cisco/cjose/0.7.0..master)
 
+### Update
+
+* Add the Octet Key Pair (OKP) JWK type of RFC 8037 holding an Ed25519 or Ed448 signature key (RFC 8032) or an X25519 or X448 key agreement key (RFC 7748): cjose_jwk_create_OKP_random, cjose_jwk_create_OKP_spec, cjose_jwk_OKP_get_curve and import/export; needs OpenSSL 1.1.1
+
 ### Fix
 
 * Check the key type before the HMAC digest step: cjose_jws_sign with an HS256, HS384 or HS512 header and an EC or RSA key ran the HMAC over the key structure and past the end of its allocation before failing with CJOSE_ERR_INVALID_ARG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Update
 
 * Add the Octet Key Pair (OKP) JWK type of RFC 8037 holding an Ed25519 or Ed448 signature key (RFC 8032) or an X25519 or X448 key agreement key (RFC 7748): cjose_jwk_create_OKP_random, cjose_jwk_create_OKP_spec, cjose_jwk_OKP_get_curve and import/export; needs OpenSSL 1.1.1
+* Add the fully-specified EdDSA JWS signing algorithms Ed25519 and Ed448 of RFC 9864 over OKP keys; the polymorphic "EdDSA" identifier of RFC 8037, which RFC 9864 deprecates, is not supported
 
 ### Fix
 

--- a/cmake/exports/cjose.def
+++ b/cmake/exports/cjose.def
@@ -67,8 +67,11 @@ EXPORTS
     cjose_jwe_import_json
     cjose_jwe_release
     cjose_jwk_EC_get_curve
+    cjose_jwk_OKP_get_curve
     cjose_jwk_create_EC_random
     cjose_jwk_create_EC_spec
+    cjose_jwk_create_OKP_random
+    cjose_jwk_create_OKP_spec
     cjose_jwk_create_RSA_random
     cjose_jwk_create_RSA_spec
     cjose_jwk_create_oct_random

--- a/cmake/exports/libcjose.symbols
+++ b/cmake/exports/libcjose.symbols
@@ -67,8 +67,11 @@ _cjose_jwe_import
 _cjose_jwe_import_json
 _cjose_jwe_release
 _cjose_jwk_EC_get_curve
+_cjose_jwk_OKP_get_curve
 _cjose_jwk_create_EC_random
 _cjose_jwk_create_EC_spec
+_cjose_jwk_create_OKP_random
+_cjose_jwk_create_OKP_spec
 _cjose_jwk_create_RSA_random
 _cjose_jwk_create_RSA_spec
 _cjose_jwk_create_oct_random

--- a/cmake/exports/libcjose.version
+++ b/cmake/exports/libcjose.version
@@ -70,8 +70,11 @@
         cjose_jwe_import_json;
         cjose_jwe_release;
         cjose_jwk_EC_get_curve;
+        cjose_jwk_OKP_get_curve;
         cjose_jwk_create_EC_random;
         cjose_jwk_create_EC_spec;
+        cjose_jwk_create_OKP_random;
+        cjose_jwk_create_OKP_spec;
         cjose_jwk_create_RSA_random;
         cjose_jwk_create_RSA_spec;
         cjose_jwk_create_oct_random;

--- a/include/cjose/header.h
+++ b/include/cjose/header.h
@@ -85,6 +85,10 @@ extern "C" {
 #define CJOSE_HDR_ALG_ES384 "ES384"
 #define CJOSE_HDR_ALG_ES512 "ES512"
 
+/** The JWS algorithm attribute values for the fully-specified EdDSA algorithms Ed25519 and Ed448 (RFC 9864). */
+#define CJOSE_HDR_ALG_ED25519 "Ed25519"
+#define CJOSE_HDR_ALG_ED448 "Ed448"
+
 /** The JWE algorithm attribute value for "dir". */
 #define CJOSE_HDR_ALG_DIR "dir"
 

--- a/include/cjose/jwk.h
+++ b/include/cjose/jwk.h
@@ -32,7 +32,9 @@ typedef enum
     /** Elliptic Curve Public (or Private) Key */
     CJOSE_JWK_KTY_EC,
     /** Octet String (Symmetric) Key */
-    CJOSE_JWK_KTY_OCT
+    CJOSE_JWK_KTY_OCT,
+    /** Octet Key Pair (RFC 8037) Public (or Private) Key */
+    CJOSE_JWK_KTY_OKP
 } cjose_jwk_kty_t;
 
 /**
@@ -319,6 +321,87 @@ cjose_jwk_t *cjose_jwk_create_oct_random(size_t size, cjose_err *err);
  * \returns The symmetric JWK object for the given raw key data.
  */
 cjose_jwk_t *cjose_jwk_create_oct_spec(const uint8_t *data, size_t len, cjose_err *err);
+
+/** Enumeration of supported curves for Octet Key Pair (OKP) JWK objects (RFC 8037).
+ *
+ * The explicit values match OpenSSL's NIDs for the curves, like the Elliptic
+ * Curve enumeration above, without requiring OpenSSL's obj_mac.h in this
+ * public header.
+ */
+typedef enum
+{
+    /** Ed25519 signature curve (edwards25519, RFC 8032). */
+    CJOSE_JWK_OKP_ED25519 = 1087,
+    /** Ed448 signature curve (edwards448, RFC 8032). */
+    CJOSE_JWK_OKP_ED448 = 1088,
+    /** X25519 key agreement curve (curve25519, RFC 7748). */
+    CJOSE_JWK_OKP_X25519 = 1034,
+    /** X448 key agreement curve (curve448, RFC 7748). */
+    CJOSE_JWK_OKP_X448 = 1035,
+    /** Invalid Curve */
+    CJOSE_JWK_OKP_INVALID = -1
+} cjose_jwk_okp_curve;
+
+/** Key specification for Octet Key Pair (OKP) JWK objects. */
+typedef struct
+{
+    /** The curve */
+    cjose_jwk_okp_curve crv;
+    /** The raw private key (RFC 8037 "d"), or NULL for a public key */
+    uint8_t *d;
+    /** Length of <tt>d</tt>: the fixed key size of the curve, or 0 */
+    size_t dlen;
+    /** The raw public key (RFC 8037 "x") */
+    uint8_t *x;
+    /** Length of <tt>x</tt>: the fixed key size of the curve, or 0 */
+    size_t xlen;
+} cjose_jwk_okp_keyspec;
+
+/**
+ * Creates a new Octet Key Pair (OKP) JWK, using a secure random number
+ * generator.
+ *
+ * \b NOTE: The caller MUST call cjose_jwk_release() to release the JWK's
+ * resources.
+ *
+ * \b NOTE: OKP keys require OpenSSL 1.1.1 or later; with an older OpenSSL
+ * this function fails with CJOSE_ERR_INVALID_ARG.
+ *
+ * \param crv The curve to generate the key pair for
+ * \param err [out] An optional error object which can be used to get additional
+ *        information in the event of an error.
+ * \returns The generated Octet Key Pair JWK object
+ */
+cjose_jwk_t *cjose_jwk_create_OKP_random(cjose_jwk_okp_curve crv, cjose_err *err);
+
+/**
+ * Creates a new Octet Key Pair (OKP) JWK, using the given raw values for the
+ * private and/or public key. When only the private key is given the public
+ * key is derived from it; when both are given they must belong together.
+ *
+ * \b NOTE: The caller MUST call cjose_jwk_release() to release the JWK's
+ * resources.
+ *
+ * \b NOTE: This function makes a copy of all provided data; the caller
+ * MUST free the memory for <tt>spec</tt> after calling this function.
+ *
+ * \param spec The specified Octet Key Pair properties
+ * \param err [out] An optional error object which can be used to get additional
+ *        information in the event of an error.
+ * \returns The generated Octet Key Pair JWK object
+ */
+cjose_jwk_t *cjose_jwk_create_OKP_spec(const cjose_jwk_okp_keyspec *spec, cjose_err *err);
+
+/**
+ * Obtains the curve for the given (OKP) JWK.
+ *
+ * \param jwk [in] The OKP JWK to inspect
+ * \param err [out] An optional error object which can be used to get additional
+ *        information in the event of an error.
+ * \returns The curve type, or CJOSE_JWK_OKP_INVALID if <tt>jwk</tt> is not an
+ *        OKP key
+ */
+cjose_jwk_okp_curve cjose_jwk_OKP_get_curve(const cjose_jwk_t *jwk, cjose_err *err);
 
 /**
  * Instantiates a new JWK given a JSON document representation conforming

--- a/src/include/jwk_int.h
+++ b/src/include/jwk_int.h
@@ -52,6 +52,14 @@ typedef struct _ec_keydata_int
     EC_KEY *key;
 } ec_keydata;
 
+// OKP-specific keydata (RFC 8037): the EVP_PKEY holds the raw Ed25519,
+// Ed448, X25519 or X448 key
+typedef struct _okp_keydata_int
+{
+    cjose_jwk_okp_curve crv;
+    EVP_PKEY *key;
+} okp_keydata;
+
 // RSA-specific keydata = OpenSSL RSA struct
 // (just uses RSA struct)
 void _cjose_jwk_rsa_get(RSA *rsa, BIGNUM **n, BIGNUM **e, BIGNUM **d);

--- a/src/include/util_int.h
+++ b/src/include/util_int.h
@@ -18,6 +18,12 @@
 #define CJOSE_OPENSSL_11X
 #endif
 
+// the raw key API (EVP_PKEY_new_raw_private_key & co.) and PureEdDSA arrived
+// in OpenSSL 1.1.1; the OKP key type and the EdDSA algorithms depend on them
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
+#define CJOSE_OPENSSL_111X
+#endif
+
 #ifdef _WIN32
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -17,6 +17,8 @@
 #include <stdio.h>
 
 #include <openssl/bn.h>
+#include <openssl/crypto.h>
+#include <openssl/err.h>
 #include <openssl/obj_mac.h>
 #include <openssl/rand.h>
 #include <openssl/rsa.h>
@@ -35,6 +37,7 @@ static const char CJOSE_JWK_KID_STR[] = "kid";
 static const char CJOSE_JWK_KTY_EC_STR[] = "EC";
 static const char CJOSE_JWK_KTY_RSA_STR[] = "RSA";
 static const char CJOSE_JWK_KTY_OCT_STR[] = "oct";
+static const char CJOSE_JWK_KTY_OKP_STR[] = "OKP";
 static const char CJOSE_JWK_CRV_STR[] = "crv";
 static const char CJOSE_JWK_X_STR[] = "x";
 static const char CJOSE_JWK_Y_STR[] = "y";
@@ -48,7 +51,7 @@ static const char CJOSE_JWK_DQ_STR[] = "dq";
 static const char CJOSE_JWK_QI_STR[] = "qi";
 static const char CJOSE_JWK_K_STR[] = "k";
 
-static const char *JWK_KTY_NAMES[] = { CJOSE_JWK_KTY_RSA_STR, CJOSE_JWK_KTY_EC_STR, CJOSE_JWK_KTY_OCT_STR };
+static const char *JWK_KTY_NAMES[] = { CJOSE_JWK_KTY_RSA_STR, CJOSE_JWK_KTY_EC_STR, CJOSE_JWK_KTY_OCT_STR, CJOSE_JWK_KTY_OKP_STR };
 
 void _cjose_jwk_rsa_get(RSA *rsa, BIGNUM **rsa_n, BIGNUM **rsa_e, BIGNUM **rsa_d)
 {
@@ -201,10 +204,10 @@ bool _cjose_jwk_rsa_set_crt(
 
 const char *cjose_jwk_name_for_kty(cjose_jwk_kty_t kty, cjose_err *err)
 {
-    // reject anything outside [CJOSE_JWK_KTY_RSA, CJOSE_JWK_KTY_OCT]; a value
+    // reject anything outside [CJOSE_JWK_KTY_RSA, CJOSE_JWK_KTY_OKP]; a value
     // below RSA (e.g. a negative sentinel, if the enum is signed) would index
     // JWK_KTY_NAMES out of bounds
-    if (kty < CJOSE_JWK_KTY_RSA || CJOSE_JWK_KTY_OCT < kty)
+    if (kty < CJOSE_JWK_KTY_RSA || CJOSE_JWK_KTY_OKP < kty)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return NULL;
@@ -664,6 +667,10 @@ static inline bool _kty_from_name(const char *name, cjose_jwk_kty_t *kty, cjose_
     {
         *kty = CJOSE_JWK_KTY_OCT;
     }
+    else if (strncmp(name, CJOSE_JWK_KTY_OKP_STR, sizeof(CJOSE_JWK_KTY_OKP_STR)) == 0)
+    {
+        *kty = CJOSE_JWK_KTY_OKP;
+    }
     else
     {
         retval = false;
@@ -1115,6 +1122,438 @@ cjose_jwk_ec_curve cjose_jwk_EC_get_curve(const cjose_jwk_t *jwk, cjose_err *err
     }
 
     ec_keydata *keydata = jwk->keydata;
+    return keydata->crv;
+}
+
+//////////////// Octet Key Pair ////////////////
+// internal data & functions -- Octet Key Pair (RFC 8037)
+
+#if defined(CJOSE_OPENSSL_111X)
+
+static const char CJOSE_JWK_OKP_ED25519_STR[] = "Ed25519";
+static const char CJOSE_JWK_OKP_ED448_STR[] = "Ed448";
+static const char CJOSE_JWK_OKP_X25519_STR[] = "X25519";
+static const char CJOSE_JWK_OKP_X448_STR[] = "X448";
+
+static void _OKP_free(cjose_jwk_t *jwk);
+static bool _OKP_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
+static bool _OKP_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
+
+static const key_fntable OKP_FNTABLE = { _OKP_free, _OKP_public_fields, _OKP_private_fields };
+
+static inline int _okp_nid_for_curve(cjose_jwk_okp_curve crv)
+{
+    switch (crv)
+    {
+    case CJOSE_JWK_OKP_ED25519:
+        return NID_ED25519;
+    case CJOSE_JWK_OKP_ED448:
+        return NID_ED448;
+    case CJOSE_JWK_OKP_X25519:
+        return NID_X25519;
+    case CJOSE_JWK_OKP_X448:
+        return NID_X448;
+    case CJOSE_JWK_OKP_INVALID:
+        return NID_undef;
+    }
+
+    return NID_undef;
+}
+
+// the fixed size of both the raw public key "x" and the raw private key "d"
+// (RFC 8032 sections 5.1.5 and 5.2.5, RFC 7748 section 5)
+static inline size_t _okp_size_for_curve(cjose_jwk_okp_curve crv)
+{
+    switch (crv)
+    {
+    case CJOSE_JWK_OKP_ED25519:
+        return 32;
+    case CJOSE_JWK_OKP_ED448:
+        return 57;
+    case CJOSE_JWK_OKP_X25519:
+        return 32;
+    case CJOSE_JWK_OKP_X448:
+        return 56;
+    case CJOSE_JWK_OKP_INVALID:
+        return 0;
+    }
+
+    return 0;
+}
+
+static inline const char *_okp_name_for_curve(cjose_jwk_okp_curve crv)
+{
+    switch (crv)
+    {
+    case CJOSE_JWK_OKP_ED25519:
+        return CJOSE_JWK_OKP_ED25519_STR;
+    case CJOSE_JWK_OKP_ED448:
+        return CJOSE_JWK_OKP_ED448_STR;
+    case CJOSE_JWK_OKP_X25519:
+        return CJOSE_JWK_OKP_X25519_STR;
+    case CJOSE_JWK_OKP_X448:
+        return CJOSE_JWK_OKP_X448_STR;
+    case CJOSE_JWK_OKP_INVALID:
+        return NULL;
+    }
+
+    return NULL;
+}
+
+static inline bool _okp_curve_from_name(const char *name, cjose_jwk_okp_curve *crv)
+{
+    bool retval = true;
+    if (strncmp(name, CJOSE_JWK_OKP_ED25519_STR, sizeof(CJOSE_JWK_OKP_ED25519_STR)) == 0)
+    {
+        *crv = CJOSE_JWK_OKP_ED25519;
+    }
+    else if (strncmp(name, CJOSE_JWK_OKP_ED448_STR, sizeof(CJOSE_JWK_OKP_ED448_STR)) == 0)
+    {
+        *crv = CJOSE_JWK_OKP_ED448;
+    }
+    else if (strncmp(name, CJOSE_JWK_OKP_X25519_STR, sizeof(CJOSE_JWK_OKP_X25519_STR)) == 0)
+    {
+        *crv = CJOSE_JWK_OKP_X25519;
+    }
+    else if (strncmp(name, CJOSE_JWK_OKP_X448_STR, sizeof(CJOSE_JWK_OKP_X448_STR)) == 0)
+    {
+        *crv = CJOSE_JWK_OKP_X448;
+    }
+    else
+    {
+        retval = false;
+    }
+    return retval;
+}
+
+static cjose_jwk_t *_OKP_new(cjose_jwk_okp_curve crv, EVP_PKEY *pkey, cjose_err *err)
+{
+    okp_keydata *keydata = cjose_get_alloc()(sizeof(okp_keydata));
+    if (!keydata)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        return NULL;
+    }
+    keydata->crv = crv;
+    keydata->key = pkey;
+
+    cjose_jwk_t *jwk = cjose_get_alloc()(sizeof(cjose_jwk_t));
+    if (!jwk)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        cjose_get_dealloc()(keydata);
+        return NULL;
+    }
+    memset(jwk, 0, sizeof(cjose_jwk_t));
+    jwk->retained = 1;
+    jwk->kty = CJOSE_JWK_KTY_OKP;
+    jwk->keysize = _okp_size_for_curve(crv) * 8;
+    jwk->keydata = keydata;
+    jwk->fns = &OKP_FNTABLE;
+
+    return jwk;
+}
+
+static void _OKP_free(cjose_jwk_t *jwk)
+{
+    okp_keydata *keydata = (okp_keydata *)jwk->keydata;
+    jwk->keydata = NULL;
+
+    if (keydata)
+    {
+        EVP_PKEY_free(keydata->key);
+        keydata->key = NULL;
+        cjose_get_dealloc()(keydata);
+    }
+    cjose_get_dealloc()(jwk);
+}
+
+static bool _OKP_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
+{
+    okp_keydata *keydata = (okp_keydata *)jwk->keydata;
+    uint8_t *buffer = NULL;
+    char *b64u = NULL;
+    size_t len = 0;
+    json_t *field = NULL;
+    bool result = false;
+
+    // the raw public key has the fixed size of the curve
+    size_t numsize = _okp_size_for_curve(keydata->crv);
+
+    // output the curve
+    field = json_string(_okp_name_for_curve(keydata->crv));
+    if (!field)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        goto _okp_to_string_cleanup;
+    }
+    json_object_set(json, "crv", field);
+    json_decref(field);
+    field = NULL;
+
+    // obtain the raw public key
+    buffer = cjose_get_alloc()(numsize);
+    if (!buffer)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        goto _okp_to_string_cleanup;
+    }
+    len = numsize;
+    if (1 != EVP_PKEY_get_raw_public_key(keydata->key, buffer, &len) || len != numsize)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto _okp_to_string_cleanup;
+    }
+
+    // output the public key x
+    if (!cjose_base64url_encode(buffer, numsize, &b64u, &len, err))
+    {
+        goto _okp_to_string_cleanup;
+    }
+    field = _cjose_json_stringn(b64u, len, err);
+    if (!field)
+    {
+        goto _okp_to_string_cleanup;
+    }
+    json_object_set(json, "x", field);
+    json_decref(field);
+    field = NULL;
+
+    result = true;
+
+_okp_to_string_cleanup:
+    cjose_get_dealloc()(buffer);
+    cjose_get_dealloc()(b64u);
+
+    return result;
+}
+
+static bool _OKP_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
+{
+    okp_keydata *keydata = (okp_keydata *)jwk->keydata;
+    uint8_t *buffer = NULL;
+    char *b64u = NULL;
+    size_t len = 0;
+    size_t b64u_len = 0;
+    json_t *field = NULL;
+    int rc = 0;
+    bool result = false;
+
+    // the raw private key has the fixed size of the curve
+    size_t numsize = _okp_size_for_curve(keydata->crv);
+
+    buffer = cjose_get_alloc()(numsize);
+    if (!buffer)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        goto _okp_to_string_cleanup;
+    }
+
+    // short circuit if there is no private key; discard the error OpenSSL may
+    // queue for the missing key so it does not surface in a later cjose_err_message()
+    len = numsize;
+    ERR_set_mark();
+    rc = EVP_PKEY_get_raw_private_key(keydata->key, buffer, &len);
+    ERR_pop_to_mark();
+    if (1 != rc)
+    {
+        result = true;
+        goto _okp_to_string_cleanup;
+    }
+    if (len != numsize)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto _okp_to_string_cleanup;
+    }
+
+    // output the private key d
+    if (!cjose_base64url_encode(buffer, numsize, &b64u, &b64u_len, err))
+    {
+        goto _okp_to_string_cleanup;
+    }
+    field = _cjose_json_stringn(b64u, b64u_len, err);
+    if (!field)
+    {
+        goto _okp_to_string_cleanup;
+    }
+    json_object_set(json, "d", field);
+    json_decref(field);
+    field = NULL;
+
+    result = true;
+
+_okp_to_string_cleanup:
+    // buffer and b64u hold the raw / base64url-encoded private key 'd';
+    // wipe them before release
+    _cjose_cleanse_dealloc(buffer, numsize);
+    _cjose_cleanse_dealloc(b64u, b64u_len);
+
+    return result;
+}
+
+// interface functions -- Octet Key Pair
+
+cjose_jwk_t *cjose_jwk_create_OKP_random(cjose_jwk_okp_curve crv, cjose_err *err)
+{
+    cjose_jwk_t *jwk = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *pkey = NULL;
+
+    int nid = _okp_nid_for_curve(crv);
+    if (NID_undef == nid)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        goto create_OKP_random_cleanup;
+    }
+
+    ctx = EVP_PKEY_CTX_new_id(nid, NULL);
+    if (NULL == ctx)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto create_OKP_random_cleanup;
+    }
+    if (1 != EVP_PKEY_keygen_init(ctx) || 1 != EVP_PKEY_keygen(ctx, &pkey))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto create_OKP_random_cleanup;
+    }
+
+    jwk = _OKP_new(crv, pkey, err);
+    if (NULL == jwk)
+    {
+        goto create_OKP_random_cleanup;
+    }
+    // the jwk owns the key now
+    pkey = NULL;
+
+create_OKP_random_cleanup:
+    EVP_PKEY_free(pkey);
+    EVP_PKEY_CTX_free(ctx);
+
+    return jwk;
+}
+
+cjose_jwk_t *cjose_jwk_create_OKP_spec(const cjose_jwk_okp_keyspec *spec, cjose_err *err)
+{
+    cjose_jwk_t *jwk = NULL;
+    EVP_PKEY *pkey = NULL;
+    uint8_t *pub = NULL;
+    size_t pub_len = 0;
+
+    if (!spec)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return NULL;
+    }
+
+    int nid = _okp_nid_for_curve(spec->crv);
+    size_t numsize = _okp_size_for_curve(spec->crv);
+    if (NID_undef == nid || 0 == numsize)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return NULL;
+    }
+
+    bool hasPriv = (NULL != spec->d && 0 < spec->dlen);
+    bool hasPub = (NULL != spec->x && 0 < spec->xlen);
+    if (!hasPriv && !hasPub)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return NULL;
+    }
+
+    // the raw keys have the fixed size of the curve (RFC 8037 section 2);
+    // check that up front instead of relying on OpenSSL to reject them
+    if ((hasPriv && spec->dlen != numsize) || (hasPub && spec->xlen != numsize))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return NULL;
+    }
+
+    if (hasPriv)
+    {
+        pkey = EVP_PKEY_new_raw_private_key(nid, NULL, spec->d, spec->dlen);
+        if (NULL == pkey)
+        {
+            CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+            goto create_OKP_spec_cleanup;
+        }
+
+        // OpenSSL derives the public key from the private key; when a public
+        // key is supplied as well it must be that one
+        if (hasPub)
+        {
+            pub = cjose_get_alloc()(numsize);
+            if (NULL == pub)
+            {
+                CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+                goto create_OKP_spec_cleanup;
+            }
+            pub_len = numsize;
+            if (1 != EVP_PKEY_get_raw_public_key(pkey, pub, &pub_len) || pub_len != numsize)
+            {
+                CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+                goto create_OKP_spec_cleanup;
+            }
+            if (0 != CRYPTO_memcmp(pub, spec->x, numsize))
+            {
+                CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+                goto create_OKP_spec_cleanup;
+            }
+        }
+    }
+    else
+    {
+        pkey = EVP_PKEY_new_raw_public_key(nid, NULL, spec->x, spec->xlen);
+        if (NULL == pkey)
+        {
+            CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+            goto create_OKP_spec_cleanup;
+        }
+    }
+
+    jwk = _OKP_new(spec->crv, pkey, err);
+    if (NULL == jwk)
+    {
+        goto create_OKP_spec_cleanup;
+    }
+    // the jwk owns the key now
+    pkey = NULL;
+
+create_OKP_spec_cleanup:
+    EVP_PKEY_free(pkey);
+    cjose_get_dealloc()(pub);
+
+    return jwk;
+}
+
+#else // !CJOSE_OPENSSL_111X
+
+// the OKP key type needs the raw key API that arrived in OpenSSL 1.1.1
+
+cjose_jwk_t *cjose_jwk_create_OKP_random(cjose_jwk_okp_curve crv, cjose_err *err)
+{
+    CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+    return NULL;
+}
+
+cjose_jwk_t *cjose_jwk_create_OKP_spec(const cjose_jwk_okp_keyspec *spec, cjose_err *err)
+{
+    CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+    return NULL;
+}
+
+#endif // CJOSE_OPENSSL_111X
+
+cjose_jwk_okp_curve cjose_jwk_OKP_get_curve(const cjose_jwk_t *jwk, cjose_err *err)
+{
+    if (NULL == jwk || CJOSE_JWK_KTY_OKP != cjose_jwk_get_kty(jwk, err))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return CJOSE_JWK_OKP_INVALID;
+    }
+
+    okp_keydata *keydata = jwk->keydata;
     return keydata->crv;
 }
 
@@ -1689,6 +2128,82 @@ import_oct_cleanup:
     return jwk;
 }
 
+#if defined(CJOSE_OPENSSL_111X)
+static cjose_jwk_t *_cjose_jwk_import_OKP(json_t *jwk_json, cjose_err *err)
+{
+    cjose_jwk_t *jwk = NULL;
+    uint8_t *x_buffer = NULL;
+    uint8_t *d_buffer = NULL;
+    size_t x_buflen = 0;
+    size_t d_buflen = 0;
+
+    // get the value of the crv attribute
+    const char *crv_str = _get_json_object_string_attribute(jwk_json, CJOSE_JWK_CRV_STR, err);
+    if (crv_str == NULL)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        goto import_OKP_cleanup;
+    }
+
+    // get the curve identifier for the curve named by crv
+    cjose_jwk_okp_curve crv;
+    if (!_okp_curve_from_name(crv_str, &crv))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        goto import_OKP_cleanup;
+    }
+
+    // get the decoded value of the public key x (of the fixed size of the
+    // curve); x is REQUIRED for every OKP key (RFC 8037 section 2), and the
+    // decoder treats a missing, empty or non-string attribute alike, so a
+    // decoded value must have come out of it
+    x_buflen = _okp_size_for_curve(crv);
+    if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_X_STR, &x_buffer, &x_buflen, err) || NULL == x_buffer)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        goto import_OKP_cleanup;
+    }
+
+    // get the decoded value of the private key d (of the fixed size of the
+    // curve); d is REQUIRED for a private key and MUST NOT be present for a
+    // public key (RFC 8037 section 2), so when the attribute is there it must
+    // decode to a key of the right size instead of quietly making a public key
+    d_buflen = _okp_size_for_curve(crv);
+    if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_D_STR, &d_buffer, &d_buflen, err)
+        || (NULL != json_object_get(jwk_json, CJOSE_JWK_D_STR) && NULL == d_buffer))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        goto import_OKP_cleanup;
+    }
+
+    // create an okp keyspec
+    cjose_jwk_okp_keyspec okp_keyspec;
+    memset(&okp_keyspec, 0, sizeof(cjose_jwk_okp_keyspec));
+    okp_keyspec.crv = crv;
+    okp_keyspec.x = x_buffer;
+    okp_keyspec.xlen = x_buflen;
+    okp_keyspec.d = d_buffer;
+    okp_keyspec.dlen = d_buflen;
+
+    // create the jwk
+    jwk = cjose_jwk_create_OKP_spec(&okp_keyspec, err);
+
+import_OKP_cleanup:
+    cjose_get_dealloc()(x_buffer);
+    // d is the private key -> wipe the decoded copy before release
+    _cjose_cleanse_dealloc(d_buffer, d_buflen);
+
+    return jwk;
+}
+#else
+static cjose_jwk_t *_cjose_jwk_import_OKP(json_t *jwk_json, cjose_err *err)
+{
+    // the OKP key type needs the raw key API that arrived in OpenSSL 1.1.1
+    CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+    return NULL;
+}
+#endif // CJOSE_OPENSSL_111X
+
 cjose_jwk_t *cjose_jwk_import(const char *jwk_str, size_t len, cjose_err *err)
 {
     cjose_jwk_t *jwk = NULL;
@@ -1760,6 +2275,10 @@ cjose_jwk_t *cjose_jwk_import_json(cjose_header_t *json, cjose_err *err)
 
     case CJOSE_JWK_KTY_OCT:
         jwk = _cjose_jwk_import_oct(jwk_json, err);
+        break;
+
+    case CJOSE_JWK_KTY_OKP:
+        jwk = _cjose_jwk_import_OKP(jwk_json, err);
         break;
 
     default:

--- a/src/jws.c
+++ b/src/jws.c
@@ -46,6 +46,16 @@ static bool _cjose_jws_verify_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
 
 static bool _cjose_jws_validate_ec_key(const char *alg, const cjose_jwk_t *jwk, cjose_err *err);
 
+#if defined(CJOSE_OPENSSL_111X)
+static bool _cjose_jws_build_dig_eddsa(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err);
+
+static bool _cjose_jws_build_sig_eddsa(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err);
+
+static bool _cjose_jws_verify_sig_eddsa(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err);
+
+static bool _cjose_jws_validate_okp_key(const char *alg, const cjose_jwk_t *jwk, cjose_err *err);
+#endif
+
 static bool _cjose_jws_validate_verify_key(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -120,6 +130,14 @@ static bool _cjose_jws_validate_hdr(cjose_jws_t *jws, cjose_err *err)
         jws->fns.sign = _cjose_jws_build_sig_ec;
         jws->fns.verify = _cjose_jws_verify_sig_ec;
     }
+#if defined(CJOSE_OPENSSL_111X)
+    else if ((strcmp(alg, CJOSE_HDR_ALG_ED25519) == 0) || (strcmp(alg, CJOSE_HDR_ALG_ED448) == 0))
+    {
+        jws->fns.digest = _cjose_jws_build_dig_eddsa;
+        jws->fns.sign = _cjose_jws_build_sig_eddsa;
+        jws->fns.verify = _cjose_jws_verify_sig_eddsa;
+    }
+#endif
     else
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1177,6 +1195,231 @@ static bool _cjose_jws_validate_ec_key(const char *alg, const cjose_jwk_t *jwk, 
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+#if defined(CJOSE_OPENSSL_111X)
+
+// the fixed size of an EdDSA signature (RFC 8032 sections 5.1.6 and 5.2.6)
+static size_t _cjose_jws_eddsa_sig_len(cjose_jwk_okp_curve crv)
+{
+    switch (crv)
+    {
+    case CJOSE_JWK_OKP_ED25519:
+        return 64;
+    case CJOSE_JWK_OKP_ED448:
+        return 114;
+    default:
+        return 0;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+static bool _cjose_jws_validate_okp_key(const char *alg, const cjose_jwk_t *jwk, cjose_err *err)
+{
+    if (jwk->kty != CJOSE_JWK_KTY_OKP)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
+    okp_keydata *keydata = (okp_keydata *)jwk->keydata;
+
+    // RFC 9864 binds the fully-specified Ed25519 and Ed448 identifiers to a key
+    // of that curve, and an X25519/X448 key agreement key never signs (RFC 8037
+    // section 3.1); the polymorphic "EdDSA" identifier of RFC 8037, which RFC
+    // 9864 deprecates, is not supported
+    bool valid = false;
+    if (strcmp(alg, CJOSE_HDR_ALG_ED25519) == 0)
+    {
+        valid = (keydata->crv == CJOSE_JWK_OKP_ED25519);
+    }
+    else if (strcmp(alg, CJOSE_HDR_ALG_ED448) == 0)
+    {
+        valid = (keydata->crv == CJOSE_JWK_OKP_ED448);
+    }
+
+    if (!valid)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+static bool _cjose_jws_build_dig_eddsa(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err)
+{
+    // PureEdDSA (RFC 8037 section 3.1) signs the message itself without a
+    // pre-hash, and OpenSSL only offers the one-shot EVP_DigestSign and
+    // EVP_DigestVerify for it: the "digest" is the JWS signing input
+    // B64U(HEADER).B64U(DATA) (RFC 7515 section 5.1)
+    if (NULL != jws->dig)
+    {
+        _cjose_cleanse_dealloc(jws->dig, jws->dig_len);
+        jws->dig = NULL;
+    }
+
+    // guard the length of the signing input (+ '.' separator) against size_t overflow
+    if (jws->dat_b64u_len > SIZE_MAX - 1 || jws->hdr_b64u_len > SIZE_MAX - 1 - jws->dat_b64u_len)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
+    jws->dig_len = jws->hdr_b64u_len + 1 + jws->dat_b64u_len;
+    jws->dig = (uint8_t *)cjose_get_alloc()(jws->dig_len);
+    if (NULL == jws->dig)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        return false;
+    }
+    memcpy(jws->dig, jws->hdr_b64u, jws->hdr_b64u_len);
+    jws->dig[jws->hdr_b64u_len] = '.';
+    memcpy(jws->dig + jws->hdr_b64u_len + 1, jws->dat_b64u, jws->dat_b64u_len);
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+static bool _cjose_jws_build_sig_eddsa(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err)
+{
+    bool retval = false;
+    EVP_MD_CTX *ctx = NULL;
+    size_t sig_len = 0;
+
+    const char *alg = json_string_value(json_object_get(jws->hdr, CJOSE_HDR_ALG));
+    if (!_cjose_jws_validate_okp_key(alg, jwk, err))
+    {
+        return false;
+    }
+
+    okp_keydata *keydata = (okp_keydata *)jwk->keydata;
+
+    // signing needs the private key: OpenSSL 1.1.1 and 3.0.0 to 3.0.7 sign
+    // with the missing private key of a public-only key instead of failing
+    // (3.0.8 added the guard), so refuse it here rather than rely on OpenSSL;
+    // 1.1.1 only reports the absence of the private key when asked to copy
+    // it out, so copy it into a scratch buffer that is wiped right after
+    size_t priv_len = 0;
+    if (1 != EVP_PKEY_get_raw_private_key(keydata->key, NULL, &priv_len) || 0 == priv_len)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+    uint8_t *priv = (uint8_t *)cjose_get_alloc()(priv_len);
+    if (NULL == priv)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        return false;
+    }
+    int has_priv = EVP_PKEY_get_raw_private_key(keydata->key, priv, &priv_len);
+    _cjose_cleanse_dealloc(priv, priv_len);
+    if (1 != has_priv)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
+    ctx = EVP_MD_CTX_new();
+    if (NULL == ctx)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto _cjose_jws_build_sig_eddsa_cleanup;
+    }
+
+    // PureEdDSA takes no digest algorithm
+    if (1 != EVP_DigestSignInit(ctx, NULL, NULL, NULL, keydata->key))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto _cjose_jws_build_sig_eddsa_cleanup;
+    }
+
+    // allocate buffer for signature: the fixed size of the curve
+    jws->sig_len = _cjose_jws_eddsa_sig_len(keydata->crv);
+    jws->sig = (uint8_t *)cjose_get_alloc()(jws->sig_len);
+    if (NULL == jws->sig)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        goto _cjose_jws_build_sig_eddsa_cleanup;
+    }
+
+    // sign the signing input in one shot
+    sig_len = jws->sig_len;
+    if (1 != EVP_DigestSign(ctx, jws->sig, &sig_len, jws->dig, jws->dig_len) || sig_len != jws->sig_len)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto _cjose_jws_build_sig_eddsa_cleanup;
+    }
+
+    // base64url encode the signature
+    if (!cjose_base64url_encode((const uint8_t *)jws->sig, jws->sig_len, &jws->sig_b64u, &jws->sig_b64u_len, err))
+    {
+        goto _cjose_jws_build_sig_eddsa_cleanup;
+    }
+
+    // if we got this far - success
+    retval = true;
+
+_cjose_jws_build_sig_eddsa_cleanup:
+    EVP_MD_CTX_free(ctx);
+
+    return retval;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+static bool _cjose_jws_verify_sig_eddsa(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err)
+{
+    bool retval = false;
+    EVP_MD_CTX *ctx = NULL;
+
+    const char *alg = json_string_value(json_object_get(jws->hdr, CJOSE_HDR_ALG));
+    if (!_cjose_jws_validate_okp_key(alg, jwk, err))
+    {
+        return false;
+    }
+
+    okp_keydata *keydata = (okp_keydata *)jwk->keydata;
+
+    // the signature has the fixed size of the curve; reject any other length
+    // before handing it to OpenSSL
+    if (jws->sig_len != _cjose_jws_eddsa_sig_len(keydata->crv))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
+    ctx = EVP_MD_CTX_new();
+    if (NULL == ctx)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto _cjose_jws_verify_sig_eddsa_cleanup;
+    }
+
+    // PureEdDSA takes no digest algorithm
+    if (1 != EVP_DigestVerifyInit(ctx, NULL, NULL, NULL, keydata->key))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto _cjose_jws_verify_sig_eddsa_cleanup;
+    }
+
+    // verify the signature over the signing input in one shot
+    if (1 != EVP_DigestVerify(ctx, jws->sig, jws->sig_len, jws->dig, jws->dig_len))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto _cjose_jws_verify_sig_eddsa_cleanup;
+    }
+
+    // if we got this far - success
+    retval = true;
+
+_cjose_jws_verify_sig_eddsa_cleanup:
+    EVP_MD_CTX_free(ctx);
+
+    return retval;
+}
+
+#endif // CJOSE_OPENSSL_111X
+
+////////////////////////////////////////////////////////////////////////////////
 static bool _cjose_jws_validate_verify_key(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err)
 {
     json_t *alg_obj = json_object_get(jws->hdr, CJOSE_HDR_ALG);
@@ -1218,6 +1461,16 @@ static bool _cjose_jws_validate_verify_key(cjose_jws_t *jws, const cjose_jwk_t *
             return false;
         }
     }
+
+#if defined(CJOSE_OPENSSL_111X)
+    if ((0 == strcmp(alg, CJOSE_HDR_ALG_ED25519)) || (0 == strcmp(alg, CJOSE_HDR_ALG_ED448)))
+    {
+        if (!_cjose_jws_validate_okp_key(alg, jwk, err))
+        {
+            return false;
+        }
+    }
+#endif
 
     return true;
 }

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -12,6 +12,7 @@
 #include <cjose/base64.h>
 #include <cjose/util.h>
 #include "include/jwk_int.h"
+#include "include/util_int.h"
 
 /**
  * Convenience function for comparing multiple string attributes of two
@@ -58,6 +59,7 @@ START_TEST(test_cjose_jwk_name_for_kty)
     ck_assert_str_eq("RSA", cjose_jwk_name_for_kty(CJOSE_JWK_KTY_RSA, &err));
     ck_assert_str_eq("EC", cjose_jwk_name_for_kty(CJOSE_JWK_KTY_EC, &err));
     ck_assert_str_eq("oct", cjose_jwk_name_for_kty(CJOSE_JWK_KTY_OCT, &err));
+    ck_assert_str_eq("OKP", cjose_jwk_name_for_kty(CJOSE_JWK_KTY_OKP, &err));
     ck_assert(NULL == cjose_jwk_name_for_kty(0, &err));
     ck_assert(NULL == cjose_jwk_name_for_kty(99, &err));
 }
@@ -454,6 +456,218 @@ START_TEST(test_cjose_jwk_create_oct_random_inval)
 }
 END_TEST
 
+#if defined(CJOSE_OPENSSL_111X)
+static void _test_cjose_jwk_create_OKP_spec(cjose_jwk_okp_curve crv, size_t keysize, const char *d, const char *x)
+{
+    cjose_err err;
+    cjose_jwk_t *jwk = NULL;
+    cjose_jwk_okp_keyspec spec;
+    uint8_t *d_raw = NULL, *x_raw = NULL;
+    size_t d_len = 0, x_len = 0;
+    char *json = NULL;
+
+    ck_assert(cjose_base64url_decode(d, strlen(d), &d_raw, &d_len, &err));
+    ck_assert(cjose_base64url_decode(x, strlen(x), &x_raw, &x_len, &err));
+
+    // private and public key
+    memset(&spec, 0, sizeof(cjose_jwk_okp_keyspec));
+    spec.crv = crv;
+    spec.d = d_raw;
+    spec.dlen = d_len;
+    spec.x = x_raw;
+    spec.xlen = x_len;
+    jwk = cjose_jwk_create_OKP_spec(&spec, &err);
+    ck_assert_msg(NULL != jwk,
+                  "cjose_jwk_create_OKP_spec failed: "
+                  "%s, file: %s, function: %s, line: %ld",
+                  err.message, err.file, err.function, err.line);
+    ck_assert(1 == jwk->retained);
+    ck_assert(CJOSE_JWK_KTY_OKP == jwk->kty);
+    ck_assert(keysize == jwk->keysize);
+    ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
+    ck_assert(NULL != jwk->keydata);
+    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+    ck_assert(crv == cjose_jwk_OKP_get_curve(jwk, &err));
+    // an OKP key is not an EC key
+    ck_assert(CJOSE_JWK_EC_INVALID == cjose_jwk_EC_get_curve(jwk, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    json = cjose_jwk_to_json(jwk, true, &err);
+    ck_assert(NULL != json);
+    ck_assert(NULL != strstr(json, x));
+    ck_assert(NULL != strstr(json, d));
+    cjose_get_dealloc()(json);
+    cjose_jwk_release(jwk);
+
+    // private key only: the public key is derived from it
+    spec.x = NULL;
+    spec.xlen = 0;
+    jwk = cjose_jwk_create_OKP_spec(&spec, &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_create_OKP_spec (private key only) failed: %s", err.message);
+    json = cjose_jwk_to_json(jwk, true, &err);
+    ck_assert(NULL != json);
+    ck_assert(NULL != strstr(json, x));
+    ck_assert(NULL != strstr(json, d));
+    cjose_get_dealloc()(json);
+    cjose_jwk_release(jwk);
+
+    // public key only: there is no private key to export
+    spec.d = NULL;
+    spec.dlen = 0;
+    spec.x = x_raw;
+    spec.xlen = x_len;
+    jwk = cjose_jwk_create_OKP_spec(&spec, &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_create_OKP_spec (public key only) failed: %s", err.message);
+    ck_assert(keysize == cjose_jwk_get_keysize(jwk, &err));
+    json = cjose_jwk_to_json(jwk, true, &err);
+    ck_assert(NULL != json);
+    ck_assert(NULL != strstr(json, x));
+    ck_assert(NULL == strstr(json, "\"d\""));
+    cjose_get_dealloc()(json);
+    cjose_jwk_release(jwk);
+
+    // a public key that does not belong to the private key is rejected
+    spec.d = d_raw;
+    spec.dlen = d_len;
+    x_raw[0] ^= 0x01;
+    ck_assert(NULL == cjose_jwk_create_OKP_spec(&spec, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    x_raw[0] ^= 0x01;
+
+    // the raw keys must have the fixed size of the curve
+    spec.xlen = x_len - 1;
+    ck_assert(NULL == cjose_jwk_create_OKP_spec(&spec, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    spec.xlen = x_len;
+    spec.dlen = d_len + 1;
+    ck_assert(NULL == cjose_jwk_create_OKP_spec(&spec, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+
+    cjose_get_dealloc()(d_raw);
+    cjose_get_dealloc()(x_raw);
+}
+
+// RFC 8037 appendix A.1
+const char *OKP_ED25519_d = "nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A";
+const char *OKP_ED25519_x = "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo";
+START_TEST(test_cjose_jwk_create_OKP_Ed25519_spec)
+{
+    _test_cjose_jwk_create_OKP_spec(CJOSE_JWK_OKP_ED25519, 256, OKP_ED25519_d, OKP_ED25519_x);
+}
+END_TEST
+
+// 57 octets each
+const char *OKP_ED448_d = "TN58WZuh-iWvRvIW-O6sXHjLBTL78bG030WeJZ2I2-ArR8exchehxoA5TXr-3Skuw1qagrV6mjdm";
+const char *OKP_ED448_x = "EwEiD2H04mq1APe4WwLHGWFqURrhfJsXvHQdYAyuOUJQ0wV2DTzOswRxeZbpt-JDdZuTS-7XTaUA";
+START_TEST(test_cjose_jwk_create_OKP_Ed448_spec)
+{
+    _test_cjose_jwk_create_OKP_spec(CJOSE_JWK_OKP_ED448, 456, OKP_ED448_d, OKP_ED448_x);
+}
+END_TEST
+
+// RFC 7748 section 6.1, Alice's key pair
+const char *OKP_X25519_d = "dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo";
+const char *OKP_X25519_x = "hSDwCYkwp1R0i33ctD73Wg2_Og0mOBr066SpjqqbTmo";
+START_TEST(test_cjose_jwk_create_OKP_X25519_spec)
+{
+    _test_cjose_jwk_create_OKP_spec(CJOSE_JWK_OKP_X25519, 256, OKP_X25519_d, OKP_X25519_x);
+}
+END_TEST
+
+// 56 octets each
+const char *OKP_X448_d = "NGzQX14aLsf-miiSLTWW4WmsrbmOY-HKsOeEqjz2vv8kXtVDfbhFP8EYQiNRMuOA8rS1POt5Zok";
+const char *OKP_X448_x = "IMAYVtBqDw96wW7CvvFmpjixDv5MNiHmLSmjjcyf50sLZLuyWZ4OkJRqwqPL_7e06Ny-z7Gsr20";
+START_TEST(test_cjose_jwk_create_OKP_X448_spec)
+{
+    _test_cjose_jwk_create_OKP_spec(CJOSE_JWK_OKP_X448, 448, OKP_X448_d, OKP_X448_x);
+}
+END_TEST
+
+START_TEST(test_cjose_jwk_create_OKP_spec_invalid)
+{
+    cjose_err err;
+    cjose_jwk_okp_keyspec spec;
+    uint8_t *x_raw = NULL;
+    size_t x_len = 0;
+
+    ck_assert(NULL == cjose_jwk_create_OKP_spec(NULL, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+
+    // neither a private nor a public key
+    memset(&spec, 0, sizeof(cjose_jwk_okp_keyspec));
+    spec.crv = CJOSE_JWK_OKP_ED25519;
+    ck_assert(NULL == cjose_jwk_create_OKP_spec(&spec, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+
+    // an invalid curve
+    ck_assert(cjose_base64url_decode(OKP_ED25519_x, strlen(OKP_ED25519_x), &x_raw, &x_len, &err));
+    spec.crv = CJOSE_JWK_OKP_INVALID;
+    spec.x = x_raw;
+    spec.xlen = x_len;
+    ck_assert(NULL == cjose_jwk_create_OKP_spec(&spec, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    cjose_get_dealloc()(x_raw);
+}
+END_TEST
+
+START_TEST(test_cjose_jwk_create_OKP_random)
+{
+    cjose_err err;
+    static const struct
+    {
+        cjose_jwk_okp_curve crv;
+        size_t keysize;
+        const char *crv_json;
+    } curves[] = { { CJOSE_JWK_OKP_ED25519, 256, "\"crv\":\"Ed25519\"" },
+                   { CJOSE_JWK_OKP_ED448, 456, "\"crv\":\"Ed448\"" },
+                   { CJOSE_JWK_OKP_X25519, 256, "\"crv\":\"X25519\"" },
+                   { CJOSE_JWK_OKP_X448, 448, "\"crv\":\"X448\"" } };
+
+    for (size_t i = 0; i < sizeof(curves) / sizeof(curves[0]); i++)
+    {
+        cjose_jwk_t *jwk = cjose_jwk_create_OKP_random(curves[i].crv, &err);
+        ck_assert_msg(NULL != jwk, "cjose_jwk_create_OKP_random failed: %s", err.message);
+        ck_assert(1 == jwk->retained);
+        ck_assert(CJOSE_JWK_KTY_OKP == jwk->kty);
+        ck_assert(curves[i].keysize == jwk->keysize);
+        ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
+        ck_assert(NULL != jwk->keydata);
+        ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+        ck_assert(curves[i].crv == cjose_jwk_OKP_get_curve(jwk, &err));
+
+        char *json = cjose_jwk_to_json(jwk, true, &err);
+        ck_assert(NULL != json);
+        ck_assert(NULL != strstr(json, "\"kty\":\"OKP\""));
+        ck_assert(NULL != strstr(json, curves[i].crv_json));
+        ck_assert(NULL != strstr(json, "\"x\":"));
+        ck_assert(NULL != strstr(json, "\"d\":"));
+        cjose_get_dealloc()(json);
+
+        cjose_jwk_release(jwk);
+    }
+
+    // an invalid curve is rejected
+    ck_assert(NULL == cjose_jwk_create_OKP_random(CJOSE_JWK_OKP_INVALID, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+}
+END_TEST
+
+START_TEST(test_cjose_jwk_OKP_get_curve_invalid)
+{
+    cjose_err err;
+
+    ck_assert(CJOSE_JWK_OKP_INVALID == cjose_jwk_OKP_get_curve(NULL, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+
+    // not an OKP key
+    cjose_jwk_t *jwk = cjose_jwk_create_EC_random(CJOSE_JWK_EC_P_256, &err);
+    ck_assert(NULL != jwk);
+    ck_assert(CJOSE_JWK_OKP_INVALID == cjose_jwk_OKP_get_curve(jwk, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    cjose_jwk_release(jwk);
+}
+END_TEST
+#endif // CJOSE_OPENSSL_111X
+
 START_TEST(test_cjose_jwk_retain_release)
 {
     cjose_err err;
@@ -501,6 +715,12 @@ START_TEST(test_cjose_jwk_get_kty)
     jwk = cjose_jwk_create_EC_random(CJOSE_JWK_EC_P_256, &err);
     ck_assert(CJOSE_JWK_KTY_EC == cjose_jwk_get_kty(jwk, &err));
     cjose_jwk_release(jwk);
+
+#if defined(CJOSE_OPENSSL_111X)
+    jwk = cjose_jwk_create_OKP_random(CJOSE_JWK_OKP_ED25519, &err);
+    ck_assert(CJOSE_JWK_KTY_OKP == cjose_jwk_get_kty(jwk, &err));
+    cjose_jwk_release(jwk);
+#endif
 }
 END_TEST
 
@@ -635,6 +855,172 @@ START_TEST(test_cjose_jwk_to_json_rsa)
     cjose_jwk_release(jwk);
 }
 END_TEST
+
+#if defined(CJOSE_OPENSSL_111X)
+START_TEST(test_cjose_jwk_to_json_okp)
+{
+    cjose_err err;
+    cjose_jwk_t *jwk = NULL;
+    cjose_jwk_okp_keyspec spec;
+
+    memset(&spec, 0, sizeof(cjose_jwk_okp_keyspec));
+    spec.crv = CJOSE_JWK_OKP_ED25519;
+    cjose_base64url_decode(OKP_ED25519_d, strlen(OKP_ED25519_d), &spec.d, &spec.dlen, &err);
+    cjose_base64url_decode(OKP_ED25519_x, strlen(OKP_ED25519_x), &spec.x, &spec.xlen, &err);
+
+    jwk = cjose_jwk_create_OKP_spec(&spec, &err);
+    cjose_get_dealloc()(spec.d);
+    cjose_get_dealloc()(spec.x);
+    ck_assert(NULL != jwk);
+
+    char *json;
+    json = cjose_jwk_to_json(jwk, false, &err);
+    ck_assert(NULL != json);
+    ck_assert_str_eq("{\"kty\":\"OKP\",\"crv\":\"Ed25519\""
+                     ",\"x\":\"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo\"}",
+                     json);
+    free(json);
+
+    json = cjose_jwk_to_json(jwk, true, &err);
+    ck_assert(NULL != json);
+    ck_assert_str_eq("{\"kty\":\"OKP\",\"crv\":\"Ed25519\""
+                     ",\"x\":\"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo\""
+                     ",\"d\":\"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A\"}",
+                     json);
+    free(json);
+
+    cjose_jwk_release(jwk);
+}
+END_TEST
+
+START_TEST(test_cjose_jwk_OKP_import_export)
+{
+    cjose_err err;
+    cjose_jwk_t *jwk = NULL;
+    char *jwk_str = NULL;
+    json_t *left_json = NULL, *right_json = NULL;
+    const char *attrs[] = { "kty", "crv", "x", "d", "kid", NULL };
+
+    // RFC 8037 appendix A.1 (private key), with a kid
+    static const char *JWK_PRIV = "{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"kid\":\"ed25519-1\","
+                                  "\"d\":\"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A\","
+                                  "\"x\":\"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo\"}";
+    jwk = cjose_jwk_import(JWK_PRIV, strlen(JWK_PRIV), &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
+    ck_assert(CJOSE_JWK_KTY_OKP == cjose_jwk_get_kty(jwk, &err));
+    ck_assert(CJOSE_JWK_OKP_ED25519 == cjose_jwk_OKP_get_curve(jwk, &err));
+    ck_assert(256 == cjose_jwk_get_keysize(jwk, &err));
+    ck_assert_str_eq("ed25519-1", cjose_jwk_get_kid(jwk, &err));
+
+    // the private export carries all attributes
+    left_json = json_loads(JWK_PRIV, 0, NULL);
+    ck_assert(NULL != left_json);
+    jwk_str = cjose_jwk_to_json(jwk, true, &err);
+    ck_assert(NULL != jwk_str);
+    right_json = json_loads(jwk_str, 0, NULL);
+    ck_assert(NULL != right_json);
+    ck_assert_msg(_match_string_attrs(left_json, right_json, attrs), "private export does not match: %s", jwk_str);
+    json_decref(right_json);
+    free(jwk_str);
+
+    // the public export leaves out d
+    jwk_str = cjose_jwk_to_json(jwk, false, &err);
+    ck_assert(NULL != jwk_str);
+    ck_assert(NULL == strstr(jwk_str, "\"d\""));
+    right_json = json_loads(jwk_str, 0, NULL);
+    ck_assert(NULL != right_json);
+    json_object_del(left_json, "d");
+    ck_assert_msg(_match_string_attrs(left_json, right_json, attrs), "public export does not match: %s", jwk_str);
+    json_decref(right_json);
+    json_decref(left_json);
+    free(jwk_str);
+    cjose_jwk_release(jwk);
+
+    // RFC 8037 appendix A.2 (public key): the private export has no d either
+    static const char *JWK_PUB = "{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":\"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo\"}";
+    jwk = cjose_jwk_import(JWK_PUB, strlen(JWK_PUB), &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
+    jwk_str = cjose_jwk_to_json(jwk, true, &err);
+    ck_assert(NULL != jwk_str);
+    ck_assert_str_eq(JWK_PUB, jwk_str);
+    free(jwk_str);
+    cjose_jwk_release(jwk);
+
+    // RFC 8037 appendix A.6: an X25519 public key
+    static const char *JWK_X25519 = "{\"kty\":\"OKP\",\"crv\":\"X25519\",\"kid\":\"Bob\","
+                                    "\"x\":\"3p7bfXt9wbTTW2HC7OQ1Nz-DQ8hbeGdNrfx-FG-IK08\"}";
+    jwk = cjose_jwk_import(JWK_X25519, strlen(JWK_X25519), &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
+    ck_assert(CJOSE_JWK_OKP_X25519 == cjose_jwk_OKP_get_curve(jwk, &err));
+    ck_assert(256 == cjose_jwk_get_keysize(jwk, &err));
+    ck_assert_str_eq("Bob", cjose_jwk_get_kid(jwk, &err));
+    cjose_jwk_release(jwk);
+
+    // the Ed448 and X448 curves
+    static const char *JWK_ED448 = "{\"kty\":\"OKP\",\"crv\":\"Ed448\","
+                                   "\"d\":\"TN58WZuh-iWvRvIW-O6sXHjLBTL78bG030WeJZ2I2-ArR8exchehxoA5TXr-3Skuw1qagrV6mjdm\","
+                                   "\"x\":\"EwEiD2H04mq1APe4WwLHGWFqURrhfJsXvHQdYAyuOUJQ0wV2DTzOswRxeZbpt-JDdZuTS-7XTaUA\"}";
+    jwk = cjose_jwk_import(JWK_ED448, strlen(JWK_ED448), &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
+    ck_assert(CJOSE_JWK_OKP_ED448 == cjose_jwk_OKP_get_curve(jwk, &err));
+    ck_assert(456 == cjose_jwk_get_keysize(jwk, &err));
+    cjose_jwk_release(jwk);
+
+    static const char *JWK_X448 = "{\"kty\":\"OKP\",\"crv\":\"X448\","
+                                  "\"d\":\"NGzQX14aLsf-miiSLTWW4WmsrbmOY-HKsOeEqjz2vv8kXtVDfbhFP8EYQiNRMuOA8rS1POt5Zok\","
+                                  "\"x\":\"IMAYVtBqDw96wW7CvvFmpjixDv5MNiHmLSmjjcyf50sLZLuyWZ4OkJRqwqPL_7e06Ny-z7Gsr20\"}";
+    jwk = cjose_jwk_import(JWK_X448, strlen(JWK_X448), &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
+    ck_assert(CJOSE_JWK_OKP_X448 == cjose_jwk_OKP_get_curve(jwk, &err));
+    ck_assert(448 == cjose_jwk_get_keysize(jwk, &err));
+    cjose_jwk_release(jwk);
+}
+END_TEST
+
+START_TEST(test_cjose_jwk_OKP_import_invalid)
+{
+    cjose_err err;
+
+    static const char *JWK_BAD[]
+        = { // missing crv
+            "{\"kty\":\"OKP\",\"x\":\"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo\"}",
+            // an EC curve is not an OKP curve
+            "{\"kty\":\"OKP\",\"crv\":\"P-256\",\"x\":\"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo\"}",
+            // neither x nor d
+            "{\"kty\":\"OKP\",\"crv\":\"Ed25519\"}",
+            // x one octet short
+            "{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":\"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHUR\"}",
+            // x of the Ed448 size for an Ed25519 key
+            "{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":"
+            "\"EwEiD2H04mq1APe4WwLHGWFqURrhfJsXvHQdYAyuOUJQ0wV2DTzOswRxeZbpt-JDdZuTS-7XTaUA\"}",
+            // d one octet long
+            "{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"d\":\"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2AA\"}",
+            // x is not base64url
+            "{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":\"!!!!\"}",
+            // x is REQUIRED (RFC 8037 section 2): d alone, even though the public key could be derived from it
+            "{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"d\":\"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A\"}",
+            // ... and an empty x is not a public key either
+            "{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":\"\",\"d\":\"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A\"}",
+            // an empty d is not a private key: d MUST NOT be present for a public key (RFC 8037 section 2)
+            "{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":\"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo\",\"d\":\"\"}",
+            // ... nor is a d that is not a string
+            "{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":\"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo\",\"d\":null}",
+            // x does not belong to d (it is the public key of another key pair)
+            "{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"d\":\"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A\","
+            "\"x\":\"I6xXpbmh5iLUVx0wy2XvVKVRQYLnx72lPpnEAdwT82I\"}",
+            NULL
+          };
+
+    for (int i = 0; NULL != JWK_BAD[i]; ++i)
+    {
+        cjose_jwk_t *jwk = cjose_jwk_import(JWK_BAD[i], strlen(JWK_BAD[i]), &err);
+        ck_assert_msg(NULL == jwk, "cjose_jwk_import accepted invalid OKP JWK %d: %s", i, JWK_BAD[i]);
+        ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "cjose_jwk_import returned wrong err.code for JWK %d (%u:%s)", i, err.code,
+                      err.message);
+    }
+}
+END_TEST
+#endif // CJOSE_OPENSSL_111X
 
 START_TEST(test_cjose_jwk_import_json_valid)
 {
@@ -1591,11 +1977,25 @@ Suite *cjose_jwk_suite(void)
     tcase_add_test(tc_jwk, test_cjose_jwk_create_oct_spec);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_oct_random);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_oct_random_inval);
+#if defined(CJOSE_OPENSSL_111X)
+    tcase_add_test(tc_jwk, test_cjose_jwk_create_OKP_Ed25519_spec);
+    tcase_add_test(tc_jwk, test_cjose_jwk_create_OKP_Ed448_spec);
+    tcase_add_test(tc_jwk, test_cjose_jwk_create_OKP_X25519_spec);
+    tcase_add_test(tc_jwk, test_cjose_jwk_create_OKP_X448_spec);
+    tcase_add_test(tc_jwk, test_cjose_jwk_create_OKP_spec_invalid);
+    tcase_add_test(tc_jwk, test_cjose_jwk_create_OKP_random);
+    tcase_add_test(tc_jwk, test_cjose_jwk_OKP_get_curve_invalid);
+#endif
     tcase_add_test(tc_jwk, test_cjose_jwk_retain_release);
     tcase_add_test(tc_jwk, test_cjose_jwk_get_kty);
     tcase_add_test(tc_jwk, test_cjose_jwk_to_json_oct);
     tcase_add_test(tc_jwk, test_cjose_jwk_to_json_ec);
     tcase_add_test(tc_jwk, test_cjose_jwk_to_json_rsa);
+#if defined(CJOSE_OPENSSL_111X)
+    tcase_add_test(tc_jwk, test_cjose_jwk_to_json_okp);
+    tcase_add_test(tc_jwk, test_cjose_jwk_OKP_import_export);
+    tcase_add_test(tc_jwk, test_cjose_jwk_OKP_import_invalid);
+#endif
     tcase_add_test(tc_jwk, test_cjose_jwk_import_json_valid);
     tcase_add_test(tc_jwk, test_cjose_jwk_import_json_invalid);
     tcase_add_test(tc_jwk, test_cjose_jwk_import_valid);

--- a/test/check_jws.c
+++ b/test/check_jws.c
@@ -11,6 +11,7 @@
 #include <jansson.h>
 #include "include/jwk_int.h"
 #include "include/jws_int.h"
+#include "include/util_int.h"
 #include <openssl/rand.h>
 
 // a JWK to be re-used for unit tests
@@ -60,6 +61,23 @@ static const char *JWK_COMMON_EC_SECP_256K1 = "{ \"kty\":\"EC\","
                                               "\"y\":\"36uMVGM7hnw-N6GnjFcihWE3SkrhMLzzLCdPMXPEXlA\","
                                               "\"d\":\"rhYFsBPF9q3-uZThy7B3c4LDF_8wnozFUAEm5LLC4Zw\" }";
 
+#if defined(CJOSE_OPENSSL_111X)
+// RFC 8037 appendix A.1: an Ed25519 key pair
+static const char *JWK_COMMON_OKP_ED25519 = "{\"kty\":\"OKP\",\"crv\":\"Ed25519\","
+                                            "\"d\":\"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A\","
+                                            "\"x\":\"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo\"}";
+
+// an Ed448 key pair
+static const char *JWK_COMMON_OKP_ED448 = "{\"kty\":\"OKP\",\"crv\":\"Ed448\","
+                                          "\"d\":\"oGPIKJFtuoGB5jlVOAndK8d9MtZcYu-1Kh4ISCqNpy2tw8NbVtNVgUHzzkSx0WaFkqQHalP3fiul\","
+                                          "\"x\":\"j531A8-05AW0GGOnvpQyiDrC3eBrHW9w1Q8YjhYZiHtBn6czxQjpluO5_sZ_xEUpQxbtW0TRjvUA\"}";
+
+// RFC 7748 section 6.1: Alice's X25519 key pair, a key agreement key that must not sign
+static const char *JWK_COMMON_OKP_X25519 = "{\"kty\":\"OKP\",\"crv\":\"X25519\","
+                                           "\"d\":\"dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo\","
+                                           "\"x\":\"hSDwCYkwp1R0i33ctD73Wg2_Og0mOBr066SpjqqbTmo\"}";
+#endif
+
 // a JWS encrypted with the above JWK_COMMON key
 static const char *JWS_COMMON
     = "eyAiYWxnIjogIlBTMjU2IiB9."
@@ -91,6 +109,12 @@ static const char *_self_get_jwk_by_alg(const char *alg)
     if ((strcmp(alg, CJOSE_HDR_ALG_ES256) == 0) || (strcmp(alg, CJOSE_HDR_ALG_ES384) == 0)
         || (strcmp(alg, CJOSE_HDR_ALG_ES512) == 0))
         return JWK_COMMON_EC;
+#if defined(CJOSE_OPENSSL_111X)
+    if (strcmp(alg, CJOSE_HDR_ALG_ED25519) == 0)
+        return JWK_COMMON_OKP_ED25519;
+    if (strcmp(alg, CJOSE_HDR_ALG_ED448) == 0)
+        return JWK_COMMON_OKP_ED448;
+#endif
     return JWK_COMMON;
 }
 
@@ -178,6 +202,10 @@ static void _self_sign_self_verify_all_algs(const uint8_t *plain, size_t plain_l
     _self_sign_self_verify(plain, plain_len, CJOSE_HDR_ALG_ES256K, err);
     _self_sign_self_verify(plain, plain_len, CJOSE_HDR_ALG_ES384, err);
     _self_sign_self_verify(plain, plain_len, CJOSE_HDR_ALG_ES512, err);
+#if defined(CJOSE_OPENSSL_111X)
+    _self_sign_self_verify(plain, plain_len, CJOSE_HDR_ALG_ED25519, err);
+    _self_sign_self_verify(plain, plain_len, CJOSE_HDR_ALG_ED448, err);
+#endif
 }
 
 START_TEST(test_cjose_jws_self_sign_self_verify)
@@ -253,6 +281,308 @@ START_TEST(test_cjose_jws_es256k_rejects_wrong_curve)
     cjose_jwk_release(p256);
 }
 END_TEST
+
+#if defined(CJOSE_OPENSSL_111X)
+// RFC 9864 fully-specified {"alg":"Ed25519"} over the RFC 8037 appendix A.4
+// payload "Example of Ed25519 signing" with the RFC 8037 appendix A.1 key; the
+// (deterministic) signature was produced with "openssl pkeyutl -sign -rawin"
+static const char *JWS_ED25519 = "eyJhbGciOiJFZDI1NTE5In0."
+                                 "RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc."
+                                 "UxhIYLHGg39NVCLpQAVD_UcfOmnGSCzLFZoXYkLiIbFccmOb_qObsgjzLKsfJw-4NlccUgvYrEHrRbNV0HcZAQ";
+static const uint8_t PLAINTEXT_ED25519[] = "Example of Ed25519 signing";
+
+// RFC 8037 appendix A.2: the public half of the appendix A.1 key
+static const char *JWK_RFC8037_A2 = "{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":\"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo\"}";
+
+// an Ed448 key pair and the RFC 9864 fully-specified {"alg":"Ed448"} over the
+// same payload with it, signed with "openssl pkeyutl -sign -rawin" as well
+static const char *JWK_ED448 = "{\"kty\":\"OKP\",\"crv\":\"Ed448\","
+                               "\"d\":\"TN58WZuh-iWvRvIW-O6sXHjLBTL78bG030WeJZ2I2-ArR8exchehxoA5TXr-3Skuw1qagrV6mjdm\","
+                               "\"x\":\"EwEiD2H04mq1APe4WwLHGWFqURrhfJsXvHQdYAyuOUJQ0wV2DTzOswRxeZbpt-JDdZuTS-7XTaUA\"}";
+// the public half of the Ed448 key pair
+static const char *JWK_ED448_PUB
+    = "{\"kty\":\"OKP\",\"crv\":\"Ed448\",\"x\":\"EwEiD2H04mq1APe4WwLHGWFqURrhfJsXvHQdYAyuOUJQ0wV2DTzOswRxeZbpt-JDdZuTS-7XTaUA\"}";
+static const char *JWS_ED448 = "eyJhbGciOiJFZDQ0OCJ9."
+                               "RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc."
+                               "lNW705OHs6eVsLWubNgE_MYb5ouwmCDM5yTit2oNcvbL2e4oBiOQG1y7cJAd57uNIKMWFw-8CFWAZ1QFn7Jnc8__MYvyFL6P"
+                               "VgNIx0ZCvFfaUkfL7Fee10JdLcEzHMlap_ydB8cpxwAgf4OlsA2tljcA";
+
+START_TEST(test_cjose_jws_verify_ed25519)
+{
+    cjose_err err;
+
+    cjose_jwk_t *jwk = cjose_jwk_import(JWK_RFC8037_A2, strlen(JWK_RFC8037_A2), &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
+
+    cjose_jws_t *jws_ok = cjose_jws_import(JWS_ED25519, strlen(JWS_ED25519), &err);
+    ck_assert_msg(NULL != jws_ok, "cjose_jws_import failed: %s", err.message);
+    ck_assert_msg(cjose_jws_verify(jws_ok, jwk, &err), "cjose_jws_verify failed: %s", err.message);
+
+    uint8_t *plain = NULL;
+    size_t plain_len = 0;
+    ck_assert(cjose_jws_get_plaintext(jws_ok, &plain, &plain_len, &err));
+    ck_assert_int_eq(sizeof(PLAINTEXT_ED25519) - 1, plain_len);
+    ck_assert(0 == memcmp(PLAINTEXT_ED25519, plain, plain_len));
+
+    // verifying the same JWS again (as a loop over candidate keys does) must work too
+    ck_assert_msg(cjose_jws_verify(jws_ok, jwk, &err), "second cjose_jws_verify failed: %s", err.message);
+    cjose_jws_release(jws_ok);
+
+    // tampered signature
+    static const char *JWS_TAMPERED_SIG = "eyJhbGciOiJFZDI1NTE5In0."
+                                          "RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc."
+                                          "UxhIYLHGg39NVCLpQAVD_UcfOmnGSCzLFZoXYkLiIbFccmOb_qObsgjzLKsfJw-4NlccUgvYrEHrRbNV0HcZAg";
+    cjose_jws_t *jws_ts = cjose_jws_import(JWS_TAMPERED_SIG, strlen(JWS_TAMPERED_SIG), &err);
+    ck_assert_msg(NULL != jws_ts, "cjose_jws_import failed: %s", err.message);
+    ck_assert_msg(!cjose_jws_verify(jws_ts, jwk, &err), "cjose_jws_verify succeeded with tampered signature");
+    ck_assert_int_eq(CJOSE_ERR_CRYPTO, err.code);
+    cjose_jws_release(jws_ts);
+
+    // tampered content ("Example of tampered Ed25519 signing")
+    static const char *JWS_TAMPERED_CONTENT
+        = "eyJhbGciOiJFZDI1NTE5In0."
+          "RXhhbXBsZSBvZiB0YW1wZXJlZCBFZDI1NTE5IHNpZ25pbmc."
+          "UxhIYLHGg39NVCLpQAVD_UcfOmnGSCzLFZoXYkLiIbFccmOb_qObsgjzLKsfJw-4NlccUgvYrEHrRbNV0HcZAQ";
+    cjose_jws_t *jws_tc = cjose_jws_import(JWS_TAMPERED_CONTENT, strlen(JWS_TAMPERED_CONTENT), &err);
+    ck_assert_msg(NULL != jws_tc, "cjose_jws_import failed: %s", err.message);
+    ck_assert_msg(!cjose_jws_verify(jws_tc, jwk, &err), "cjose_jws_verify succeeded with tampered content");
+    ck_assert_int_eq(CJOSE_ERR_CRYPTO, err.code);
+    cjose_jws_release(jws_tc);
+
+    cjose_jwk_release(jwk);
+}
+END_TEST
+
+static void _sign_and_compare(const char *s_jwk, const char *alg, const uint8_t *plain, size_t plain_len, const char *expected)
+{
+    cjose_err err;
+
+    cjose_jwk_t *jwk = cjose_jwk_import(s_jwk, strlen(s_jwk), &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
+
+    cjose_header_t *hdr = cjose_header_new(&err);
+    ck_assert(NULL != hdr);
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, alg, &err));
+
+    // sign: an EdDSA signature is deterministic (RFC 8032), so the JWS must
+    // match the reference exactly
+    cjose_jws_t *jws = cjose_jws_sign(jwk, hdr, plain, plain_len, &err);
+    ck_assert_msg(NULL != jws, "cjose_jws_sign [%s] failed: %s", alg, err.message);
+    ck_assert(hdr == cjose_jws_get_protected(jws));
+    const char *compact = NULL;
+    ck_assert(cjose_jws_export(jws, &compact, &err));
+    ck_assert_str_eq(expected, compact);
+    cjose_jws_release(jws);
+
+    // verify the reference
+    jws = cjose_jws_import(expected, strlen(expected), &err);
+    ck_assert_msg(NULL != jws, "cjose_jws_import failed: %s", err.message);
+    ck_assert_msg(cjose_jws_verify(jws, jwk, &err), "cjose_jws_verify [%s] failed: %s", alg, err.message);
+    uint8_t *plain2 = NULL;
+    size_t plain2_len = 0;
+    ck_assert(cjose_jws_get_plaintext(jws, &plain2, &plain2_len, &err));
+    ck_assert_int_eq(plain_len, plain2_len);
+    ck_assert(0 == memcmp(plain, plain2, plain_len));
+    cjose_jws_release(jws);
+
+    cjose_header_release(hdr);
+    cjose_jwk_release(jwk);
+}
+
+START_TEST(test_cjose_jws_sign_ed25519)
+{
+    _sign_and_compare(JWK_COMMON_OKP_ED25519, CJOSE_HDR_ALG_ED25519, PLAINTEXT_ED25519, sizeof(PLAINTEXT_ED25519) - 1, JWS_ED25519);
+
+    // a second reference: {"alg":"Ed25519"} over "{}" with another key
+    static const char *JWK = "{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"d\":\"VoU6Pm8SOjz8ummuRPsvoJQOPI3cjsdMfUhf2AAEc7s\","
+                             "\"x\":\"l11mBSuP-XxI0KoSG7YEWRp4GWm7dKMOPkItJy2tlMM\"}";
+    static const char *JWS
+        = "eyJhbGciOiJFZDI1NTE5In0.e30.xyg2LTblm75KbLFJtROZRhEgAFJdlqH9bhx8a9LO1yvLxNLhO9fLqnFuU3ojOdbObr8bsubPkPqUfZlPkGHXCQ";
+    _sign_and_compare(JWK, CJOSE_HDR_ALG_ED25519, (const uint8_t *)"{}", 2, JWS);
+}
+END_TEST
+
+START_TEST(test_cjose_jws_sign_verify_ed448)
+{
+    _sign_and_compare(JWK_ED448, CJOSE_HDR_ALG_ED448, PLAINTEXT_ED25519, sizeof(PLAINTEXT_ED25519) - 1, JWS_ED448);
+}
+END_TEST
+
+START_TEST(test_cjose_jws_ed25519_rejects_wrong_key)
+{
+    cjose_err err;
+    static const uint8_t plain[] = "test";
+
+    cjose_jwk_t *ed25519 = cjose_jwk_import(JWK_COMMON_OKP_ED25519, strlen(JWK_COMMON_OKP_ED25519), &err);
+    cjose_jwk_t *ed448 = cjose_jwk_import(JWK_COMMON_OKP_ED448, strlen(JWK_COMMON_OKP_ED448), &err);
+    cjose_jwk_t *x25519 = cjose_jwk_import(JWK_COMMON_OKP_X25519, strlen(JWK_COMMON_OKP_X25519), &err);
+    cjose_jwk_t *ec = cjose_jwk_import(JWK_COMMON_EC, strlen(JWK_COMMON_EC), &err);
+    cjose_jwk_t *pub = cjose_jwk_import(JWK_RFC8037_A2, strlen(JWK_RFC8037_A2), &err);
+    ck_assert(NULL != ed25519 && NULL != ed448 && NULL != x25519 && NULL != ec && NULL != pub);
+
+    cjose_header_t *hdr = cjose_header_new(&err);
+    ck_assert(NULL != hdr);
+
+    const struct
+    {
+        const char *alg;
+        cjose_jwk_t *jwk;
+    } bad[] = {
+        { CJOSE_HDR_ALG_ED25519, ec },     // Ed25519 takes an OKP key
+        { CJOSE_HDR_ALG_ED25519, x25519 }, // ... of the Ed25519 curve, not a key agreement key (RFC 8037 section 3.1)
+        { CJOSE_HDR_ALG_ED25519, ed448 },  // ... and not an Ed448 key (RFC 9864)
+        { CJOSE_HDR_ALG_ED448, ed25519 },  // Ed448 takes an Ed448 key
+        { CJOSE_HDR_ALG_ED448, x25519 },   { CJOSE_HDR_ALG_ES256, ed25519 }, // an OKP key does not serve the ECDSA family
+    };
+    for (size_t i = 0; i < sizeof(bad) / sizeof(bad[0]); i++)
+    {
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, bad[i].alg, &err));
+        cjose_jws_t *jws = cjose_jws_sign(bad[i].jwk, hdr, plain, sizeof(plain) - 1, &err);
+        ck_assert_msg(NULL == jws, "cjose_jws_sign [%s] accepted a key of the wrong type (case %zu)", bad[i].alg, i);
+        ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    }
+
+    // signing needs the private key: the library refuses a public-only key
+    // itself, since OpenSSL 1.1.1 and 3.0.0 to 3.0.7 sign with the missing
+    // private key instead of failing (3.0.8 added the guard)
+    cjose_jwk_t *ed448_pub = cjose_jwk_import(JWK_ED448_PUB, strlen(JWK_ED448_PUB), &err);
+    ck_assert(NULL != ed448_pub);
+    const struct
+    {
+        const char *alg;
+        cjose_jwk_t *jwk;
+    } pub_only[] = { { CJOSE_HDR_ALG_ED25519, pub }, { CJOSE_HDR_ALG_ED448, ed448_pub } };
+    cjose_jws_t *jws = NULL;
+    for (size_t i = 0; i < sizeof(pub_only) / sizeof(pub_only[0]); i++)
+    {
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, pub_only[i].alg, &err));
+        jws = cjose_jws_sign(pub_only[i].jwk, hdr, plain, sizeof(plain) - 1, &err);
+        ck_assert_msg(NULL == jws, "cjose_jws_sign [%s] succeeded with a public key", pub_only[i].alg);
+        ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    }
+
+    // verification rejects the wrong key types and curves as well
+    jws = cjose_jws_import(JWS_ED25519, strlen(JWS_ED25519), &err);
+    ck_assert(NULL != jws);
+    ck_assert(!cjose_jws_verify(jws, ec, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    ck_assert(!cjose_jws_verify(jws, x25519, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    ck_assert(!cjose_jws_verify(jws, ed448, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    cjose_jws_release(jws);
+
+    jws = cjose_jws_import(JWS_ED448, strlen(JWS_ED448), &err);
+    ck_assert(NULL != jws);
+    ck_assert(!cjose_jws_verify(jws, ed25519, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    ck_assert(!cjose_jws_verify(jws, x25519, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    cjose_jws_release(jws);
+
+    cjose_header_release(hdr);
+    cjose_jwk_release(ed448_pub);
+    cjose_jwk_release(pub);
+    cjose_jwk_release(ec);
+    cjose_jwk_release(x25519);
+    cjose_jwk_release(ed448);
+    cjose_jwk_release(ed25519);
+}
+END_TEST
+
+START_TEST(test_cjose_jws_eddsa_deprecated)
+{
+    cjose_err err;
+
+    // RFC 9864 deprecates the polymorphic "EdDSA" identifier of RFC 8037 in
+    // favour of Ed25519 and Ed448, so it is not supported: the RFC 8037
+    // appendix A.4 JWS does not even import ...
+    static const char *JWS_RFC8037_A4 = "eyJhbGciOiJFZERTQSJ9."
+                                        "RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc."
+                                        "hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt9g7sVvpAr_MuM0KAg";
+    ck_assert(NULL == cjose_jws_import(JWS_RFC8037_A4, strlen(JWS_RFC8037_A4), &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+
+    // ... and nothing can be signed with it
+    cjose_jwk_t *jwk = cjose_jwk_import(JWK_COMMON_OKP_ED25519, strlen(JWK_COMMON_OKP_ED25519), &err);
+    ck_assert(NULL != jwk);
+    cjose_header_t *hdr = cjose_header_new(&err);
+    ck_assert(NULL != hdr);
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, "EdDSA", &err));
+    ck_assert(NULL == cjose_jws_sign(jwk, hdr, PLAINTEXT_ED25519, sizeof(PLAINTEXT_ED25519) - 1, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+
+    cjose_header_release(hdr);
+    cjose_jwk_release(jwk);
+}
+END_TEST
+
+START_TEST(test_cjose_jws_verify_ed25519_sig_bad_length)
+{
+    cjose_err err;
+
+    // an Ed25519 signature is exactly 64 octets (RFC 8032 section 5.1.6)
+    cjose_jwk_t *jwk = cjose_jwk_import(JWK_RFC8037_A2, strlen(JWK_RFC8037_A2), &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
+
+    // split the compact serialization into the signing input (header.payload.)
+    // and the base64url-encoded signature
+    const char *last_dot = strrchr(JWS_ED25519, '.');
+    ck_assert(NULL != last_dot);
+    size_t prefix_len = (last_dot - JWS_ED25519) + 1; // include the trailing '.'
+    const char *sig_b64u = last_dot + 1;
+
+    // recover the raw 64-octet signature
+    uint8_t *sig_raw = NULL;
+    size_t sig_raw_len = 0;
+    ck_assert(cjose_base64url_decode(sig_b64u, strlen(sig_b64u), &sig_raw, &sig_raw_len, &err));
+    ck_assert_int_eq(64, sig_raw_len);
+
+    // an over-length (65) and an under-length (63) signature must be rejected
+    // up front with CJOSE_ERR_INVALID_ARG
+    size_t bad_lens[] = { sig_raw_len + 1, sig_raw_len - 1 };
+    for (size_t i = 0; i < sizeof(bad_lens) / sizeof(bad_lens[0]); i++)
+    {
+        size_t bad_len = bad_lens[i];
+
+        uint8_t *bad_raw = (uint8_t *)cjose_get_alloc()(bad_len);
+        ck_assert(NULL != bad_raw);
+        memcpy(bad_raw, sig_raw, (bad_len < sig_raw_len) ? bad_len : sig_raw_len);
+        if (bad_len > sig_raw_len)
+        {
+            bad_raw[sig_raw_len] = 0x00; // append a trailing octet
+        }
+
+        char *bad_sig_b64u = NULL;
+        size_t bad_sig_b64u_len = 0;
+        ck_assert(cjose_base64url_encode(bad_raw, bad_len, &bad_sig_b64u, &bad_sig_b64u_len, &err));
+
+        // assemble header.payload. + tampered signature
+        size_t cser_len = prefix_len + bad_sig_b64u_len;
+        char *cser = (char *)cjose_get_alloc()(cser_len + 1);
+        ck_assert(NULL != cser);
+        memcpy(cser, JWS_ED25519, prefix_len);
+        memcpy(cser + prefix_len, bad_sig_b64u, bad_sig_b64u_len);
+        cser[cser_len] = '\0';
+
+        cjose_jws_t *jws_bad = cjose_jws_import(cser, cser_len, &err);
+        ck_assert_msg(NULL != jws_bad, "cjose_jws_import failed for bad-length sig: %s", err.message);
+
+        ck_assert_msg(!cjose_jws_verify(jws_bad, jwk, &err), "cjose_jws_verify accepted a %lu-octet Ed25519 signature",
+                      (unsigned long)bad_len);
+        ck_assert_msg(err.code == CJOSE_ERR_INVALID_ARG, "expected CJOSE_ERR_INVALID_ARG, got (%i:%s)", err.code, err.message);
+
+        cjose_jws_release(jws_bad);
+        cjose_get_dealloc()(cser);
+        cjose_get_dealloc()(bad_sig_b64u);
+        cjose_get_dealloc()(bad_raw);
+    }
+
+    cjose_get_dealloc()(sig_raw);
+    cjose_jwk_release(jwk);
+}
+END_TEST
+#endif // CJOSE_OPENSSL_111X
 
 START_TEST(test_cjose_jws_self_sign_self_verify_short)
 {
@@ -1234,6 +1564,14 @@ Suite *cjose_jws_suite(void)
     tcase_add_test(tc_jws, test_cjose_jws_verify_ec256);
     tcase_add_test(tc_jws, test_cjose_jws_verify_es256k);
     tcase_add_test(tc_jws, test_cjose_jws_es256k_rejects_wrong_curve);
+#if defined(CJOSE_OPENSSL_111X)
+    tcase_add_test(tc_jws, test_cjose_jws_verify_ed25519);
+    tcase_add_test(tc_jws, test_cjose_jws_sign_ed25519);
+    tcase_add_test(tc_jws, test_cjose_jws_sign_verify_ed448);
+    tcase_add_test(tc_jws, test_cjose_jws_ed25519_rejects_wrong_key);
+    tcase_add_test(tc_jws, test_cjose_jws_eddsa_deprecated);
+    tcase_add_test(tc_jws, test_cjose_jws_verify_ed25519_sig_bad_length);
+#endif
     tcase_add_test(tc_jws, test_cjose_jws_sign_with_bad_header);
     tcase_add_test(tc_jws, test_cjose_jws_sign_with_bad_key);
     tcase_add_test(tc_jws, test_cjose_jws_sign_hmac_with_non_oct_key);


### PR DESCRIPTION
## Summary

Two commits, ported from the `version-1.0.x` branch of OpenIDC/cjose and reworked for master:

1. **jwk: add the Octet Key Pair (OKP) key type of RFC 8037.** `"kty":"OKP"` JWKs holding a raw Ed25519 or Ed448 signature key (RFC 8032) or an X25519 or X448 key agreement key (RFC 7748). New public API: `cjose_jwk_okp_curve`, `cjose_jwk_okp_keyspec`, `cjose_jwk_create_OKP_random()`, `cjose_jwk_create_OKP_spec()` and `cjose_jwk_OKP_get_curve()`, added to the three export lists; `cjose_jwk_import()` and `cjose_jwk_to_json()` handle the new type.
2. **jws: add the Ed25519 and Ed448 signing algorithms of RFC 9864.** The fully-specified EdDSA identifiers over OKP keys: `CJOSE_HDR_ALG_ED25519` and `CJOSE_HDR_ALG_ED448`.

## Design notes

- **No `"EdDSA"`.** RFC 9864 sets the JOSE implementation requirements of the polymorphic `"EdDSA"` identifier of RFC 8037 to Deprecated in favour of `Ed25519` and `Ed448`, so it is deliberately not supported: a JWS carrying it does not import and nothing can be signed with it (`test_cjose_jws_eddsa_deprecated`). Accepting it anyway, for interoperability with existing deployments, would be a three-line change in `_cjose_jws_validate_hdr()` and `_cjose_jws_validate_okp_key()`.
- **Key/algorithm binding.** Each identifier only accepts a key of its own curve, X25519/X448 keys are refused for signing (RFC 8037 section 3.1), an OKP key is refused for the other families, and a signature must have the fixed size of the curve (64 or 114 octets) before it is handed to OpenSSL, like the existing ECDSA `2 * coordlen` check.
- **PureEdDSA.** There is no pre-hash, so the digest step keeps the signing input `B64U(HEADER).B64U(DATA)` and signing/verification use the one-shot `EVP_DigestSign()` / `EVP_DigestVerify()`. The digest step frees a previous digest first so `cjose_jws_verify()` can be called repeatedly on one JWS with different candidate keys.
- **Key import.** `x` is required (RFC 8037 section 2) and `d`, when present, must be a non-empty string; both must have the fixed size of the curve, and when `d` is given `x` must be the public key that belongs to it (the 1.0.x code accepted mismatched pairs). A lone `d` is only accepted by `cjose_jwk_create_OKP_spec()`, which derives the public key. The decoded `d` is wiped after use like the other private key material.
- **Signing needs the private key.** `cjose_jws_sign()` refuses a public-only OKP key with `CJOSE_ERR_INVALID_ARG` before calling OpenSSL: OpenSSL 1.1.1 and 3.0.0 through 3.0.7 sign with the missing private key and crash instead of failing (3.0.8 added the guard), which is what the review found; #170 adds those releases to CI.
- **OpenSSL.** The 1.0.x code used the OpenSSL 3 `OSSL_PARAM` API; this port uses the OpenSSL 1.1.1 raw key API (`EVP_PKEY_new_raw_private_key()` & co.) and gates everything on a new `CJOSE_OPENSSL_111X` macro next to `CJOSE_OPENSSL_11X`, since master still declares OpenSSL 1.0.1 as its minimum. With an older OpenSSL the library still builds, the OKP functions fail with `CJOSE_ERR_INVALID_ARG`, the two identifiers are unknown, and the new tests are compiled out; verified with the gate forced off.
- **Public headers stay OpenSSL-free** (#166): the curve enum uses the literal NID values, like the EC enum.
- **Header constants** are macro-only, following the `ES256K` precedent in #167.

## Tests

- `check_jwk`: create/spec/random for all four curves, private-only and public-only specs, mismatched `x`/`d`, wrong sizes, JSON export, import/export round trips with the RFC 8037 appendix A.1/A.2/A.6 keys and the RFC 7748 X25519 vectors, invalid JWKs (including `d` without `x`, empty `x`, empty or non-string `d`).
- `check_jws`: self sign/verify for `Ed25519` and `Ed448` in the existing loops; fixed vectors (EdDSA signatures are deterministic; cross-checked with `openssl pkeyutl -sign -rawin`); tampered signature and content; wrong key type or curve for sign and verify; signing with a public-only Ed25519 or Ed448 key; `"EdDSA"` refused; 63 and 65 octet signatures refused.

Verified locally with `-Wall -Werror`, the full `check_cjose` run, valgrind on the `jwk` and `jws` suites, the `clang-format` target (no diff) and doxygen. Each commit builds and passes on its own.

Rebased onto #168, merging the two "Unreleased" CHANGELOG sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

