### PR TITLE
Use cjose_const_memcmp for every constant-time comparison

### DIFF
--- a/src/jwe.c
+++ b/src/jwe.c
@@ -15,7 +15,6 @@
 #include <assert.h>
 #include <limits.h>
 #include <openssl/rand.h>
-#include <openssl/crypto.h>
 #include <openssl/rsa.h>
 #include <openssl/evp.h>
 #include <openssl/aes.h>
@@ -1759,7 +1758,7 @@ static bool _cjose_jwe_decrypt_dat_aes_cbc(cjose_jwe_t *jwe, cjose_err *err)
     }
 
     // compare the provided Authentication Tag against our calculation
-    if ((tag_len != jwe->enc_auth_tag.raw_len) || (CRYPTO_memcmp(tag, jwe->enc_auth_tag.raw, tag_len) != 0))
+    if ((tag_len != jwe->enc_auth_tag.raw_len) || (cjose_const_memcmp(tag, jwe->enc_auth_tag.raw, tag_len) != 0))
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         return false;

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -17,7 +17,6 @@
 #include <stdio.h>
 
 #include <openssl/bn.h>
-#include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/obj_mac.h>
 #include <openssl/rand.h>
@@ -1495,7 +1494,7 @@ cjose_jwk_t *cjose_jwk_create_OKP_spec(const cjose_jwk_okp_keyspec *spec, cjose_
                 CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
                 goto create_OKP_spec_cleanup;
             }
-            if (0 != CRYPTO_memcmp(pub, spec->x, numsize))
+            if (0 != cjose_const_memcmp(pub, spec->x, numsize))
             {
                 CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
                 goto create_OKP_spec_cleanup;

--- a/src/jws.c
+++ b/src/jws.c
@@ -13,7 +13,6 @@
 
 #include <string.h>
 #include <openssl/evp.h>
-#include <openssl/crypto.h>
 #include <openssl/rsa.h>
 #include <openssl/bn.h>
 #include <openssl/err.h>
@@ -1071,7 +1070,7 @@ static bool _cjose_jws_verify_sig_hmac_sha(cjose_jws_t *jws, const cjose_jwk_t *
     diff |= (jws->sig_len != jws->dig_len);
     if (jws->sig_len == jws->dig_len)
     {
-        diff |= CRYPTO_memcmp(jws->dig, jws->sig, jws->dig_len);
+        diff |= cjose_const_memcmp(jws->dig, jws->sig, jws->dig_len);
     }
     if (diff != 0)
     {

--- a/test/check_util.c
+++ b/test/check_util.c
@@ -251,6 +251,28 @@ START_TEST(test_cjose_err_message)
 }
 END_TEST
 
+START_TEST(test_cjose_const_memcmp)
+{
+    static const uint8_t a[] = { 0x00, 0x01, 0x02, 0x03, 0xff };
+    static const uint8_t b[] = { 0x00, 0x01, 0x02, 0x03, 0xff };
+    static const uint8_t first[] = { 0x80, 0x01, 0x02, 0x03, 0xff };
+    static const uint8_t last[] = { 0x00, 0x01, 0x02, 0x03, 0xfe };
+
+    // equal: zero, like memcmp
+    ck_assert_int_eq(0, cjose_const_memcmp(a, b, sizeof(a)));
+    ck_assert_int_eq(0, cjose_const_memcmp(a, a, sizeof(a)));
+
+    // a difference anywhere: non-zero, but only equal/unequal, not ordered
+    ck_assert(0 != cjose_const_memcmp(a, first, sizeof(a)));
+    ck_assert(0 != cjose_const_memcmp(a, last, sizeof(a)));
+    ck_assert(0 != cjose_const_memcmp(last, a, sizeof(a)));
+
+    // only the first size octets take part
+    ck_assert_int_eq(0, cjose_const_memcmp(a, last, sizeof(a) - 1));
+    ck_assert_int_eq(0, cjose_const_memcmp(a, first, 0));
+}
+END_TEST
+
 Suite *cjose_util_suite(void)
 {
     Suite *suite = suite_create("util");
@@ -259,6 +281,7 @@ Suite *cjose_util_suite(void)
     tcase_add_test(tc_util, test_cjose_set_allocators);
     tcase_add_test(tc_util, test_cjose_set_allocators_ex);
     tcase_add_test(tc_util, test_cjose_err_message);
+    tcase_add_test(tc_util, test_cjose_const_memcmp);
     suite_add_tcase(suite, tc_util);
 
     return suite;


### PR DESCRIPTION
The library compares secrets under two names: the AES-CBC-HMAC authentication tag (`jwe.c`), the HMAC signature (`jws.c`) and the OKP public key derived from `d` (`jwk.c`) call OpenSSL's `CRYPTO_memcmp` directly, while the multi-recipient CEK check (`jwe.c`) goes through `cjose_const_memcmp`, the public wrapper around the same function. Both are constant time; this is about having one way to do it.

Route all four through `cjose_const_memcmp`, so `CRYPTO_memcmp` and the `<openssl/crypto.h>` include are confined to `util.c`, and give the wrapper the unit test it never had: equal inputs, a difference in the first and in the last octet, and only the first `size` octets taking part. No behaviour change.

Verified with the full `check_cjose` run and valgrind on the `util` suite, the `clang-format` target (no diff), and builds against OpenSSL 1.0.1u, 1.1.1w, 3.0.7 and 4.0.2 in addition to the system 3.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
