### PR TITLE
Eight consistency fixes across the library, tests, build and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,52 @@
 
 Implementation of JOSE for C/C++
 
+## Supported Algorithms ##
+
+JWS signing algorithms (`alg`):
+
+| Identifier | Algorithm | Requires |
+|------------|-----------|----------|
+| `HS256`, `HS384`, `HS512` | HMAC with SHA-2 | |
+| `RS256`, `RS384`, `RS512` | RSASSA-PKCS1-v1_5 with SHA-2 | |
+| `PS256`, `PS384`, `PS512` | RSASSA-PSS with SHA-2 | |
+| `ES256`, `ES384`, `ES512` | ECDSA with P-256, P-384 and P-521 | |
+| `ES256K` | ECDSA with secp256k1 | OpenSSL built with `secp256k1` |
+| `Ed25519`, `Ed448` | EdDSA (RFC 9864) | OpenSSL 1.1.1 |
+
+The polymorphic `EdDSA` identifier of RFC 8037, deprecated by RFC 9864, and
+`none` are not accepted.
+
+JWE key management algorithms (`alg`):
+
+| Identifier | Algorithm | Requires |
+|------------|-----------|----------|
+| `RSA-OAEP` | RSAES OAEP | |
+| `RSA1_5` | RSAES-PKCS1-v1_5 | build option `CJOSE_ENABLE_RSA1_5` |
+| `A128KW`, `A192KW`, `A256KW` | AES Key Wrap | |
+| `dir` | direct use of a shared symmetric key | |
+| `ECDH-ES` | ECDH-ES direct key agreement | |
+| `ECDH-ES+A128KW`, `ECDH-ES+A192KW`, `ECDH-ES+A256KW` | ECDH-ES with AES Key Wrap | |
+
+JWE content encryption algorithms (`enc`):
+
+| Identifier | Algorithm |
+|------------|-----------|
+| `A128GCM`, `A192GCM`, `A256GCM` | AES GCM |
+| `A128CBC-HS256`, `A192CBC-HS384`, `A256CBC-HS512` | AES CBC with HMAC SHA-2 |
+
+JWK key types (`kty`):
+
+| Identifier | Keys | Requires |
+|------------|------|----------|
+| `RSA` | RSA | |
+| `EC` | `P-256`, `P-384`, `P-521`, `secp256k1` | `secp256k1`: OpenSSL built with it |
+| `oct` | symmetric | |
+| `OKP` | `Ed25519`, `Ed448`, `X25519`, `X448` | OpenSSL 1.1.1 |
+
+JWEs can be produced and consumed in both the compact and the JSON
+serialization, with one or more recipients.
+
 ## Prerequisites ##
 
 *MAC OS X* All of the prerequisites can be installed via [brew](http://brew.sh/).

--- a/include/cjose/cjose.h
+++ b/include/cjose/cjose.h
@@ -1,3 +1,10 @@
+/*
+ * Copyrights
+ *
+ * Portions created or assigned to Cisco Systems, Inc. are
+ * Copyright (c) 2014-2016 Cisco Systems, Inc.  All Rights Reserved.
+ */
+
 /**
  * \file
  * \brief

--- a/src/base64.c
+++ b/src/base64.c
@@ -40,7 +40,8 @@ static const uint8_t TEBAHPLA_B64[]
 
 // internal functions
 
-static inline bool _decode(const char *input, size_t inlen, uint8_t **output, size_t *outlen, bool url, cjose_err *err)
+static inline bool
+_cjose_base64_decode_impl(const char *input, size_t inlen, uint8_t **output, size_t *outlen, bool url, cjose_err *err)
 {
     if ((NULL == input) || (NULL == output) || (NULL == outlen))
     {
@@ -168,7 +169,8 @@ b64_decode_failed:
     return false;
 }
 
-static inline bool _encode(const uint8_t *input, size_t inlen, char **output, size_t *outlen, const char *alphabet, cjose_err *err)
+static inline bool
+_cjose_base64_encode_impl(const uint8_t *input, size_t inlen, char **output, size_t *outlen, const char *alphabet, cjose_err *err)
 {
     if ((inlen > 0 && NULL == input) || (NULL == output) || (NULL == outlen))
     {
@@ -255,18 +257,18 @@ static inline bool _encode(const uint8_t *input, size_t inlen, char **output, si
 
 bool cjose_base64_encode(const uint8_t *input, size_t inlen, char **output, size_t *outlen, cjose_err *err)
 {
-    return _encode(input, inlen, output, outlen, ALPHABET_B64, err);
+    return _cjose_base64_encode_impl(input, inlen, output, outlen, ALPHABET_B64, err);
 }
 bool cjose_base64url_encode(const uint8_t *input, size_t inlen, char **output, size_t *outlen, cjose_err *err)
 {
-    return _encode(input, inlen, output, outlen, ALPHABET_B64U, err);
+    return _cjose_base64_encode_impl(input, inlen, output, outlen, ALPHABET_B64U, err);
 }
 
 bool cjose_base64_decode(const char *input, size_t inlen, uint8_t **output, size_t *outlen, cjose_err *err)
 {
-    return _decode(input, inlen, output, outlen, false, err);
+    return _cjose_base64_decode_impl(input, inlen, output, outlen, false, err);
 }
 bool cjose_base64url_decode(const char *input, size_t inlen, uint8_t **output, size_t *outlen, cjose_err *err)
 {
-    return _decode(input, inlen, output, outlen, true, err);
+    return _cjose_base64_decode_impl(input, inlen, output, outlen, true, err);
 }

--- a/src/concatkdf.c
+++ b/src/concatkdf.c
@@ -20,7 +20,7 @@
 #include <cjose/util.h>
 
 ////////////////////////////////////////////////////////////////////////////////
-static uint8_t *_apply_uint32(const uint32_t value, uint8_t *buffer)
+static uint8_t *_cjose_concatkdf_apply_uint32(const uint32_t value, uint8_t *buffer)
 {
     const uint32_t big_endian_int32 = htonl(value);
 
@@ -28,11 +28,11 @@ static uint8_t *_apply_uint32(const uint32_t value, uint8_t *buffer)
     return buffer + 4;
 }
 
-static uint8_t *_apply_lendata(const uint8_t *data, const size_t len, uint8_t *buffer)
+static uint8_t *_cjose_concatkdf_apply_lendata(const uint8_t *data, const size_t len, uint8_t *buffer)
 {
     uint8_t *ptr = buffer;
 
-    ptr = _apply_uint32(len, ptr);
+    ptr = _cjose_concatkdf_apply_uint32(len, ptr);
     if (0 < len)
     {
         memcpy(ptr, data, len);
@@ -85,11 +85,11 @@ bool cjose_concatkdf_create_otherinfo(
         goto concatkdf_create_otherinfo_finish;
     }
     uint8_t *ptr = buffer;
-    ptr = _apply_lendata((const uint8_t *)alg, algLen, ptr);
-    ptr = _apply_lendata(apu, apuLen, ptr);
-    ptr = _apply_lendata(apv, apvLen, ptr);
+    ptr = _cjose_concatkdf_apply_lendata((const uint8_t *)alg, algLen, ptr);
+    ptr = _cjose_concatkdf_apply_lendata(apu, apuLen, ptr);
+    ptr = _cjose_concatkdf_apply_lendata(apv, apvLen, ptr);
     // final write; the returned (end) pointer is intentionally not stored
-    _apply_uint32(keylen, ptr);
+    _cjose_concatkdf_apply_uint32(keylen, ptr);
 
     *otherinfoLen = bufferLen;
     *otherinfo = buffer;
@@ -134,7 +134,7 @@ uint8_t *cjose_concatkdf_derive(const size_t keylen,
     for (size_t idx = 1; N >= idx; idx++)
     {
         uint8_t counter[4];
-        _apply_uint32((uint32_t)idx, counter);
+        _cjose_concatkdf_apply_uint32((uint32_t)idx, counter);
 
         uint8_t *hash = cjose_get_alloc()(hashlen * sizeof(uint8_t));
         if (NULL == hash)

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -611,6 +611,15 @@ static bool _cjose_jwe_decrypt_ek_dir(_jwe_int_recipient_t *recipient, cjose_jwe
 {
     // do not try and decrypt the ek. that's impossible.
     // instead... only try to realize the truth.  there is no ek.
+    // RFC 7516 section 5.2 step 12: with Direct Encryption the JWE Encrypted
+    // Key must be empty (an empty string may have been allocated for it upon
+    // import, so check the length rather than the pointer)
+    if (0 != recipient->enc_key.raw_len)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
     return jwe->fns.set_cek(jwe, jwk, false, err);
 }
 
@@ -951,6 +960,15 @@ static bool _cjose_jwe_decrypt_ek_ecdh_es(_jwe_int_recipient_t *recipient, cjose
     size_t otherinfo_len = 0;
     uint8_t *derived = NULL;
     bool result = false;
+
+    // RFC 7516 section 5.2 step 12: with Direct Key Agreement the JWE
+    // Encrypted Key must be empty (an empty string may have been allocated
+    // for it upon import, so check the length rather than the pointer)
+    if (0 != recipient->enc_key.raw_len)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
 
     // err is optional in the public API, but the logic below inspects
     // err->code to distinguish an absent EPK header from a real failure;

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -178,7 +178,7 @@ static bool _cjose_convert_to_base64(struct _cjose_jwe_int *jwe, cjose_err *err)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-static size_t _keylen_from_enc(const char *alg)
+static size_t _cjose_jwe_keylen_from_enc(const char *alg)
 {
     size_t keylen = 0;
 
@@ -211,7 +211,7 @@ static size_t _keylen_from_enc(const char *alg)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-static size_t _ivlen_from_enc(const char *enc)
+static size_t _cjose_jwe_ivlen_from_enc(const char *enc)
 {
     size_t ivlen = 0;
 
@@ -914,7 +914,7 @@ static bool _cjose_jwe_encrypt_ek_ecdh_es(_jwe_int_recipient_t *recipient, cjose
     //   * keylen (determined from {enc})
     cjose_header_t *hdr = jwe->hdr;
     const char *algId = cjose_header_get(hdr, CJOSE_HDR_ENC, err);
-    const size_t keylen = _keylen_from_enc(algId) / 8;
+    const size_t keylen = _cjose_jwe_keylen_from_enc(algId) / 8;
 
     if (!cjose_concatkdf_create_otherinfo(algId, keylen * 8, hdr, &otherinfo, &otherinfo_len, err))
     {
@@ -1016,7 +1016,7 @@ static bool _cjose_jwe_decrypt_ek_ecdh_es(_jwe_int_recipient_t *recipient, cjose
     //   * keylen (determined from {enc})
     cjose_header_t *hdr = jwe->hdr;
     const char *algId = cjose_header_get(hdr, CJOSE_HDR_ENC, err);
-    const size_t keylen = _keylen_from_enc(algId) / 8;
+    const size_t keylen = _cjose_jwe_keylen_from_enc(algId) / 8;
 
     if (!cjose_concatkdf_create_otherinfo(algId, keylen * 8, hdr, &otherinfo, &otherinfo_len, err))
     {
@@ -2028,7 +2028,7 @@ cjose_jwe_t *cjose_jwe_encrypt_multi_iv(const cjose_jwe_recipient_t *recipients,
         // algorithm requires; a short buffer would otherwise be over-read by
         // EVP_EncryptInit_ex, which reads a fixed number of IV bytes
         const char *enc = cjose_header_get(protected_header, CJOSE_HDR_ENC, err);
-        if (NULL == enc || iv_len != _ivlen_from_enc(enc))
+        if (NULL == enc || iv_len != _cjose_jwe_ivlen_from_enc(enc))
         {
             CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
             cjose_jwe_release(jwe);

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -2211,6 +2211,7 @@ cjose_jwk_t *cjose_jwk_import(const char *jwk_str, size_t len, cjose_err *err)
     // check params
     if ((NULL == jwk_str) || (0 == len))
     {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return NULL;
     }
 

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -413,13 +413,13 @@ to_json_cleanup:
 //////////////// Octet String ////////////////
 // internal data & functions -- Octet String
 
-static void _oct_free(cjose_jwk_t *jwk);
-static bool _oct_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
-static bool _oct_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
+static void _cjose_jwk_oct_free(cjose_jwk_t *jwk);
+static bool _cjose_jwk_oct_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
+static bool _cjose_jwk_oct_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
 
-static const key_fntable OCT_FNTABLE = { _oct_free, _oct_public_fields, _oct_private_fields };
+static const key_fntable OCT_FNTABLE = { _cjose_jwk_oct_free, _cjose_jwk_oct_public_fields, _cjose_jwk_oct_private_fields };
 
-static cjose_jwk_t *_oct_new(uint8_t *buffer, size_t keysize, cjose_err *err)
+static cjose_jwk_t *_cjose_jwk_oct_new(uint8_t *buffer, size_t keysize, cjose_err *err)
 {
     cjose_jwk_t *jwk = (cjose_jwk_t *)cjose_get_alloc()(sizeof(cjose_jwk_t));
     if (NULL == jwk)
@@ -439,7 +439,7 @@ static cjose_jwk_t *_oct_new(uint8_t *buffer, size_t keysize, cjose_err *err)
     return jwk;
 }
 
-static void _oct_free(cjose_jwk_t *jwk)
+static void _cjose_jwk_oct_free(cjose_jwk_t *jwk)
 {
     uint8_t *buffer = (uint8_t *)jwk->keydata;
     jwk->keydata = NULL;
@@ -450,9 +450,9 @@ static void _oct_free(cjose_jwk_t *jwk)
     cjose_get_dealloc()(jwk);
 }
 
-static bool _oct_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err) { return true; }
+static bool _cjose_jwk_oct_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err) { return true; }
 
-static bool _oct_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
+static bool _cjose_jwk_oct_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
 {
     json_t *field = NULL;
     char *k = NULL;
@@ -506,7 +506,7 @@ cjose_jwk_t *cjose_jwk_create_oct_random(size_t keysize, cjose_err *err)
         goto create_oct_failed;
     }
 
-    jwk = _oct_new(buffer, keysize, err);
+    jwk = _cjose_jwk_oct_new(buffer, keysize, err);
     if (NULL == jwk)
     {
         goto create_oct_failed;
@@ -542,7 +542,7 @@ cjose_jwk_t *cjose_jwk_create_oct_spec(const uint8_t *data, size_t len, cjose_er
     }
     memcpy(buffer, data, len);
 
-    jwk = _oct_new(buffer, len * 8, err);
+    jwk = _cjose_jwk_oct_new(buffer, len * 8, err);
     if (NULL == jwk)
     {
         goto create_oct_failed;
@@ -563,13 +563,13 @@ create_oct_failed:
 //////////////// Elliptic Curve ////////////////
 // internal data & functions -- Elliptic Curve
 
-static void _EC_free(cjose_jwk_t *jwk);
-static bool _EC_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
-static bool _EC_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
+static void _cjose_jwk_EC_free(cjose_jwk_t *jwk);
+static bool _cjose_jwk_EC_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
+static bool _cjose_jwk_EC_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
 
-static const key_fntable EC_FNTABLE = { _EC_free, _EC_public_fields, _EC_private_fields };
+static const key_fntable EC_FNTABLE = { _cjose_jwk_EC_free, _cjose_jwk_EC_public_fields, _cjose_jwk_EC_private_fields };
 
-static inline int _ec_nid_for_curve(cjose_jwk_ec_curve crv)
+static inline int _cjose_jwk_ec_nid_for_curve(cjose_jwk_ec_curve crv)
 {
     switch (crv)
     {
@@ -588,7 +588,7 @@ static inline int _ec_nid_for_curve(cjose_jwk_ec_curve crv)
     return NID_undef;
 }
 
-static inline uint8_t _ec_size_for_curve(cjose_jwk_ec_curve crv, cjose_err *err)
+static inline uint8_t _cjose_jwk_ec_size_for_curve(cjose_jwk_ec_curve crv, cjose_err *err)
 {
     switch (crv)
     {
@@ -607,7 +607,7 @@ static inline uint8_t _ec_size_for_curve(cjose_jwk_ec_curve crv, cjose_err *err)
     return 0;
 }
 
-static inline const char *_ec_name_for_curve(cjose_jwk_ec_curve crv, cjose_err *err)
+static inline const char *_cjose_jwk_ec_name_for_curve(cjose_jwk_ec_curve crv, cjose_err *err)
 {
     switch (crv)
     {
@@ -626,7 +626,7 @@ static inline const char *_ec_name_for_curve(cjose_jwk_ec_curve crv, cjose_err *
     return NULL;
 }
 
-static inline bool _ec_curve_from_name(const char *name, cjose_jwk_ec_curve *crv, cjose_err *err)
+static inline bool _cjose_jwk_ec_curve_from_name(const char *name, cjose_jwk_ec_curve *crv, cjose_err *err)
 {
     bool retval = true;
     if (strncmp(name, CJOSE_JWK_EC_P_256_STR, sizeof(CJOSE_JWK_EC_P_256_STR)) == 0)
@@ -652,7 +652,7 @@ static inline bool _ec_curve_from_name(const char *name, cjose_jwk_ec_curve *crv
     return retval;
 }
 
-static inline bool _kty_from_name(const char *name, cjose_jwk_kty_t *kty, cjose_err *err)
+static inline bool _cjose_jwk_kty_from_name(const char *name, cjose_jwk_kty_t *kty, cjose_err *err)
 {
     bool retval = true;
     if (strncmp(name, CJOSE_JWK_KTY_EC_STR, sizeof(CJOSE_JWK_KTY_EC_STR)) == 0)
@@ -678,7 +678,7 @@ static inline bool _kty_from_name(const char *name, cjose_jwk_kty_t *kty, cjose_
     return retval;
 }
 
-static cjose_jwk_t *_EC_new(cjose_jwk_ec_curve crv, EC_KEY *ec, cjose_err *err)
+static cjose_jwk_t *_cjose_jwk_EC_new(cjose_jwk_ec_curve crv, EC_KEY *ec, cjose_err *err)
 {
     ec_keydata *keydata = cjose_get_alloc()(sizeof(ec_keydata));
     if (!keydata)
@@ -724,7 +724,7 @@ static cjose_jwk_t *_EC_new(cjose_jwk_ec_curve crv, EC_KEY *ec, cjose_err *err)
     return jwk;
 }
 
-static void _EC_free(cjose_jwk_t *jwk)
+static void _cjose_jwk_EC_free(cjose_jwk_t *jwk)
 {
     ec_keydata *keydata = (ec_keydata *)jwk->keydata;
     jwk->keydata = NULL;
@@ -742,7 +742,7 @@ static void _EC_free(cjose_jwk_t *jwk)
     cjose_get_dealloc()(jwk);
 }
 
-static bool _EC_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
+static bool _cjose_jwk_EC_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
 {
     ec_keydata *keydata = (ec_keydata *)jwk->keydata;
     const EC_GROUP *params = NULL;
@@ -755,10 +755,10 @@ static bool _EC_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *e
     bool result = false;
 
     // track expected binary data size
-    uint8_t numsize = _ec_size_for_curve(keydata->crv, err);
+    uint8_t numsize = _cjose_jwk_ec_size_for_curve(keydata->crv, err);
 
     // output the curve
-    field = json_string(_ec_name_for_curve(keydata->crv, err));
+    field = json_string(_cjose_jwk_ec_name_for_curve(keydata->crv, err));
     if (!field)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
@@ -857,7 +857,7 @@ _ec_to_string_cleanup:
     return result;
 }
 
-static bool _EC_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
+static bool _cjose_jwk_EC_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
 {
     ec_keydata *keydata = (ec_keydata *)jwk->keydata;
     const BIGNUM *bnD = EC_KEY_get0_private_key(keydata->key);
@@ -868,7 +868,7 @@ static bool _EC_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *
     bool result = false;
 
     // track expected binary data size
-    uint8_t numsize = _ec_size_for_curve(keydata->crv, err);
+    uint8_t numsize = _cjose_jwk_ec_size_for_curve(keydata->crv, err);
 
     // short circuit if 'd' is NULL or 0
     if (!bnD || BN_is_zero(bnD))
@@ -918,7 +918,7 @@ cjose_jwk_t *cjose_jwk_create_EC_random(cjose_jwk_ec_curve crv, cjose_err *err)
     cjose_jwk_t *jwk = NULL;
     EC_KEY *ec = NULL;
 
-    ec = EC_KEY_new_by_curve_name(_ec_nid_for_curve(crv));
+    ec = EC_KEY_new_by_curve_name(_cjose_jwk_ec_nid_for_curve(crv));
     if (!ec)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -931,7 +931,7 @@ cjose_jwk_t *cjose_jwk_create_EC_random(cjose_jwk_ec_curve crv, cjose_err *err)
         goto create_EC_failed;
     }
 
-    jwk = _EC_new(crv, ec, err);
+    jwk = _cjose_jwk_EC_new(crv, ec, err);
     if (!jwk)
     {
         goto create_EC_failed;
@@ -978,7 +978,7 @@ cjose_jwk_t *cjose_jwk_create_EC_spec(const cjose_jwk_ec_keyspec *spec, cjose_er
         return NULL;
     }
 
-    ec = EC_KEY_new_by_curve_name(_ec_nid_for_curve(spec->crv));
+    ec = EC_KEY_new_by_curve_name(_cjose_jwk_ec_nid_for_curve(spec->crv));
     if (NULL == ec)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1067,7 +1067,7 @@ cjose_jwk_t *cjose_jwk_create_EC_spec(const cjose_jwk_ec_keyspec *spec, cjose_er
         goto create_EC_failed;
     }
 
-    jwk = _EC_new(spec->crv, ec, err);
+    jwk = _cjose_jwk_EC_new(spec->crv, ec, err);
     if (!jwk)
     {
         goto create_EC_failed;
@@ -1135,13 +1135,13 @@ static const char CJOSE_JWK_OKP_ED448_STR[] = "Ed448";
 static const char CJOSE_JWK_OKP_X25519_STR[] = "X25519";
 static const char CJOSE_JWK_OKP_X448_STR[] = "X448";
 
-static void _OKP_free(cjose_jwk_t *jwk);
-static bool _OKP_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
-static bool _OKP_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
+static void _cjose_jwk_OKP_free(cjose_jwk_t *jwk);
+static bool _cjose_jwk_OKP_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
+static bool _cjose_jwk_OKP_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
 
-static const key_fntable OKP_FNTABLE = { _OKP_free, _OKP_public_fields, _OKP_private_fields };
+static const key_fntable OKP_FNTABLE = { _cjose_jwk_OKP_free, _cjose_jwk_OKP_public_fields, _cjose_jwk_OKP_private_fields };
 
-static inline int _okp_nid_for_curve(cjose_jwk_okp_curve crv)
+static inline int _cjose_jwk_okp_nid_for_curve(cjose_jwk_okp_curve crv)
 {
     switch (crv)
     {
@@ -1162,7 +1162,7 @@ static inline int _okp_nid_for_curve(cjose_jwk_okp_curve crv)
 
 // the fixed size of both the raw public key "x" and the raw private key "d"
 // (RFC 8032 sections 5.1.5 and 5.2.5, RFC 7748 section 5)
-static inline size_t _okp_size_for_curve(cjose_jwk_okp_curve crv)
+static inline size_t _cjose_jwk_okp_size_for_curve(cjose_jwk_okp_curve crv)
 {
     switch (crv)
     {
@@ -1181,7 +1181,7 @@ static inline size_t _okp_size_for_curve(cjose_jwk_okp_curve crv)
     return 0;
 }
 
-static inline const char *_okp_name_for_curve(cjose_jwk_okp_curve crv)
+static inline const char *_cjose_jwk_okp_name_for_curve(cjose_jwk_okp_curve crv)
 {
     switch (crv)
     {
@@ -1200,7 +1200,7 @@ static inline const char *_okp_name_for_curve(cjose_jwk_okp_curve crv)
     return NULL;
 }
 
-static inline bool _okp_curve_from_name(const char *name, cjose_jwk_okp_curve *crv)
+static inline bool _cjose_jwk_okp_curve_from_name(const char *name, cjose_jwk_okp_curve *crv)
 {
     bool retval = true;
     if (strncmp(name, CJOSE_JWK_OKP_ED25519_STR, sizeof(CJOSE_JWK_OKP_ED25519_STR)) == 0)
@@ -1226,7 +1226,7 @@ static inline bool _okp_curve_from_name(const char *name, cjose_jwk_okp_curve *c
     return retval;
 }
 
-static cjose_jwk_t *_OKP_new(cjose_jwk_okp_curve crv, EVP_PKEY *pkey, cjose_err *err)
+static cjose_jwk_t *_cjose_jwk_OKP_new(cjose_jwk_okp_curve crv, EVP_PKEY *pkey, cjose_err *err)
 {
     okp_keydata *keydata = cjose_get_alloc()(sizeof(okp_keydata));
     if (!keydata)
@@ -1247,14 +1247,14 @@ static cjose_jwk_t *_OKP_new(cjose_jwk_okp_curve crv, EVP_PKEY *pkey, cjose_err 
     memset(jwk, 0, sizeof(cjose_jwk_t));
     jwk->retained = 1;
     jwk->kty = CJOSE_JWK_KTY_OKP;
-    jwk->keysize = _okp_size_for_curve(crv) * 8;
+    jwk->keysize = _cjose_jwk_okp_size_for_curve(crv) * 8;
     jwk->keydata = keydata;
     jwk->fns = &OKP_FNTABLE;
 
     return jwk;
 }
 
-static void _OKP_free(cjose_jwk_t *jwk)
+static void _cjose_jwk_OKP_free(cjose_jwk_t *jwk)
 {
     okp_keydata *keydata = (okp_keydata *)jwk->keydata;
     jwk->keydata = NULL;
@@ -1268,7 +1268,7 @@ static void _OKP_free(cjose_jwk_t *jwk)
     cjose_get_dealloc()(jwk);
 }
 
-static bool _OKP_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
+static bool _cjose_jwk_OKP_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
 {
     okp_keydata *keydata = (okp_keydata *)jwk->keydata;
     uint8_t *buffer = NULL;
@@ -1278,10 +1278,10 @@ static bool _OKP_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *
     bool result = false;
 
     // the raw public key has the fixed size of the curve
-    size_t numsize = _okp_size_for_curve(keydata->crv);
+    size_t numsize = _cjose_jwk_okp_size_for_curve(keydata->crv);
 
     // output the curve
-    field = json_string(_okp_name_for_curve(keydata->crv));
+    field = json_string(_cjose_jwk_okp_name_for_curve(keydata->crv));
     if (!field)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
@@ -1328,7 +1328,7 @@ _okp_to_string_cleanup:
     return result;
 }
 
-static bool _OKP_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
+static bool _cjose_jwk_OKP_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
 {
     okp_keydata *keydata = (okp_keydata *)jwk->keydata;
     uint8_t *buffer = NULL;
@@ -1340,7 +1340,7 @@ static bool _OKP_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err 
     bool result = false;
 
     // the raw private key has the fixed size of the curve
-    size_t numsize = _okp_size_for_curve(keydata->crv);
+    size_t numsize = _cjose_jwk_okp_size_for_curve(keydata->crv);
 
     buffer = cjose_get_alloc()(numsize);
     if (!buffer)
@@ -1399,7 +1399,7 @@ cjose_jwk_t *cjose_jwk_create_OKP_random(cjose_jwk_okp_curve crv, cjose_err *err
     EVP_PKEY_CTX *ctx = NULL;
     EVP_PKEY *pkey = NULL;
 
-    int nid = _okp_nid_for_curve(crv);
+    int nid = _cjose_jwk_okp_nid_for_curve(crv);
     if (NID_undef == nid)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1418,7 +1418,7 @@ cjose_jwk_t *cjose_jwk_create_OKP_random(cjose_jwk_okp_curve crv, cjose_err *err
         goto create_OKP_random_cleanup;
     }
 
-    jwk = _OKP_new(crv, pkey, err);
+    jwk = _cjose_jwk_OKP_new(crv, pkey, err);
     if (NULL == jwk)
     {
         goto create_OKP_random_cleanup;
@@ -1446,8 +1446,8 @@ cjose_jwk_t *cjose_jwk_create_OKP_spec(const cjose_jwk_okp_keyspec *spec, cjose_
         return NULL;
     }
 
-    int nid = _okp_nid_for_curve(spec->crv);
-    size_t numsize = _okp_size_for_curve(spec->crv);
+    int nid = _cjose_jwk_okp_nid_for_curve(spec->crv);
+    size_t numsize = _cjose_jwk_okp_size_for_curve(spec->crv);
     if (NID_undef == nid || 0 == numsize)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1512,7 +1512,7 @@ cjose_jwk_t *cjose_jwk_create_OKP_spec(const cjose_jwk_okp_keyspec *spec, cjose_
         }
     }
 
-    jwk = _OKP_new(spec->crv, pkey, err);
+    jwk = _cjose_jwk_OKP_new(spec->crv, pkey, err);
     if (NULL == jwk)
     {
         goto create_OKP_spec_cleanup;
@@ -1560,19 +1560,19 @@ cjose_jwk_okp_curve cjose_jwk_OKP_get_curve(const cjose_jwk_t *jwk, cjose_err *e
 //////////////// RSA ////////////////
 // internal data & functions -- RSA
 
-static void _RSA_free(cjose_jwk_t *jwk);
-static bool _RSA_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
-static bool _RSA_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
+static void _cjose_jwk_RSA_free(cjose_jwk_t *jwk);
+static bool _cjose_jwk_RSA_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
+static bool _cjose_jwk_RSA_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err);
 
-static const key_fntable RSA_FNTABLE = { _RSA_free, _RSA_public_fields, _RSA_private_fields };
+static const key_fntable RSA_FNTABLE = { _cjose_jwk_RSA_free, _cjose_jwk_RSA_public_fields, _cjose_jwk_RSA_private_fields };
 
-static inline cjose_jwk_t *_RSA_new(RSA *rsa, cjose_err *err)
+static inline cjose_jwk_t *_cjose_jwk_RSA_new(RSA *rsa, cjose_err *err)
 {
     cjose_jwk_t *jwk = cjose_get_alloc()(sizeof(cjose_jwk_t));
     if (!jwk)
     {
-        // _RSA_new owns rsa on every path; free it here so the callers that
-        // `return _RSA_new(rsa, err)` do not leak it on allocation failure
+        // _cjose_jwk_RSA_new owns rsa on every path; free it here so the callers that
+        // `return _cjose_jwk_RSA_new(rsa, err)` do not leak it on allocation failure
         RSA_free(rsa);
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         return NULL;
@@ -1587,7 +1587,7 @@ static inline cjose_jwk_t *_RSA_new(RSA *rsa, cjose_err *err)
     return jwk;
 }
 
-static void _RSA_free(cjose_jwk_t *jwk)
+static void _cjose_jwk_RSA_free(cjose_jwk_t *jwk)
 {
     RSA *rsa = (RSA *)jwk->keydata;
     jwk->keydata = NULL;
@@ -1598,7 +1598,7 @@ static void _RSA_free(cjose_jwk_t *jwk)
     cjose_get_dealloc()(jwk);
 }
 
-static inline bool _RSA_json_field(BIGNUM *param, const char *name, json_t *json, cjose_err *err)
+static inline bool _cjose_jwk_RSA_json_field(BIGNUM *param, const char *name, json_t *json, cjose_err *err)
 {
     json_t *field = NULL;
     uint8_t *data = NULL;
@@ -1644,18 +1644,18 @@ RSA_json_field_cleanup:
     return result;
 }
 
-static bool _RSA_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
+static bool _cjose_jwk_RSA_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
 {
     RSA *rsa = (RSA *)jwk->keydata;
 
     BIGNUM *rsa_n = NULL, *rsa_e = NULL, *rsa_d = NULL;
     _cjose_jwk_rsa_get(rsa, &rsa_n, &rsa_e, &rsa_d);
 
-    if (!_RSA_json_field(rsa_e, "e", json, err))
+    if (!_cjose_jwk_RSA_json_field(rsa_e, "e", json, err))
     {
         return false;
     }
-    if (!_RSA_json_field(rsa_n, "n", json, err))
+    if (!_cjose_jwk_RSA_json_field(rsa_n, "n", json, err))
     {
         return false;
     }
@@ -1663,7 +1663,7 @@ static bool _RSA_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *
     return true;
 }
 
-static bool _RSA_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
+static bool _cjose_jwk_RSA_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
 {
     RSA *rsa = (RSA *)jwk->keydata;
 
@@ -1676,27 +1676,27 @@ static bool _RSA_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err 
     BIGNUM *rsa_dmp1 = NULL, *rsa_dmq1 = NULL, *rsa_iqmp = NULL;
     _cjose_jwk_rsa_get_crt(rsa, &rsa_dmp1, &rsa_dmq1, &rsa_iqmp);
 
-    if (!_RSA_json_field(rsa_d, "d", json, err))
+    if (!_cjose_jwk_RSA_json_field(rsa_d, "d", json, err))
     {
         return false;
     }
-    if (!_RSA_json_field(rsa_p, "p", json, err))
+    if (!_cjose_jwk_RSA_json_field(rsa_p, "p", json, err))
     {
         return false;
     }
-    if (!_RSA_json_field(rsa_q, "q", json, err))
+    if (!_cjose_jwk_RSA_json_field(rsa_q, "q", json, err))
     {
         return false;
     }
-    if (!_RSA_json_field(rsa_dmp1, "dp", json, err))
+    if (!_cjose_jwk_RSA_json_field(rsa_dmp1, "dp", json, err))
     {
         return false;
     }
-    if (!_RSA_json_field(rsa_dmq1, "dq", json, err))
+    if (!_cjose_jwk_RSA_json_field(rsa_dmq1, "dq", json, err))
     {
         return false;
     }
-    if (!_RSA_json_field(rsa_iqmp, "qi", json, err))
+    if (!_cjose_jwk_RSA_json_field(rsa_iqmp, "qi", json, err))
     {
         return false;
     }
@@ -1746,7 +1746,7 @@ cjose_jwk_t *cjose_jwk_create_RSA_random(size_t keysize, const uint8_t *e, size_
     }
 
     BN_free(bn);
-    return _RSA_new(rsa, err);
+    return _cjose_jwk_RSA_new(rsa, err);
 
 create_RSA_random_failed:
     if (bn)
@@ -1822,7 +1822,7 @@ cjose_jwk_t *cjose_jwk_create_RSA_spec(const cjose_jwk_rsa_keyspec *spec, cjose_
         }
     }
 
-    return _RSA_new(rsa, err);
+    return _cjose_jwk_RSA_new(rsa, err);
 
 create_RSA_spec_failed:
     if (rsa)
@@ -1836,7 +1836,7 @@ create_RSA_spec_failed:
 //////////////// Import ////////////////
 // internal data & functions -- JWK key import
 
-static const char *_get_json_object_string_attribute(json_t *json, const char *key, cjose_err *err)
+static const char *_cjose_jwk_get_json_object_string_attribute(json_t *json, const char *key, cjose_err *err)
 {
     const char *attr_str = NULL;
     json_t *attr_json = json_object_get(json, key);
@@ -1867,11 +1867,11 @@ static const char *_get_json_object_string_attribute(json_t *json, const char *k
  * \returns true  if attribute is either not present or successfully decoded.
  *                false otherwise.
  */
-static bool
-_decode_json_object_base64url_attribute(json_t *jwk_json, const char *key, uint8_t **buffer, size_t *buflen, cjose_err *err)
+static bool _cjose_jwk_decode_json_object_base64url_attribute(
+    json_t *jwk_json, const char *key, uint8_t **buffer, size_t *buflen, cjose_err *err)
 {
     // get the base64url encoded string value of the attribute (if any)
-    const char *str = _get_json_object_string_attribute(jwk_json, key, err);
+    const char *str = _cjose_jwk_get_json_object_string_attribute(jwk_json, key, err);
     if (str == NULL || strlen(str) == 0)
     {
         *buflen = 0;
@@ -1921,7 +1921,7 @@ static cjose_jwk_t *_cjose_jwk_import_EC(json_t *jwk_json, cjose_err *err)
     size_t d_buflen = 0;
 
     // get the value of the crv attribute
-    const char *crv_str = _get_json_object_string_attribute(jwk_json, CJOSE_JWK_CRV_STR, err);
+    const char *crv_str = _cjose_jwk_get_json_object_string_attribute(jwk_json, CJOSE_JWK_CRV_STR, err);
     if (crv_str == NULL)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1930,31 +1930,31 @@ static cjose_jwk_t *_cjose_jwk_import_EC(json_t *jwk_json, cjose_err *err)
 
     // get the curve identifer for the curve named by crv
     cjose_jwk_ec_curve crv;
-    if (!_ec_curve_from_name(crv_str, &crv, err))
+    if (!_cjose_jwk_ec_curve_from_name(crv_str, &crv, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto import_EC_cleanup;
     }
 
     // get the decoded value of the x coordinate
-    x_buflen = (size_t)_ec_size_for_curve(crv, err);
-    if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_X_STR, &x_buffer, &x_buflen, err))
+    x_buflen = (size_t)_cjose_jwk_ec_size_for_curve(crv, err);
+    if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_X_STR, &x_buffer, &x_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto import_EC_cleanup;
     }
 
     // get the decoded value of the y coordinate
-    y_buflen = (size_t)_ec_size_for_curve(crv, err);
-    if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_Y_STR, &y_buffer, &y_buflen, err))
+    y_buflen = (size_t)_cjose_jwk_ec_size_for_curve(crv, err);
+    if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_Y_STR, &y_buffer, &y_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto import_EC_cleanup;
     }
 
     // get the decoded value of the private key d
