### PR TITLE
Restore Check 0.9.4 compatibility with a ck_assert shim in the test header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,7 @@ if(CJOSE_BUILD_TESTS)
     if(NOT _cjose_check_target)
         find_package(PkgConfig QUIET)
         if(PkgConfig_FOUND)
-            pkg_check_modules(CHECK QUIET check>=0.12.0 IMPORTED_TARGET)
+            pkg_check_modules(CHECK QUIET check>=0.9.4 IMPORTED_TARGET)
             if(TARGET PkgConfig::CHECK)
                 set(_cjose_check_target PkgConfig::CHECK)
             endif()
@@ -360,7 +360,7 @@ if(CJOSE_BUILD_TESTS)
     endif()
 
     if(NOT _cjose_check_target)
-        message(WARNING "Check (>= 0.12.0) not found; skipping cjose unit tests.")
+        message(WARNING "Check (>= 0.9.4) not found; skipping cjose unit tests.")
     else()
         set(CJOSE_TEST_SOURCES
             test/check_cjose.c

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Implementation of JOSE for C/C++
 
 * CMake (>= 3.22)
 * A C99 compiler (LLVM/Clang >= 5.1, GCC >= 4.5 or MSVC >= 14)
-* Check (>= 0.12.0) - unit testing (e.g. check-devel)
+* Check (>= 0.9.4) - unit testing (e.g. check-devel)
 * Doxygen (>= 1.8) - API documentation (optional)
 * clang-format - source formatting (optional)
 

--- a/configure
+++ b/configure
@@ -14700,19 +14700,19 @@ $as_echo "no" >&6; }
 fi
 
 pkg_failed=no
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for check >= 0.12.0" >&5
-$as_echo_n "checking for check >= 0.12.0... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for check >= 0.9.4" >&5
+$as_echo_n "checking for check >= 0.9.4... " >&6; }
 
 if test -n "$CHECK_CFLAGS"; then
     pkg_cv_CHECK_CFLAGS="$CHECK_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"check >= 0.12.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "check >= 0.12.0") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"check >= 0.9.4\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "check >= 0.9.4") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_CHECK_CFLAGS=`$PKG_CONFIG --cflags "check >= 0.12.0" 2>/dev/null`
+  pkg_cv_CHECK_CFLAGS=`$PKG_CONFIG --cflags "check >= 0.9.4" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -14724,12 +14724,12 @@ if test -n "$CHECK_LIBS"; then
     pkg_cv_CHECK_LIBS="$CHECK_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"check >= 0.12.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "check >= 0.12.0") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"check >= 0.9.4\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "check >= 0.9.4") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_CHECK_LIBS=`$PKG_CONFIG --libs "check >= 0.12.0" 2>/dev/null`
+  pkg_cv_CHECK_LIBS=`$PKG_CONFIG --libs "check >= 0.9.4" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -14750,9 +14750,9 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        CHECK_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "check >= 0.12.0" 2>&1`
+	        CHECK_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "check >= 0.9.4" 2>&1`
         else
-	        CHECK_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "check >= 0.12.0" 2>&1`
+	        CHECK_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "check >= 0.9.4" 2>&1`
         fi
 	# Put the nasty error message in config.log where it belongs
 	echo "$CHECK_PKG_ERRORS" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ DX_INIT_DOXYGEN([CJOSE], [Doxyfile], [doc])
 
 ### Check for CHECK
 PKG_CHECK_MODULES([CHECK],
-        [check >= 0.12.0],
+        [check >= 0.9.4],
         [have_check="yes"],
         [   AC_MSG_WARN([Check not found; cannot run unit tests!]);
             [have_check="no"]

--- a/test/check_cjose.h
+++ b/test/check_cjose.h
@@ -7,6 +7,29 @@
 
 #include <check.h>
 
+// Check 0.9.4 and 0.9.5 predate the ck_assert family, which 0.9.6 added on
+// top of fail_unless, and ck_assert_uint_eq only arrived in 0.9.10; these
+// are the definitions of the release that introduced each, with the integer
+// comparisons printing intmax_t and uintmax_t like later releases do
+#ifndef ck_assert_msg
+#define ck_assert_msg fail_unless
+#endif
+#ifndef ck_assert
+#define ck_assert(C) ck_assert_msg(C, NULL)
+#endif
+#ifndef ck_assert_int_eq
+#define ck_assert_int_eq(X, Y) \
+    ck_assert_msg((X) == (Y), "Assertion '" #X "==" #Y "' failed: " #X "==%jd, " #Y "==%jd", (intmax_t)(X), (intmax_t)(Y))
+#endif
+#ifndef ck_assert_uint_eq
+#define ck_assert_uint_eq(X, Y) \
+    ck_assert_msg((X) == (Y), "Assertion '" #X "==" #Y "' failed: " #X "==%ju, " #Y "==%ju", (uintmax_t)(X), (uintmax_t)(Y))
+#endif
+#ifndef ck_assert_str_eq
+#define ck_assert_str_eq(X, Y) \
+    ck_assert_msg(0 == strcmp(X, Y), "Assertion '" #X "==" #Y "' failed: " #X "==\"%s\", " #Y "==\"%s\"", X, Y)
+#endif
+
 #ifdef _WIN32
 #define random rand
 #endif


### PR DESCRIPTION
Follow-up to #159 and #161, which fixed #91 by raising the documented Check minimum from 0.9.4 to 0.12.0. This restores the 0.9.4 minimum for the 0.x line without touching the test code: the tests never actually built against 0.9.4, because the `ck_assert` family (`ck_assert`, `ck_assert_msg`, `ck_assert_int_eq`, `ck_assert_str_eq`) only arrived in Check 0.9.6, and `ck_assert_uint_eq` in 0.9.10.

Two commits:

1. **test: provide the ck_assert family for Check 0.9.4 to 0.9.9.** Twenty-three lines in `check_cjose.h` under `#ifndef`: `ck_assert_msg`, `ck_assert`, `ck_assert_int_eq`, `ck_assert_uint_eq` and `ck_assert_str_eq`, using the definitions of the release that introduced each (the integer comparisons print `intmax_t` / `uintmax_t` like later releases do). The `.c` test files are unchanged.
2. **Revert the 0.12.0 bump** in README.md, CMakeLists.txt, configure.ac and configure, with the rationale in the commit message. RHEL 6 ships Check 0.9.8, RHEL 7 0.9.9, RHEL 8 0.12.0 (checked against the CentOS vault and Rocky mirrors); 1.0.x remains free to raise the floor.

Changes since the first revision, per the review: `ck_assert_uint_eq` joined the shim so the two uses in `check_concatkdf.c` stay as they are (the #159 cherry-pick is gone), and the separate Check CI workflow is dropped; the regular CI keeps compiling and running the tests against the distro's Check.

Verified locally against Check 0.9.4, 0.9.6, 0.9.8, 0.9.9, 0.9.10, 0.9.14, 0.10.0, 0.12.0 and 0.15.2: all pass. Without commit 1, 0.9.4 fails to build on `ck_assert_str_eq` and 0.9.6 to 0.9.9 on `ck_assert_uint_eq`; with it, a deliberately wrong expected length reports `Assertion 'otherinfoLen==24' failed: otherinfoLen==23, 24==24` on 0.9.4 and 0.9.9 exactly as 0.9.10 does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
