### PR TITLE
Remove obsolete OpenSSL compatibility guards

### DIFF
--- a/src/include/util_int.h
+++ b/src/include/util_int.h
@@ -11,26 +11,7 @@
 #include <cjose/error.h>
 
 #include <jansson.h>
-#include <openssl/opensslv.h>
 #include <string.h>
-
-#if OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)
-#define CJOSE_OPENSSL_11X
-#endif
-
-// the raw key API (EVP_PKEY_new_raw_private_key & co.) and PureEdDSA arrived
-// in OpenSSL 1.1.1; the OKP key type and the EdDSA algorithms depend on them
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
-#define CJOSE_OPENSSL_111X
-#endif
-
-// OpenSSL 1.0.2 (and LibreSSL 2.7) added the OAEP padding functions that take
-// the digest for the hash and for MGF1, RSA_padding_add_PKCS1_OAEP_mgf1 and
-// RSA_padding_check_PKCS1_OAEP_mgf1, which RSA-OAEP-256 needs
-#if (OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)) \
-    || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
-#define CJOSE_OPENSSL_102X
-#endif
 
 #ifdef _WIN32
 #include <BaseTsd.h>

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -44,12 +44,10 @@ _cjose_jwe_encrypt_ek_rsa_oaep(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe
 
 static bool
 _cjose_jwe_decrypt_ek_rsa_oaep(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err);
-#ifdef CJOSE_OPENSSL_102X
 static bool
 _cjose_jwe_encrypt_ek_rsa_oaep_256(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err);
 static bool
 _cjose_jwe_decrypt_ek_rsa_oaep_256(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err);
-#endif // CJOSE_OPENSSL_102X
 
 #ifdef HAVE_RSA_PKCS1_PADDING
 static bool _cjose_jwe_encrypt_ek_rsa1_5(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err);
@@ -391,13 +389,11 @@ static bool _cjose_jwe_validate_alg(cjose_header_t *protected_header,
         recipient->fns.encrypt_ek = _cjose_jwe_encrypt_ek_rsa_oaep;
         recipient->fns.decrypt_ek = _cjose_jwe_decrypt_ek_rsa_oaep;
     }
-#ifdef CJOSE_OPENSSL_102X
     if (strcmp(alg, CJOSE_HDR_ALG_RSA_OAEP_256) == 0)
     {
         recipient->fns.encrypt_ek = _cjose_jwe_encrypt_ek_rsa_oaep_256;
         recipient->fns.decrypt_ek = _cjose_jwe_decrypt_ek_rsa_oaep_256;
     }
-#endif // CJOSE_OPENSSL_102X
 #ifdef HAVE_RSA_PKCS1_PADDING
     if (strcmp(alg, CJOSE_HDR_ALG_RSA1_5) == 0)
     {
@@ -784,7 +780,6 @@ static bool _cjose_jwe_encrypt_ek_rsa_padding(
         return false;
     }
 
-#ifdef CJOSE_OPENSSL_102X
     if (NULL != oaep_md)
     {
         // pad the CEK into a scratch buffer of the modulus size with OAEP
@@ -808,7 +803,6 @@ static bool _cjose_jwe_encrypt_ek_rsa_padding(
         }
         return true;
     }
-#endif // CJOSE_OPENSSL_102X
 
     // encrypt the CEK using RSA v1.5 or OAEP padding
     if (RSA_public_encrypt(jwe->cek_len, jwe->cek, recipient->enc_key.raw, (RSA *)jwk->keydata, padding)
@@ -874,7 +868,6 @@ static bool _cjose_jwe_decrypt_ek_rsa_padding(
         return false;
     }
 
-#ifdef CJOSE_OPENSSL_102X
     if (NULL != oaep_md)
     {
         // decrypt raw into the scratch buffer, then remove the OAEP padding
@@ -905,7 +898,6 @@ static bool _cjose_jwe_decrypt_ek_rsa_padding(
         }
         return ok;
     }
-#endif // CJOSE_OPENSSL_102X
 
     // decrypt the CEK using RSA v1.5 or OAEP padding and require that its
     // length matches the CEK size dictated by the enc header (RFC 7518 sec 4.2/4.3)
@@ -937,7 +929,6 @@ _cjose_jwe_decrypt_ek_rsa_oaep(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe
     return _cjose_jwe_decrypt_ek_rsa_padding(recipient, jwe, jwk, RSA_PKCS1_OAEP_PADDING, NULL, err);
 }
 
-#ifdef CJOSE_OPENSSL_102X
 ////////////////////////////////////////////////////////////////////////////////
 static bool
 _cjose_jwe_encrypt_ek_rsa_oaep_256(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err)
@@ -951,7 +942,6 @@ _cjose_jwe_decrypt_ek_rsa_oaep_256(_jwe_int_recipient_t *recipient, cjose_jwe_t 
 {
     return _cjose_jwe_decrypt_ek_rsa_padding(recipient, jwe, jwk, RSA_NO_PADDING, EVP_sha256(), err);
 }
-#endif // CJOSE_OPENSSL_102X
 
 #ifdef HAVE_RSA_PKCS1_PADDING
 ////////////////////////////////////////////////////////////////////////////////
@@ -1419,14 +1409,6 @@ static bool _cjose_jwe_set_iv_aes_cbc(cjose_jwe_t *jwe, cjose_err *err)
     return true;
 }
 
-#if defined(CJOSE_OPENSSL_11X)
-#define CJOSE_EVP_CTRL_GCM_GET_TAG EVP_CTRL_AEAD_GET_TAG
-#define CJOSE_EVP_CTRL_GCM_SET_TAG EVP_CTRL_AEAD_SET_TAG
-#else
-#define CJOSE_EVP_CTRL_GCM_GET_TAG EVP_CTRL_GCM_GET_TAG
-#define CJOSE_EVP_CTRL_GCM_SET_TAG EVP_CTRL_GCM_SET_TAG
-#endif
-
 ////////////////////////////////////////////////////////////////////////////////
 static bool _cjose_jwe_encrypt_dat_aes_gcm(cjose_jwe_t *jwe, const uint8_t *plaintext, size_t plaintext_len, cjose_err *err)
 {
@@ -1525,7 +1507,7 @@ static bool _cjose_jwe_encrypt_dat_aes_gcm(cjose_jwe_t *jwe, const uint8_t *plai
     }
 
     // get the GCM-mode authentication tag
-    if (EVP_CIPHER_CTX_ctrl(ctx, CJOSE_EVP_CTRL_GCM_GET_TAG, jwe->enc_auth_tag.raw_len, jwe->enc_auth_tag.raw) != 1)
+    if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, jwe->enc_auth_tag.raw_len, jwe->enc_auth_tag.raw) != 1)
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _cjose_jwe_encrypt_dat_fail;
@@ -1797,7 +1779,7 @@ static bool _cjose_jwe_decrypt_dat_aes_gcm(cjose_jwe_t *jwe, cjose_err *err)
     }
 
     // set the expected GCM-mode authentication tag
-    if (EVP_CIPHER_CTX_ctrl(ctx, CJOSE_EVP_CTRL_GCM_SET_TAG, jwe->enc_auth_tag.raw_len, jwe->enc_auth_tag.raw) != 1)
+    if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG, jwe->enc_auth_tag.raw_len, jwe->enc_auth_tag.raw) != 1)
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _cjose_jwe_decrypt_dat_aes_gcm_fail;

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -86,10 +86,7 @@ bool _cjose_jwk_rsa_set(RSA *rsa, uint8_t *n, size_t n_len, uint8_t *e, size_t e
     return true;
 }
 