-    d_buflen = (size_t)_ec_size_for_curve(crv, err);
-    if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_D_STR, &d_buffer, &d_buflen, err))
+    d_buflen = (size_t)_cjose_jwk_ec_size_for_curve(crv, err);
+    if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_D_STR, &d_buffer, &d_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto import_EC_cleanup;
@@ -2013,56 +2013,56 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     size_t qi_buflen = 0;
 
     // get the decoded value of n (buflen = 0 means no particular expected len)
-    if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_N_STR, &n_buffer, &n_buflen, err))
+    if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_N_STR, &n_buffer, &n_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto import_RSA_cleanup;
     }
 
     // get the decoded value of e
-    if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_E_STR, &e_buffer, &e_buflen, err))
+    if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_E_STR, &e_buffer, &e_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto import_RSA_cleanup;
     }
 
     // get the decoded value of d
-    if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_D_STR, &d_buffer, &d_buflen, err))
+    if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_D_STR, &d_buffer, &d_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto import_RSA_cleanup;
     }
 
     // get the decoded value of p
-    if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_P_STR, &p_buffer, &p_buflen, err))
+    if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_P_STR, &p_buffer, &p_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto import_RSA_cleanup;
     }
 
     // get the decoded value of q
-    if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_Q_STR, &q_buffer, &q_buflen, err))
+    if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_Q_STR, &q_buffer, &q_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto import_RSA_cleanup;
     }
 
     // get the decoded value of dp
