### PR TITLE
Require OpenSSL 3.0.0 or newer

### DIFF
--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -15,19 +15,15 @@ jobs:
     name: OpenSSL ${{ matrix.openssl }}
 
     # The Build and Archs workflows test against the OpenSSL that the platform
-    # packages provide, which is a recent release. README.md promises OpenSSL
-    # 1.0.1h or newer, so this workflow builds the last release of every
-    # release series from source and tests against it, plus 3.0.7: the release
-    # RHEL 9 is based on and the last 3.0.x whose EdDSA signing dereferences a
-    # missing private key instead of failing (guarded in 3.0.8).
+    # packages provide, which is a recent release. This workflow builds the
+    # supported OpenSSL releases from source and tests against them, plus
+    # 3.0.7: the release RHEL 9 is based on and the last 3.0.x whose EdDSA
+    # signing dereferences a missing private key instead of failing (guarded in
+    # 3.0.8).
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { openssl: 1.0.1u, tag: OpenSSL_1_0_1u, sha256: 4312b4ca1215b6f2c97007503d80db80d5157f76f8f7d3febbe6b4c56ff26739 }
-          - { openssl: 1.0.2u, tag: OpenSSL_1_0_2u, sha256: ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16 }
-          - { openssl: 1.1.0l, tag: OpenSSL_1_1_0l, sha256: 74a2f756c64fd7386a29184dc0344f4831192d61dc2481a93a4c5dd727f41148 }
-          - { openssl: 1.1.1w, tag: OpenSSL_1_1_1w, sha256: cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8 }
           - { openssl: 3.0.7, tag: openssl-3.0.7, sha256: 83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e }
           - { openssl: 3.0.22, tag: openssl-3.0.22, sha256: 67ebca7e50d17383028045486653492195b83db95f8558709701bb47b5c1ef81 }
           - { openssl: 3.1.8, tag: openssl-3.1.8, sha256: d319da6aecde3aa6f426b44bbf997406d95275c5c59ab6f6ef53caaa079f456f }
@@ -59,23 +55,8 @@ jobs:
         echo "${{ matrix.sha256 }}  openssl-${{ matrix.openssl }}.tar.gz" | sha256sum -c -
         tar xzf "openssl-${{ matrix.openssl }}.tar.gz"
         cd "openssl-${{ matrix.openssl }}"
-        case "${{ matrix.openssl }}" in
-          1.0.*)
-            # static by default, no --libdir, needs 'make depend', parallel make is unreliable
-            ./config --prefix="$OPENSSL_PREFIX" shared
-            make depend
-            make
-            ;;
-          1.1.0*)
-            # has --libdir but not no-tests
-            ./config --prefix="$OPENSSL_PREFIX" --libdir=lib
-            make -j"$(nproc)"
-            ;;
-          *)
-            ./config --prefix="$OPENSSL_PREFIX" --libdir=lib no-tests
-            make -j"$(nproc)"
-            ;;
-        esac
+        ./config --prefix="$OPENSSL_PREFIX" --libdir=lib no-tests
+        make -j"$(nproc)"
         make install_sw
     - name: Configure
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DOPENSSL_ROOT_DIR="$OPENSSL_PREFIX"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 # ---------------------------------------------------------------------------
 # Dependencies
 # ---------------------------------------------------------------------------
-find_package(OpenSSL 1.0.1 REQUIRED)
+find_package(OpenSSL 3.0.0 REQUIRED)
 find_package(Jansson 2.3 REQUIRED)
 
 if(WIN32)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ JWS signing algorithms (`alg`):
 | `PS256`, `PS384`, `PS512` | RSASSA-PSS with SHA-2 | |
 | `ES256`, `ES384`, `ES512` | ECDSA with P-256, P-384 and P-521 | |
 | `ES256K` | ECDSA with secp256k1 | OpenSSL built with `secp256k1` |
-| `Ed25519`, `Ed448` | EdDSA (RFC 9864) | OpenSSL 1.1.1 |
+| `Ed25519`, `Ed448` | EdDSA (RFC 9864) | |
 
 The polymorphic `EdDSA` identifier of RFC 8037, deprecated by RFC 9864, and
 `none` are not accepted.
@@ -27,7 +27,7 @@ JWE key management algorithms (`alg`):
 | Identifier | Algorithm | Requires |
 |------------|-----------|----------|
 | `RSA-OAEP` | RSAES OAEP with SHA-1 and MGF1 with SHA-1 | |
-| `RSA-OAEP-256` | RSAES OAEP with SHA-256 and MGF1 with SHA-256 | OpenSSL 1.0.2 |
+| `RSA-OAEP-256` | RSAES OAEP with SHA-256 and MGF1 with SHA-256 | |
 | `RSA1_5` | RSAES-PKCS1-v1_5 | build option `CJOSE_ENABLE_RSA1_5` |
 | `A128KW`, `A192KW`, `A256KW` | AES Key Wrap | |
 | `dir` | direct use of a shared symmetric key | |