-void _cjose_jwk_rsa_get_factors(RSA *rsa, BIGNUM **p, BIGNUM **q)
-{
-    RSA_get0_factors(rsa, (const BIGNUM **)p, (const BIGNUM **)q);
-}
+void _cjose_jwk_rsa_get_factors(RSA *rsa, BIGNUM **p, BIGNUM **q) { RSA_get0_factors(rsa, (const BIGNUM **)p, (const BIGNUM **)q); }
 
 bool _cjose_jwk_rsa_set_factors(RSA *rsa, uint8_t *p, size_t p_len, uint8_t *q, size_t q_len)
 {

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -56,13 +56,7 @@ void _cjose_jwk_rsa_get(RSA *rsa, BIGNUM **rsa_n, BIGNUM **rsa_e, BIGNUM **rsa_d
 {
     if (rsa == NULL)
         return;
-#if defined(CJOSE_OPENSSL_11X)
     RSA_get0_key(rsa, (const BIGNUM **)rsa_n, (const BIGNUM **)rsa_e, (const BIGNUM **)rsa_d);
-#else
-    *rsa_n = rsa->n;
-    *rsa_e = rsa->e;
-    *rsa_d = rsa->d;
-#endif
 }
 
 bool _cjose_jwk_rsa_set(RSA *rsa, uint8_t *n, size_t n_len, uint8_t *e, size_t e_len, uint8_t *d, size_t d_len)
@@ -80,7 +74,6 @@ bool _cjose_jwk_rsa_set(RSA *rsa, uint8_t *n, size_t n_len, uint8_t *e, size_t e
     if (d && d_len > 0)
         rsa_d = BN_bin2bn(d, d_len, NULL);
 
-#if defined(CJOSE_OPENSSL_11X)
     if (1 != RSA_set0_key(rsa, rsa_n, rsa_e, rsa_d))
     {
         // the setter takes ownership only on success; free the BIGNUMs it
@@ -91,22 +84,11 @@ bool _cjose_jwk_rsa_set(RSA *rsa, uint8_t *n, size_t n_len, uint8_t *e, size_t e
         return false;
     }
     return true;
-#else
-    rsa->n = rsa_n;
-    rsa->e = rsa_e;
-    rsa->d = rsa_d;
-    return true;
-#endif
 }
 
 void _cjose_jwk_rsa_get_factors(RSA *rsa, BIGNUM **p, BIGNUM **q)
 {
-#if defined(CJOSE_OPENSSL_11X)
     RSA_get0_factors(rsa, (const BIGNUM **)p, (const BIGNUM **)q);
-#else
-    *p = rsa->p;
-    *q = rsa->q;
-#endif
 }
 
 bool _cjose_jwk_rsa_set_factors(RSA *rsa, uint8_t *p, size_t p_len, uint8_t *q, size_t q_len)
@@ -131,29 +113,18 @@ bool _cjose_jwk_rsa_set_factors(RSA *rsa, uint8_t *p, size_t p_len, uint8_t *q, 
         return false;
     }
 
-#if defined(CJOSE_OPENSSL_11X)
     if (1 != RSA_set0_factors(rsa, rsa_p, rsa_q))
     {
         BN_free(rsa_p);
         BN_free(rsa_q);
         return false;
     }
-#else
-    rsa->p = rsa_p;
-    rsa->q = rsa_q;
-#endif
     return true;
 }
 
 void _cjose_jwk_rsa_get_crt(RSA *rsa, BIGNUM **dmp1, BIGNUM **dmq1, BIGNUM **iqmp)
 {
-#if defined(CJOSE_OPENSSL_11X)
     RSA_get0_crt_params(rsa, (const BIGNUM **)dmp1, (const BIGNUM **)dmq1, (const BIGNUM **)iqmp);
-#else
-    *dmp1 = rsa->dmp1;
-    *dmq1 = rsa->dmq1;
-    *iqmp = rsa->iqmp;
-#endif
 }
 
 bool _cjose_jwk_rsa_set_crt(
@@ -182,7 +153,6 @@ bool _cjose_jwk_rsa_set_crt(
         return false;
     }
 
-#if defined(CJOSE_OPENSSL_11X)
     if (1 != RSA_set0_crt_params(rsa, rsa_dmp1, rsa_dmq1, rsa_iqmp))
     {
         BN_free(rsa_dmp1);
@@ -190,11 +160,6 @@ bool _cjose_jwk_rsa_set_crt(
         BN_free(rsa_iqmp);
         return false;
     }
-#else
-    rsa->dmp1 = rsa_dmp1;
-    rsa->dmq1 = rsa_dmq1;
-    rsa->iqmp = rsa_iqmp;
-#endif
 
     return true;
 }
@@ -1127,8 +1092,6 @@ cjose_jwk_ec_curve cjose_jwk_EC_get_curve(const cjose_jwk_t *jwk, cjose_err *err
 //////////////// Octet Key Pair ////////////////
 // internal data & functions -- Octet Key Pair (RFC 8037)
 
-#if defined(CJOSE_OPENSSL_111X)
-
 static const char CJOSE_JWK_OKP_ED25519_STR[] = "Ed25519";
 static const char CJOSE_JWK_OKP_ED448_STR[] = "Ed448";
 static const char CJOSE_JWK_OKP_X25519_STR[] = "X25519";
@@ -1525,24 +1488,6 @@ create_OKP_spec_cleanup:
 
     return jwk;
 }
-
-#else // !CJOSE_OPENSSL_111X
-
-// the OKP key type needs the raw key API that arrived in OpenSSL 1.1.1
-
-cjose_jwk_t *cjose_jwk_create_OKP_random(cjose_jwk_okp_curve crv, cjose_err *err)
-{
-    CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-    return NULL;
-}
-
-cjose_jwk_t *cjose_jwk_create_OKP_spec(const cjose_jwk_okp_keyspec *spec, cjose_err *err)
-{
-    CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-    return NULL;
-}
-
-#endif // CJOSE_OPENSSL_111X
 
 cjose_jwk_okp_curve cjose_jwk_OKP_get_curve(const cjose_jwk_t *jwk, cjose_err *err)
 {
@@ -2127,7 +2072,6 @@ import_oct_cleanup:
     return jwk;
 }
 
-#if defined(CJOSE_OPENSSL_111X)
 static cjose_jwk_t *_cjose_jwk_import_OKP(json_t *jwk_json, cjose_err *err)
 {
     cjose_jwk_t *jwk = NULL;
@@ -2195,14 +2139,6 @@ import_OKP_cleanup:
 
     return jwk;
 }
-#else
-static cjose_jwk_t *_cjose_jwk_import_OKP(json_t *jwk_json, cjose_err *err)
-{
-    // the OKP key type needs the raw key API that arrived in OpenSSL 1.1.1
-    CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-    return NULL;
-}
-#endif // CJOSE_OPENSSL_111X
 
 cjose_jwk_t *cjose_jwk_import(const char *jwk_str, size_t len, cjose_err *err)
 {

--- a/src/jws.c
+++ b/src/jws.c
@@ -46,7 +46,6 @@ static bool _cjose_jws_verify_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
 
 static bool _cjose_jws_validate_ec_key(const char *alg, const cjose_jwk_t *jwk, cjose_err *err);
 
-#if defined(CJOSE_OPENSSL_111X)
 static bool _cjose_jws_build_dig_eddsa(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err);
 
 static bool _cjose_jws_build_sig_eddsa(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err);
@@ -54,7 +53,6 @@ static bool _cjose_jws_build_sig_eddsa(cjose_jws_t *jws, const cjose_jwk_t *jwk,
 static bool _cjose_jws_verify_sig_eddsa(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err);
 
 static bool _cjose_jws_validate_okp_key(const char *alg, const cjose_jwk_t *jwk, cjose_err *err);
-#endif
 
 static bool _cjose_jws_validate_verify_key(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err);
 
@@ -130,14 +128,12 @@ static bool _cjose_jws_validate_hdr(cjose_jws_t *jws, cjose_err *err)
         jws->fns.sign = _cjose_jws_build_sig_ec;
         jws->fns.verify = _cjose_jws_verify_sig_ec;
     }
-#if defined(CJOSE_OPENSSL_111X)
     else if ((strcmp(alg, CJOSE_HDR_ALG_ED25519) == 0) || (strcmp(alg, CJOSE_HDR_ALG_ED448) == 0))
     {
         jws->fns.digest = _cjose_jws_build_dig_eddsa;
         jws->fns.sign = _cjose_jws_build_sig_eddsa;
         jws->fns.verify = _cjose_jws_verify_sig_eddsa;
     }
-#endif
     else
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -325,20 +321,12 @@ static bool _cjose_jws_build_dig_hmac_sha(cjose_jws_t *jws, const cjose_jwk_t *j
     }
 
     // instantiate and initialize a new mac digest context
-#if defined(CJOSE_OPENSSL_11X)
     ctx = HMAC_CTX_new();
-#else
-    ctx = cjose_get_alloc()(sizeof(HMAC_CTX));
-#endif
     if (NULL == ctx)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         goto _cjose_jws_build_dig_hmac_sha_cleanup;
     }
-
-#if !defined(CJOSE_OPENSSL_11X)
-    HMAC_CTX_init(ctx);
-#endif
 
     // create digest as DIGEST(B64U(HEADER).B64U(DATA))
     if (HMAC_Init_ex(ctx, jwk->keydata, jwk->keysize / 8, digest_alg, NULL) != 1)
@@ -373,12 +361,7 @@ static bool _cjose_jws_build_dig_hmac_sha(cjose_jws_t *jws, const cjose_jwk_t *j
 _cjose_jws_build_dig_hmac_sha_cleanup:
     if (NULL != ctx)
     {
-#if defined(CJOSE_OPENSSL_11X)
         HMAC_CTX_free(ctx);
-#else
-        HMAC_CTX_cleanup(ctx);
-        cjose_get_dealloc()(ctx);
-#endif
     }
 
     return retval;
@@ -624,12 +607,7 @@ static bool _cjose_jws_build_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, cj
     memset(jws->sig, 0, jws->sig_len);
 
     const BIGNUM *pr, *ps;
-#if defined(CJOSE_OPENSSL_11X)
     ECDSA_SIG_get0(ecdsa_sig, &pr, &ps);
-#else
-    pr = ecdsa_sig->r;
-    ps = ecdsa_sig->s;
-#endif
 
     int rlen = BN_num_bytes(pr);
     int slen = BN_num_bytes(ps);
@@ -1140,7 +1118,6 @@ static bool _cjose_jws_verify_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
     }
     int key_len = jws->sig_len / 2;
 
-#if defined(CJOSE_OPENSSL_11X)
     BIGNUM *pr = BN_new();
     BIGNUM *ps = BN_new();
     if (pr == NULL || ps == NULL)
@@ -1153,10 +1130,6 @@ static bool _cjose_jws_verify_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
     BN_bin2bn(jws->sig, key_len, pr);
     BN_bin2bn(jws->sig + key_len, key_len, ps);
     ECDSA_SIG_set0(ecdsa_sig, pr, ps); // takes ownership of pr and ps
-#else
-    BN_bin2bn(jws->sig, key_len, ecdsa_sig->r);
-    BN_bin2bn(jws->sig + key_len, key_len, ecdsa_sig->s);
-#endif
 
     if (ECDSA_do_verify(jws->dig, jws->dig_len, ecdsa_sig, ec) != 1)
     {
@@ -1197,8 +1170,6 @@ static bool _cjose_jws_validate_ec_key(const char *alg, const cjose_jwk_t *jwk, 
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-#if defined(CJOSE_OPENSSL_111X)
-
 // the fixed size of an EdDSA signature (RFC 8032 sections 5.1.6 and 5.2.6)
 static size_t _cjose_jws_eddsa_sig_len(cjose_jwk_okp_curve crv)
 {
@@ -1419,8 +1390,6 @@ _cjose_jws_verify_sig_eddsa_cleanup:
     return retval;
 }
 
-#endif // CJOSE_OPENSSL_111X
-
 ////////////////////////////////////////////////////////////////////////////////
 static bool _cjose_jws_validate_verify_key(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err)
 {
@@ -1464,7 +1433,6 @@ static bool _cjose_jws_validate_verify_key(cjose_jws_t *jws, const cjose_jwk_t *
         }
     }
 
-#if defined(CJOSE_OPENSSL_111X)
     if ((0 == strcmp(alg, CJOSE_HDR_ALG_ED25519)) || (0 == strcmp(alg, CJOSE_HDR_ALG_ED448)))
     {
         if (!_cjose_jws_validate_okp_key(alg, jwk, err))
@@ -1472,7 +1440,6 @@ static bool _cjose_jws_validate_verify_key(cjose_jws_t *jws, const cjose_jwk_t *
             return false;
         }
     }
-#endif
 
     return true;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -50,11 +50,7 @@ static void _cjose_apply_allocs(void)
 {
     // set upstream
     json_set_alloc_funcs(cjose_get_alloc(), cjose_get_dealloc());
-#if defined(CJOSE_OPENSSL_11X)
     CRYPTO_set_mem_functions(cjose_get_alloc3(), cjose_get_realloc3(), cjose_get_dealloc3());
-#else
-    CRYPTO_set_mem_functions(cjose_get_alloc(), cjose_get_realloc(), cjose_get_dealloc());
-#endif
 }
 
 void cjose_set_alloc_funcs(cjose_alloc_fn_t alloc, cjose_realloc_fn_t realloc, cjose_dealloc_fn_t dealloc)

--- a/test/check_cjose.c
+++ b/test/check_cjose.c
@@ -5,9 +5,6 @@
 #include "check_cjose.h"
 
 #include <stdlib.h>
-#include <openssl/err.h>
-#include <openssl/evp.h>
-#include <openssl/opensslv.h>
 
 Suite *cjose_suite(void)
 {
@@ -18,12 +15,6 @@ Suite *cjose_suite(void)
 
 int main(void)
 {
-    // initialize "OpenSSL" crypto (automatic since OpenSSL 1.1.0)
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-    ERR_load_crypto_strings();
-    OpenSSL_add_all_algorithms();
-#endif
-
     // setup suites
     SRunner *runner = srunner_create(cjose_suite());
 
@@ -41,12 +32,6 @@ int main(void)
     srunner_run_all(runner, CK_VERBOSE);
     int failed = srunner_ntests_failed(runner);
     srunner_free(runner);
-
-    // cleanup "OpenSSL" crypto (automatic since OpenSSL 1.1.0)
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-    EVP_cleanup();
-    ERR_free_strings();
-#endif
 
     return (0 == failed) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -214,12 +214,10 @@ static void _self_encrypt_self_decrypt(const uint8_t *plain1, size_t plain1_len)
     _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_RSA_OAEP, CJOSE_HDR_ENC_A192GCM, JWK_RSA, plain1, plain1_len);
 
     _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_RSA_OAEP, CJOSE_HDR_ENC_A256GCM, JWK_RSA, plain1, plain1_len);
-#ifdef CJOSE_OPENSSL_102X
     _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_RSA_OAEP_256, CJOSE_HDR_ENC_A128GCM, JWK_RSA, plain1, plain1_len);
     _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_RSA_OAEP_256, CJOSE_HDR_ENC_A256GCM, JWK_RSA, plain1, plain1_len);
     _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_RSA_OAEP_256, CJOSE_HDR_ENC_A128CBC_HS256, JWK_RSA, plain1, plain1_len);
     _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_RSA_OAEP_256, CJOSE_HDR_ENC_A256CBC_HS512, JWK_RSA, plain1, plain1_len);
-#endif // CJOSE_OPENSSL_102X
 
 #ifdef HAVE_RSA_PKCS1_PADDING
     _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_RSA1_5, CJOSE_HDR_ENC_A256GCM, JWK_RSA, plain1, plain1_len);