-    if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_DP_STR, &dp_buffer, &dp_buflen, err))
+    if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_DP_STR, &dp_buffer, &dp_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto import_RSA_cleanup;
     }
 
     // get the decoded value of dq
-    if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_DQ_STR, &dq_buffer, &dq_buflen, err))
+    if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_DQ_STR, &dq_buffer, &dq_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto import_RSA_cleanup;
     }
 
     // get the decoded value of qi
-    if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_QI_STR, &qi_buffer, &qi_buflen, err))
+    if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_QI_STR, &qi_buffer, &qi_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto import_RSA_cleanup;
@@ -2112,7 +2112,7 @@ static cjose_jwk_t *_cjose_jwk_import_oct(json_t *jwk_json, cjose_err *err)
 
     // get the decoded value of k (buflen = 0 means no particular expected len)
     size_t k_buflen = 0;
-    if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_K_STR, &k_buffer, &k_buflen, err))
+    if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_K_STR, &k_buffer, &k_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto import_oct_cleanup;
@@ -2138,7 +2138,7 @@ static cjose_jwk_t *_cjose_jwk_import_OKP(json_t *jwk_json, cjose_err *err)
     size_t d_buflen = 0;
 
     // get the value of the crv attribute
-    const char *crv_str = _get_json_object_string_attribute(jwk_json, CJOSE_JWK_CRV_STR, err);
+    const char *crv_str = _cjose_jwk_get_json_object_string_attribute(jwk_json, CJOSE_JWK_CRV_STR, err);
     if (crv_str == NULL)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -2147,7 +2147,7 @@ static cjose_jwk_t *_cjose_jwk_import_OKP(json_t *jwk_json, cjose_err *err)
 
     // get the curve identifier for the curve named by crv
     cjose_jwk_okp_curve crv;