@@ -48,7 +48,7 @@ JWK key types (`kty`):
 | `RSA` | RSA | |
 | `EC` | `P-256`, `P-384`, `P-521`, `secp256k1` | `secp256k1`: OpenSSL built with it |
 | `oct` | symmetric | |
-| `OKP` | `Ed25519`, `Ed448`, `X25519`, `X448` | OpenSSL 1.1.1 |
+| `OKP` | `Ed25519`, `Ed448`, `X25519`, `X448` | |
 
 JWEs can be produced and consumed in both the compact and the JSON
 serialization, with one or more recipients.
@@ -67,7 +67,7 @@ serialization, with one or more recipients.
 
 ### Libraries ###
 
-* OpenSSL >= 1.0.1h (or its API equivalent)
+* OpenSSL >= 3.0.0
 * Jansson >= 2.3
 
 ## Getting Started ##

--- a/cmake/cjoseConfig.cmake.in
+++ b/cmake/cjoseConfig.cmake.in
@@ -27,10 +27,10 @@ if(@CJOSE_BUILD_STATIC@)
     # optional/required static target dependencies.
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
     if(_cjose_require_static)
-        find_dependency(OpenSSL 1.0.1)
+        find_dependency(OpenSSL 3.0.0)
         find_dependency(Jansson 2.3)
     else()
-        find_package(OpenSSL 1.0.1 QUIET)
+        find_package(OpenSSL 3.0.0 QUIET)
         find_package(Jansson 2.3 QUIET)
     endif()
 

--- a/include/cjose/jwk.h
+++ b/include/cjose/jwk.h
@@ -364,9 +364,6 @@ typedef struct
  * \b NOTE: The caller MUST call cjose_jwk_release() to release the JWK's
  * resources.
  *
- * \b NOTE: OKP keys require OpenSSL 1.1.1 or later; with an older OpenSSL
- * this function fails with CJOSE_ERR_INVALID_ARG.
- *
  * \param crv The curve to generate the key pair for
  * \param err [out] An optional error object which can be used to get additional
  *        information in the event of an error.

--- a/include/cjose/util.h
+++ b/include/cjose/util.h
@@ -76,7 +76,7 @@ void cjose_set_alloc_funcs(cjose_alloc_fn_t alloc, cjose_realloc_fn_t realloc, c
 
 /**
  * Sets the enhanced allocator and deallocator functions. This function provides
- * improved support for OpenSSL >= 1.1.x.
+ * support for OpenSSL's allocator callbacks.
  *
  * **NOTE:** This function is mutually exclusive from
  * <tt>cjose_set_alloc_funcs()</tt>. Both SHOULD NOT be called.
@@ -89,11 +89,11 @@ void cjose_set_alloc_funcs(cjose_alloc_fn_t alloc, cjose_realloc_fn_t realloc, c
  * is used.
  *
  * \param alloc3 [in] The custom allocator function to use for
- *        OpenSSL >= 1.1.0, called with extra file/line params.
+ *        OpenSSL, called with extra file/line params.
  * \param realloc3 [in] The custom reallocator function to use for
- *        OpenSSL >= 1.1.0, called with extra file/line params.
+ *        OpenSSL, called with extra file/line params.
  * \param dealloc3 [in] The custom deallocator function to use for
- *        OpenSSL >= 1.1.0, called with extra file/line params.
+ *        OpenSSL, called with extra file/line params.
  */
 void cjose_set_alloc_ex_funcs(cjose_alloc3_fn_t alloc3, cjose_realloc3_fn_t realloc3, cjose_dealloc3_fn_t dealloc3);
 

--- a/platform/centos/cjose.spec
+++ b/platform/centos/cjose.spec
@@ -8,8 +8,8 @@ URL:            https://github.com/cisco/cjose
 Source0:        cjose-%{version}.tar.gz
 
 BuildRoot:      %{_tmppath}/cjose-%{version}-%{release}-build
-Requires:       openssl, jansson
-BuildRequires:  cmake, openssl-devel, jansson-devel, check-devel
+Requires:       openssl >= 3.0.0, jansson
+BuildRequires:  cmake, openssl-devel >= 3.0.0, jansson-devel, check-devel
 
 %define _topdir /opt/rpmbuild
 %define debug_package %{nil}

--- a/platform/debian/debian/control
+++ b/platform/debian/debian/control
@@ -1,6 +1,6 @@
 Source: cjose
 Maintainer: Matthew A. Miller <linuxwolf@outer-planes.net>
-Build-Depends: debhelper (>= 8), cmake (>= 3.22), libssl-dev (>= 1.0.1), libjansson-dev (>= 2.3), pkg-config, check
+Build-Depends: debhelper (>= 8), cmake (>= 3.22), libssl-dev (>= 3.0.0), libjansson-dev (>= 2.3), pkg-config, check
 Standards-Version: 3.9.4
 Section: utils
 Priority: extra


### PR DESCRIPTION
Update the project and package metadata to require OpenSSL 3.0.0+. Refresh related documentation and remove GitHub Actions compatibility checks for older OpenSSL releases.