@@ -352,9 +350,7 @@ static void _self_encrypt_self_decrypt_with_key_iv(
 static void _self_encrypt_self_decrypt_iv(const uint8_t *plain1, size_t plain1_len)
 {
     _self_encrypt_self_decrypt_with_key_iv(CJOSE_HDR_ALG_RSA_OAEP, CJOSE_HDR_ENC_A256GCM, JWK_RSA, 12, plain1, plain1_len);
-#ifdef CJOSE_OPENSSL_102X
     _self_encrypt_self_decrypt_with_key_iv(CJOSE_HDR_ALG_RSA_OAEP_256, CJOSE_HDR_ENC_A256GCM, JWK_RSA, 12, plain1, plain1_len);
-#endif // CJOSE_OPENSSL_102X
 
     _self_encrypt_self_decrypt_with_key_iv(CJOSE_HDR_ALG_DIR, CJOSE_HDR_ENC_A128GCM, JWK_OCT_16, 12, plain1, plain1_len);
 
@@ -1915,7 +1911,6 @@ START_TEST(test_cjose_jwe_direct_rejects_encrypted_key)
     }
 }
 END_TEST
-#ifdef CJOSE_OPENSSL_102X
 // RSA-OAEP-256 JWEs produced by python-jwcrypto with the JWK_RSA key over the
 // plaintext below: the compact serialization with A256GCM and with
 // A128CBC-HS256, and the JSON serialization with two recipients for the same