-    if (!_okp_curve_from_name(crv_str, &crv))
+    if (!_cjose_jwk_okp_curve_from_name(crv_str, &crv))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto import_OKP_cleanup;
@@ -2157,8 +2157,9 @@ static cjose_jwk_t *_cjose_jwk_import_OKP(json_t *jwk_json, cjose_err *err)
     // curve); x is REQUIRED for every OKP key (RFC 8037 section 2), and the
     // decoder treats a missing, empty or non-string attribute alike, so a
     // decoded value must have come out of it
-    x_buflen = _okp_size_for_curve(crv);
-    if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_X_STR, &x_buffer, &x_buflen, err) || NULL == x_buffer)
+    x_buflen = _cjose_jwk_okp_size_for_curve(crv);
+    if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_X_STR, &x_buffer, &x_buflen, err)
+        || NULL == x_buffer)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto import_OKP_cleanup;
@@ -2168,8 +2169,8 @@ static cjose_jwk_t *_cjose_jwk_import_OKP(json_t *jwk_json, cjose_err *err)
     // curve); d is REQUIRED for a private key and MUST NOT be present for a
     // public key (RFC 8037 section 2), so when the attribute is there it must
     // decode to a key of the right size instead of quietly making a public key
-    d_buflen = _okp_size_for_curve(crv);
-    if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_D_STR, &d_buffer, &d_buflen, err)
+    d_buflen = _cjose_jwk_okp_size_for_curve(crv);
+    if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_D_STR, &d_buffer, &d_buflen, err)
         || (NULL != json_object_get(jwk_json, CJOSE_JWK_D_STR) && NULL == d_buffer))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -2248,7 +2249,7 @@ cjose_jwk_t *cjose_jwk_import_json(cjose_header_t *json, cjose_err *err)
     }
 
     // get the string value of the kty attribute of the jwk
-    const char *kty_str = _get_json_object_string_attribute(jwk_json, CJOSE_JWK_KTY_STR, err);
+    const char *kty_str = _cjose_jwk_get_json_object_string_attribute(jwk_json, CJOSE_JWK_KTY_STR, err);
     if (NULL == kty_str)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -2257,7 +2258,7 @@ cjose_jwk_t *cjose_jwk_import_json(cjose_header_t *json, cjose_err *err)
 
     // get kty corresponding to kty_str (kty is required)
     cjose_jwk_kty_t kty;
-    if (!_kty_from_name(kty_str, &kty, err))
+    if (!_cjose_jwk_kty_from_name(kty_str, &kty, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return NULL;
@@ -2293,7 +2294,7 @@ cjose_jwk_t *cjose_jwk_import_json(cjose_header_t *json, cjose_err *err)
     }
 
     // get the value of the kid attribute (kid is optional)
-    const char *kid_str = _get_json_object_string_attribute(jwk_json, CJOSE_JWK_KID_STR, err);
+    const char *kid_str = _cjose_jwk_get_json_object_string_attribute(jwk_json, CJOSE_JWK_KID_STR, err);
     if (kid_str != NULL)
     {
         jwk->kid = _cjose_strndup(kid_str, -1, err);

--- a/src/jws.c
+++ b/src/jws.c
@@ -766,12 +766,14 @@ void cjose_jws_release(cjose_jws_t *jws)
     }
 
     cjose_get_dealloc()(jws->hdr_b64u);
-    cjose_get_dealloc()(jws->dat);
-    cjose_get_dealloc()(jws->dat_b64u);
+    // the payload may be sensitive: wipe it and the copies that embed it,
+    // like the decrypted plaintext of a JWE
+    _cjose_cleanse_dealloc(jws->dat, jws->dat_len);
+    _cjose_cleanse_dealloc(jws->dat_b64u, jws->dat_b64u_len);
     _cjose_cleanse_dealloc(jws->dig, jws->dig_len);
     _cjose_cleanse_dealloc(jws->sig, jws->sig_len);
     cjose_get_dealloc()(jws->sig_b64u);
-    cjose_get_dealloc()(jws->cser);
+    _cjose_cleanse_dealloc(jws->cser, jws->cser_len);
     cjose_get_dealloc()(jws);
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -46,7 +46,7 @@ void cjose_dealloc3_default(void *p, const char *file, int line)
     cjose_get_dealloc()(p);
 }
 