@@ -2013,38 +2008,6 @@ START_TEST(test_cjose_jwe_rsa_oaep_256)
     cjose_jwk_release(jwk);
 }
 END_TEST
-#else  // !CJOSE_OPENSSL_102X
-START_TEST(test_cjose_jwe_rsa_oaep_256_unavailable)
-{
-    // OpenSSL before 1.0.2 has no OAEP with a digest other than SHA-1: the
-    // identifier is refused for encryption and for decryption
-    cjose_err err;
-    cjose_jwk_t *jwk = cjose_jwk_import(JWK_RSA, strlen(JWK_RSA), &err);
-    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
-
-    cjose_header_t *hdr = cjose_header_new(&err);
-    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_RSA_OAEP_256, &err));
-    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
-    ck_assert(NULL == cjose_jwe_encrypt(jwk, hdr, (const uint8_t *)PLAINTEXT, sizeof(PLAINTEXT) - 1, &err));
-    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
-
-    // header {"alg":"RSA-OAEP-256","enc":"A256GCM"} with dummy segments
-    static const char *cser = "eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIn0.AAAA.AAAA.AAAA.AAAA";
-    cjose_jwe_t *jwe = cjose_jwe_import(cser, strlen(cser), &err);
-    if (NULL != jwe)
-    {
-        size_t plain_len = 0;
-        uint8_t *plain = cjose_jwe_decrypt(jwe, jwk, &plain_len, &err);
-        ck_assert_msg(NULL == plain, "cjose_jwe_decrypt succeeded with RSA-OAEP-256 although it is unavailable");
-        cjose_jwe_release(jwe);
-    }
-    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
-
-    cjose_header_release(hdr);
-    cjose_jwk_release(jwk);
-}
-END_TEST
-#endif // CJOSE_OPENSSL_102X
 
 Suite *cjose_jwe_suite(void)
 {
@@ -2076,11 +2039,7 @@ Suite *cjose_jwe_suite(void)
 #ifndef HAVE_RSA_PKCS1_PADDING
     tcase_add_test(tc_jwe, test_cjose_jwe_rsa1_5_disabled);
 #endif
-#ifdef CJOSE_OPENSSL_102X
     tcase_add_test(tc_jwe, test_cjose_jwe_rsa_oaep_256);
-#else
-    tcase_add_test(tc_jwe, test_cjose_jwe_rsa_oaep_256_unavailable);
-#endif
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_rsa_wrong_cek_length);
     tcase_add_test(tc_jwe, test_cjose_jwe_import_json_shared_unprotected);
     tcase_add_test(tc_jwe, test_cjose_jwe_ecdh_es_null_err);

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -456,7 +456,6 @@ START_TEST(test_cjose_jwk_create_oct_random_inval)
 }
 END_TEST
 