-static void cjose_apply_allocs(void)
+static void _cjose_apply_allocs(void)
 {
     // set upstream
     json_set_alloc_funcs(cjose_get_alloc(), cjose_get_dealloc());
@@ -67,7 +67,7 @@ void cjose_set_alloc_funcs(cjose_alloc_fn_t alloc, cjose_realloc_fn_t realloc, c
     _realloc3 = cjose_realloc3_default;
     _dealloc3 = cjose_dealloc3_default;
 
-    cjose_apply_allocs();
+    _cjose_apply_allocs();
 }
 
 void cjose_set_alloc_ex_funcs(cjose_alloc3_fn_t alloc3, cjose_realloc3_fn_t realloc3, cjose_dealloc3_fn_t dealloc3)
@@ -80,7 +80,7 @@ void cjose_set_alloc_ex_funcs(cjose_alloc3_fn_t alloc3, cjose_realloc3_fn_t real
     _realloc = (NULL != realloc3) ? cjose_realloc_wrapped : NULL;
     _dealloc = (NULL != dealloc3) ? cjose_dealloc_wrapped : NULL;
 
-    cjose_apply_allocs();
+    _cjose_apply_allocs();
 }
 
 cjose_alloc_fn_t cjose_get_alloc(void) { return (!_alloc) ? malloc : _alloc; }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,6 +1,6 @@
 if HAVE_CHECK
 
-AM_CPPFLAGS =-std=gnu99 --pedantic -Wall -g -O2 -I$(top_builddir)/include
+AM_CPPFLAGS =-std=gnu99 --pedantic -Wall -Werror -g -O2 -DOPENSSL_API_COMPAT=0x10100000L -I$(top_builddir)/include
 
 AM_CPPFLAGS += @CHECK_CFLAGS@
 TESTS = check_cjose

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -546,8 +546,9 @@ target_alias = @target_alias@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
-@HAVE_CHECK_TRUE@AM_CPPFLAGS = -std=gnu99 --pedantic -Wall -g -O2 \
-@HAVE_CHECK_TRUE@	-I$(top_builddir)/include @CHECK_CFLAGS@
+@HAVE_CHECK_TRUE@AM_CPPFLAGS = -std=gnu99 --pedantic -Wall -Werror -g -O2 \
+@HAVE_CHECK_TRUE@	-DOPENSSL_API_COMPAT=0x10100000L -I$(top_builddir)/include \
+@HAVE_CHECK_TRUE@	@CHECK_CFLAGS@
 @HAVE_CHECK_TRUE@check_cjose_CFLAGS = @CHECK_CFLAGS@ -I$(top_builddir)/include \
 @HAVE_CHECK_TRUE@                     -I$(top_builddir)/src -I$(top_srcdir)/src
 

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -1849,6 +1849,63 @@ START_TEST(test_cjose_jwe_rsa1_5_disabled)
 END_TEST
 #endif // HAVE_RSA_PKCS1_PADDING
 
+START_TEST(test_cjose_jwe_direct_rejects_encrypted_key)
+{
+    // RFC 7516 section 5.2 step 12: with Direct Encryption ("dir") and Direct
+    // Key Agreement (ECDH-ES) the JWE Encrypted Key must be the empty octet
+    // sequence, like the other key management algorithms check their sizes
+    static const uint8_t plain[] = "test";
+    static const char *bogus_ek = "AAAAAAAAAAAAAAAAAAAAAA"; // 16 octets
+    const struct
+    {
+        const char *alg;
+        const char *enc;
+        const char *jwk;
+    } cases[]
+        = { { CJOSE_HDR_ALG_DIR, CJOSE_HDR_ENC_A128GCM, JWK_OCT_16 }, { CJOSE_HDR_ALG_ECDH_ES, CJOSE_HDR_ENC_A128GCM, JWK_EC } };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++)
+    {
+        cjose_err err;
+        cjose_jwk_t *jwk = cjose_jwk_import(cases[i].jwk, strlen(cases[i].jwk), &err);
+        ck_assert(NULL != jwk);
+        cjose_header_t *hdr = cjose_header_new(&err);
+        ck_assert(NULL != hdr);
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, cases[i].alg, &err));
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, cases[i].enc, &err));
+        cjose_jwe_t *jwe = cjose_jwe_encrypt(jwk, hdr, plain, sizeof(plain) - 1, &err);
+        ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt [%s] failed: %s", cases[i].alg, err.message);
+        char *compact = cjose_jwe_export(jwe, &err);
+        ck_assert(NULL != compact);
+
+        // the second part, the encrypted key, is empty: splice one in
+        const char *dot = strchr(compact, '.');
+        ck_assert(NULL != dot && '.' == dot[1]);
+        size_t prefix_len = dot + 1 - compact;
+        size_t tampered_len = strlen(compact) + strlen(bogus_ek);
+        char *tampered = malloc(tampered_len + 1);
+        ck_assert(NULL != tampered);
+        memcpy(tampered, compact, prefix_len);
+        strcpy(tampered + prefix_len, bogus_ek);
+        strcpy(tampered + prefix_len + strlen(bogus_ek), compact + prefix_len);
+
+        cjose_jwe_t *jwe2 = cjose_jwe_import(tampered, tampered_len, &err);
+        ck_assert_msg(NULL != jwe2, "cjose_jwe_import [%s] failed: %s", cases[i].alg, err.message);
+        size_t out_len = 0;
+        uint8_t *out = cjose_jwe_decrypt(jwe2, jwk, &out_len, &err);
+        ck_assert_msg(NULL == out, "cjose_jwe_decrypt [%s] accepted a non-empty encrypted key", cases[i].alg);
+        ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+
+        cjose_jwe_release(jwe2);
+        free(tampered);
+        cjose_get_dealloc()(compact);
+        cjose_jwe_release(jwe);
+        cjose_header_release(hdr);
+        cjose_jwk_release(jwk);
+    }
+}
+END_TEST
+
 Suite *cjose_jwe_suite(void)
 {
     Suite *suite = suite_create("jwe");
@@ -1882,6 +1939,7 @@ Suite *cjose_jwe_suite(void)
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_rsa_wrong_cek_length);
     tcase_add_test(tc_jwe, test_cjose_jwe_import_json_shared_unprotected);
     tcase_add_test(tc_jwe, test_cjose_jwe_ecdh_es_null_err);
+    tcase_add_test(tc_jwe, test_cjose_jwe_direct_rejects_encrypted_key);
     suite_add_tcase(suite, tc_jwe);
 
     return suite;

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -1381,8 +1381,8 @@ static void _cjose_test_empty_headers(const cjose_jwk_t *key)
                   err.message, err.file, err.function, err.line);
     ck_assert_msg((len == 1) && (*test == 0), "Decrypted data does not match original");
 
-    free(test);
-    free(json);
+    cjose_get_dealloc()(test);
+    cjose_get_dealloc()(json);
     cjose_jwe_release(jwe);
 }
 

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -1610,6 +1610,14 @@ START_TEST(test_cjose_jwk_import_invalid)
         ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
         cjose_jwk_release(jwk);
     }
+
+    // no input at all is reported like any other invalid input
+    err.code = CJOSE_ERR_NONE;
+    ck_assert(NULL == cjose_jwk_import(NULL, 0, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    err.code = CJOSE_ERR_NONE;
+    ck_assert(NULL == cjose_jwk_import("{}", 0, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
 }
 END_TEST
 

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -377,9 +377,9 @@ START_TEST(test_cjose_jwk_create_EC_P521_spec)
     ck_assert(NULL != jwk->keydata);
     ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
     ck_assert(CJOSE_JWK_EC_P_521 == cjose_jwk_EC_get_curve(jwk, &err));
-    free(spec.d);
-    free(spec.x);
-    free(spec.y);
+    cjose_get_dealloc()(spec.d);
+    cjose_get_dealloc()(spec.x);
+    cjose_get_dealloc()(spec.y);
 
     // cleanup
     cjose_jwk_release(jwk);
@@ -739,12 +739,12 @@ START_TEST(test_cjose_jwk_to_json_oct)
     json = cjose_jwk_to_json(jwk, false, &err);
     ck_assert(NULL != json);
     ck_assert_str_eq("{\"kty\":\"oct\"}", json);
-    free(json);
+    cjose_get_dealloc()(json);
 
     json = cjose_jwk_to_json(jwk, true, &err);
     ck_assert(NULL != json);
     ck_assert_str_eq("{\"kty\":\"oct\",\"k\":\"pKE-eSbyFqPdtA5WzazKFg\"}", json);
-    free(json);
+    cjose_get_dealloc()(json);
 
     cjose_jwk_release(jwk);
 }
@@ -773,7 +773,7 @@ START_TEST(test_cjose_jwk_to_json_ec)
                      ",\"x\":\"ii8jCnvs4FLc0rteSWxanup22pNDhzizmlGN-bfTcFk\""
                      ",\"y\":\"KbkZ7r_DQ-t67pnxPnFDHObTLBqn44BSjcqn0STUkaM\"}",
                      json);
-    free(json);
+    cjose_get_dealloc()(json);
 
     json = cjose_jwk_to_json(jwk, true, &err);
     ck_assert(NULL != json);
@@ -782,7 +782,7 @@ START_TEST(test_cjose_jwk_to_json_ec)
                      ",\"y\":\"KbkZ7r_DQ-t67pnxPnFDHObTLBqn44BSjcqn0STUkaM\""
                      ",\"d\":\"RSSjcBQW_EBxm1gzYhejCdWtj3Id_GuwldwEgSuKCEM\"}",
                      json);