-#if defined(CJOSE_OPENSSL_111X)
 static void _test_cjose_jwk_create_OKP_spec(cjose_jwk_okp_curve crv, size_t keysize, const char *d, const char *x)
 {
     cjose_err err;
@@ -666,7 +665,6 @@ START_TEST(test_cjose_jwk_OKP_get_curve_invalid)
     cjose_jwk_release(jwk);
 }
 END_TEST
-#endif // CJOSE_OPENSSL_111X
 
 START_TEST(test_cjose_jwk_retain_release)
 {
@@ -716,11 +714,9 @@ START_TEST(test_cjose_jwk_get_kty)
     ck_assert(CJOSE_JWK_KTY_EC == cjose_jwk_get_kty(jwk, &err));
     cjose_jwk_release(jwk);
 
-#if defined(CJOSE_OPENSSL_111X)
     jwk = cjose_jwk_create_OKP_random(CJOSE_JWK_OKP_ED25519, &err);
     ck_assert(CJOSE_JWK_KTY_OKP == cjose_jwk_get_kty(jwk, &err));
     cjose_jwk_release(jwk);
-#endif
 }
 END_TEST
 
@@ -856,7 +852,6 @@ START_TEST(test_cjose_jwk_to_json_rsa)
 }
 END_TEST
 
-#if defined(CJOSE_OPENSSL_111X)
 START_TEST(test_cjose_jwk_to_json_okp)
 {
     cjose_err err;
@@ -1020,7 +1015,6 @@ START_TEST(test_cjose_jwk_OKP_import_invalid)
     }
 }
 END_TEST
-#endif // CJOSE_OPENSSL_111X
 
 START_TEST(test_cjose_jwk_import_json_valid)
 {
@@ -1985,7 +1979,6 @@ Suite *cjose_jwk_suite(void)
     tcase_add_test(tc_jwk, test_cjose_jwk_create_oct_spec);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_oct_random);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_oct_random_inval);
-#if defined(CJOSE_OPENSSL_111X)
     tcase_add_test(tc_jwk, test_cjose_jwk_create_OKP_Ed25519_spec);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_OKP_Ed448_spec);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_OKP_X25519_spec);
@@ -1993,17 +1986,14 @@ Suite *cjose_jwk_suite(void)
     tcase_add_test(tc_jwk, test_cjose_jwk_create_OKP_spec_invalid);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_OKP_random);
     tcase_add_test(tc_jwk, test_cjose_jwk_OKP_get_curve_invalid);
-#endif
     tcase_add_test(tc_jwk, test_cjose_jwk_retain_release);
     tcase_add_test(tc_jwk, test_cjose_jwk_get_kty);
     tcase_add_test(tc_jwk, test_cjose_jwk_to_json_oct);
     tcase_add_test(tc_jwk, test_cjose_jwk_to_json_ec);
     tcase_add_test(tc_jwk, test_cjose_jwk_to_json_rsa);