-    free(json);
+    cjose_get_dealloc()(json);
 
     cjose_jwk_release(jwk);
 }
@@ -825,7 +825,7 @@ START_TEST(test_cjose_jwk_to_json_rsa)
     json = cjose_jwk_to_json(jwk, false, &err);
     ck_assert(NULL != json);
     ck_assert_str_eq(RSA_PUBLIC_JSON, json);
-    free(json);
+    cjose_get_dealloc()(json);
 
     json = cjose_jwk_to_json(jwk, true, &err);
     ck_assert(NULL != json);
@@ -850,7 +850,7 @@ START_TEST(test_cjose_jwk_to_json_rsa)
                      "szu9adi9bgb_-egvc_NAvRkuGE9fUmB2_nAyU-j4VUh1MMSP5qqQhMYvFdAF5y36MpI-pV1SLFQ\""
                      "}",
                      json);
-    free(json);
+    cjose_get_dealloc()(json);
 
     cjose_jwk_release(jwk);
 }
@@ -879,7 +879,7 @@ START_TEST(test_cjose_jwk_to_json_okp)
     ck_assert_str_eq("{\"kty\":\"OKP\",\"crv\":\"Ed25519\""
                      ",\"x\":\"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo\"}",
                      json);
-    free(json);
+    cjose_get_dealloc()(json);
 
     json = cjose_jwk_to_json(jwk, true, &err);
     ck_assert(NULL != json);
@@ -887,7 +887,7 @@ START_TEST(test_cjose_jwk_to_json_okp)
                      ",\"x\":\"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo\""
                      ",\"d\":\"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A\"}",
                      json);
-    free(json);
+    cjose_get_dealloc()(json);
 
     cjose_jwk_release(jwk);
 }
@@ -921,7 +921,7 @@ START_TEST(test_cjose_jwk_OKP_import_export)
     ck_assert(NULL != right_json);
     ck_assert_msg(_match_string_attrs(left_json, right_json, attrs), "private export does not match: %s", jwk_str);
     json_decref(right_json);
-    free(jwk_str);
+    cjose_get_dealloc()(jwk_str);
 
     // the public export leaves out d
     jwk_str = cjose_jwk_to_json(jwk, false, &err);
@@ -933,7 +933,7 @@ START_TEST(test_cjose_jwk_OKP_import_export)
     ck_assert_msg(_match_string_attrs(left_json, right_json, attrs), "public export does not match: %s", jwk_str);
     json_decref(right_json);
     json_decref(left_json);
-    free(jwk_str);
+    cjose_get_dealloc()(jwk_str);
     cjose_jwk_release(jwk);
 
     // RFC 8037 appendix A.2 (public key): the private export has no d either
@@ -943,7 +943,7 @@ START_TEST(test_cjose_jwk_OKP_import_export)
     jwk_str = cjose_jwk_to_json(jwk, true, &err);
     ck_assert(NULL != jwk_str);
     ck_assert_str_eq(JWK_PUB, jwk_str);
-    free(jwk_str);
+    cjose_get_dealloc()(jwk_str);
     cjose_jwk_release(jwk);
 
     // RFC 8037 appendix A.6: an X25519 public key
@@ -1191,7 +1191,7 @@ START_TEST(test_cjose_jwk_import_json_valid)
             ck_assert_str_eq(JWK[i], jwk_str);
         }
 
-        free(jwk_str);
+        cjose_get_dealloc()(jwk_str);
         json_decref(left_json);
         json_decref(right_json);
         cjose_jwk_release(jwk);
@@ -1475,7 +1475,7 @@ START_TEST(test_cjose_jwk_import_valid)
             ck_assert_str_eq(JWK[i], jwk_str);
         }
 
-        free(jwk_str);
+        cjose_get_dealloc()(jwk_str);
         json_decref(left_json);
         json_decref(right_json);
         cjose_jwk_release(jwk);
@@ -1677,7 +1677,7 @@ START_TEST(test_cjose_jwk_import_no_zero_termination)
         ck_assert_str_eq(JWK, jwk_str);
     }
 
-    free(jwk_str);
+    cjose_get_dealloc()(jwk_str);
     json_decref(left_json);
     json_decref(right_json);
     cjose_jwk_release(jwk);
@@ -1719,7 +1719,7 @@ START_TEST(test_cjose_jwk_import_with_base64url_padding)
         ck_assert_str_eq(JWK_OUT, jwk_str);
     }
 
-    free(jwk_str);
+    cjose_get_dealloc()(jwk_str);
     json_decref(left_json);
     json_decref(right_json);
     cjose_jwk_release(jwk);
@@ -1761,7 +1761,7 @@ START_TEST(test_cjose_jwk_EC_import_with_priv_export_with_pub)
         ck_assert_str_eq(JWK_OUT, jwk_str);
     }
 
-    free(jwk_str);
+    cjose_get_dealloc()(jwk_str);
     json_decref(left_json);
     json_decref(right_json);
     cjose_jwk_release(jwk);
@@ -1884,7 +1884,7 @@ START_TEST(test_cjose_jwk_get_and_set_kid)
 
         // freedom!
         cjose_jwk_release(jwk);
-        free(json);
+        cjose_get_dealloc()(json);
     }
 }
 END_TEST


### PR DESCRIPTION
A sweep for places where the library, the tests, the two build systems and the docs do the same thing in two different ways, one commit per item, on top of #173's `cjose_const_memcmp` unification. Only the first commit changes what the library accepts; the rest are behaviour-preserving.

1. **jwe: require an empty encrypted key for dir and ECDH-ES.** RFC 7516 section 5.2 step 12. The AES key wrap, ECDH-ES+A*KW and RSA paths check the encrypted key for its exact expected size before handing it to OpenSSL; the `dir` and direct `ECDH-ES` paths never looked at it, so a JWE carrying one was decrypted as if it were absent. Now `CJOSE_ERR_INVALID_ARG`, with a regression test for both algorithms that fails on master.
2. **jwk: report a missing import string as `CJOSE_ERR_INVALID_ARG`.** `cjose_jwk_import(NULL, ...)` and a zero length returned NULL without touching `err`, unlike every other entry point. Regression test.
3. **jws: wipe the payload on release like the JWE plaintext.** `cjose_jwe_release` wipes the decrypted plaintext; `cjose_jws_release` wiped the digest and signature but freed the payload, its base64url encoding and the compact serialization with a plain dealloc.
4. **test: release library allocations with `cjose_get_dealloc`.** 22 places freed strings from `cjose_jwk_to_json` and `cjose_jwe_export_json`, plaintext from `cjose_jwe_decrypt` and buffers from `cjose_base64url_decode` with `free()`, which only works while the allocators are the defaults; the other 140 already used `cjose_get_dealloc()`.
5. **build: give the autotools test build the flags of the library and of CMake.** `test/Makefile.am` compiled the tests without `-Werror` and without `OPENSSL_API_COMPAT=0x10100000L`, both of which `src/Makefile.am` and CMake set. `Makefile.in` mirrored by hand.
6. **Prefix every static helper with `_cjose_` and its module.** jws.c and jwe.c already did; jwk.c had 28 helpers named after the key type alone, plus a handful in jwe.c, base64.c, concatkdf.c and a static `cjose_apply_allocs` in util.c that looked public. Mechanical rename.
7. **Add the copyright header to cjose.h**, the only file without one.
8. **README: list the supported algorithms, key types and serializations.** The additions of the recent releases were only discoverable through CHANGELOG.md and the headers.

Verified with CMake (`-pedantic -Wall -Werror`, RSA1_5 off and on), the full `check_cjose` run and valgrind on all suites, the `clang-format` target (no diff), an autotools `./configure && make && make check` confirming the test objects now compile with the new flags, and builds against OpenSSL 1.0.1u, 1.1.1w, 3.0.7 and 4.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