-#if defined(CJOSE_OPENSSL_111X)
     tcase_add_test(tc_jwk, test_cjose_jwk_to_json_okp);
     tcase_add_test(tc_jwk, test_cjose_jwk_OKP_import_export);
     tcase_add_test(tc_jwk, test_cjose_jwk_OKP_import_invalid);
-#endif
     tcase_add_test(tc_jwk, test_cjose_jwk_import_json_valid);
     tcase_add_test(tc_jwk, test_cjose_jwk_import_json_invalid);
     tcase_add_test(tc_jwk, test_cjose_jwk_import_valid);

--- a/test/check_jws.c
+++ b/test/check_jws.c
@@ -61,7 +61,6 @@ static const char *JWK_COMMON_EC_SECP_256K1 = "{ \"kty\":\"EC\","
                                               "\"y\":\"36uMVGM7hnw-N6GnjFcihWE3SkrhMLzzLCdPMXPEXlA\","
                                               "\"d\":\"rhYFsBPF9q3-uZThy7B3c4LDF_8wnozFUAEm5LLC4Zw\" }";
 
-#if defined(CJOSE_OPENSSL_111X)
 // RFC 8037 appendix A.1: an Ed25519 key pair
 static const char *JWK_COMMON_OKP_ED25519 = "{\"kty\":\"OKP\",\"crv\":\"Ed25519\","
                                             "\"d\":\"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A\","
@@ -76,7 +75,6 @@ static const char *JWK_COMMON_OKP_ED448 = "{\"kty\":\"OKP\",\"crv\":\"Ed448\","
 static const char *JWK_COMMON_OKP_X25519 = "{\"kty\":\"OKP\",\"crv\":\"X25519\","
                                            "\"d\":\"dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo\","
                                            "\"x\":\"hSDwCYkwp1R0i33ctD73Wg2_Og0mOBr066SpjqqbTmo\"}";
-#endif
 
 // a JWS encrypted with the above JWK_COMMON key
 static const char *JWS_COMMON
@@ -109,12 +107,10 @@ static const char *_self_get_jwk_by_alg(const char *alg)
     if ((strcmp(alg, CJOSE_HDR_ALG_ES256) == 0) || (strcmp(alg, CJOSE_HDR_ALG_ES384) == 0)
         || (strcmp(alg, CJOSE_HDR_ALG_ES512) == 0))
         return JWK_COMMON_EC;
-#if defined(CJOSE_OPENSSL_111X)
     if (strcmp(alg, CJOSE_HDR_ALG_ED25519) == 0)
         return JWK_COMMON_OKP_ED25519;
     if (strcmp(alg, CJOSE_HDR_ALG_ED448) == 0)
         return JWK_COMMON_OKP_ED448;
-#endif
     return JWK_COMMON;
 }
 
@@ -202,10 +198,8 @@ static void _self_sign_self_verify_all_algs(const uint8_t *plain, size_t plain_l
     _self_sign_self_verify(plain, plain_len, CJOSE_HDR_ALG_ES256K, err);
     _self_sign_self_verify(plain, plain_len, CJOSE_HDR_ALG_ES384, err);
     _self_sign_self_verify(plain, plain_len, CJOSE_HDR_ALG_ES512, err);
-#if defined(CJOSE_OPENSSL_111X)
     _self_sign_self_verify(plain, plain_len, CJOSE_HDR_ALG_ED25519, err);
     _self_sign_self_verify(plain, plain_len, CJOSE_HDR_ALG_ED448, err);
-#endif
 }
 
 START_TEST(test_cjose_jws_self_sign_self_verify)
@@ -282,7 +276,6 @@ START_TEST(test_cjose_jws_es256k_rejects_wrong_curve)
 }
 END_TEST
 
-#if defined(CJOSE_OPENSSL_111X)
 // RFC 9864 fully-specified {"alg":"Ed25519"} over the RFC 8037 appendix A.4
 // payload "Example of Ed25519 signing" with the RFC 8037 appendix A.1 key; the
 // (deterministic) signature was produced with "openssl pkeyutl -sign -rawin"
@@ -582,7 +575,6 @@ START_TEST(test_cjose_jws_verify_ed25519_sig_bad_length)
     cjose_jwk_release(jwk);
 }
 END_TEST
-#endif // CJOSE_OPENSSL_111X
 
 START_TEST(test_cjose_jws_self_sign_self_verify_short)
 {
@@ -1564,14 +1556,12 @@ Suite *cjose_jws_suite(void)
     tcase_add_test(tc_jws, test_cjose_jws_verify_ec256);
     tcase_add_test(tc_jws, test_cjose_jws_verify_es256k);
     tcase_add_test(tc_jws, test_cjose_jws_es256k_rejects_wrong_curve);
-#if defined(CJOSE_OPENSSL_111X)
     tcase_add_test(tc_jws, test_cjose_jws_verify_ed25519);
     tcase_add_test(tc_jws, test_cjose_jws_sign_ed25519);
     tcase_add_test(tc_jws, test_cjose_jws_sign_verify_ed448);
     tcase_add_test(tc_jws, test_cjose_jws_ed25519_rejects_wrong_key);
     tcase_add_test(tc_jws, test_cjose_jws_eddsa_deprecated);
     tcase_add_test(tc_jws, test_cjose_jws_verify_ed25519_sig_bad_length);
-#endif
     tcase_add_test(tc_jws, test_cjose_jws_sign_with_bad_header);
     tcase_add_test(tc_jws, test_cjose_jws_sign_with_bad_key);
     tcase_add_test(tc_jws, test_cjose_jws_sign_hmac_with_non_oct_key);


### PR DESCRIPTION
With OpenSSL 3.0.0 now required, remove the `CJOSE_OPENSSL_11X`, `CJOSE_OPENSSL_111X`, and `CJOSE_OPENSSL_102X` macros and their legacy code paths. OpenSSL-dependent tests now run unconditionally against the supported API.