### PR TITLE
Complete migration to OpenSSL 3 APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,14 +55,6 @@ if(WIN32)
     set(CJOSE_PLATFORM_LIBRARIES ws2_32)
 endif()
 
-# Optional Cisco "Fundamental EC" OpenSSL extension (openssl/fec.h).
-include(CheckIncludeFile)
-include(CMakePushCheckState)
-cmake_push_check_state(RESET)
-set(CMAKE_REQUIRED_LIBRARIES OpenSSL::Crypto)
-check_include_file("openssl/fec.h" CJOSE_HAVE_OPENSSL_FEC_H)
-cmake_pop_check_state()
-
 # ---------------------------------------------------------------------------
 # Generated public header (version.h)
 # ---------------------------------------------------------------------------
@@ -118,12 +110,8 @@ set_target_properties(cjose_objects PROPERTIES
     C_STANDARD_REQUIRED ON
     C_EXTENSIONS ON)
 
-target_compile_definitions(cjose_objects PRIVATE OPENSSL_API_COMPAT=0x10100000L)
 if(CJOSE_ENABLE_RSA1_5)
     target_compile_definitions(cjose_objects PRIVATE HAVE_RSA_PKCS1_PADDING=1)
-endif()
-if(CJOSE_HAVE_OPENSSL_FEC_H)
-    target_compile_definitions(cjose_objects PRIVATE HAVE_OPENSSL_FEC_H=1)
 endif()
 if(MSVC)
     target_compile_options(cjose_objects PRIVATE /W3 /WX /wd4267)
@@ -392,7 +380,6 @@ if(CJOSE_BUILD_TESTS)
             C_STANDARD 99
             C_STANDARD_REQUIRED ON
             C_EXTENSIONS ON)
-        target_compile_definitions(check_cjose PRIVATE OPENSSL_API_COMPAT=0x10100000L)
         if(CJOSE_ENABLE_RSA1_5)
             target_compile_definitions(check_cjose PRIVATE HAVE_RSA_PKCS1_PADDING=1)
         endif()

--- a/include/cjose/jwk.h
+++ b/include/cjose/jwk.h
@@ -95,13 +95,19 @@ cjose_jwk_kty_t cjose_jwk_get_kty(const cjose_jwk_t *jwk, cjose_err *err);
 size_t cjose_jwk_get_keysize(const cjose_jwk_t *jwk, cjose_err *err);
 
 /**
- * Retrieves the raw key data for this JWK.
+ * Retrieves the key data owned by this JWK.
  *
- * \b WARNING: this is the raw data specific to the key type, and could
- * contain private key material.
- * \b NOTE: This key data will be released when the key is released.
+ * For octet keys, the returned pointer addresses the raw key bytes. For all
+ * other key types, it refers to an implementation-specific representation and
+ * must be treated as opaque.
+ *
+ * \b WARNING: The returned data may contain private key material.
+ * \b NOTE: The data is borrowed and must not be modified or freed. It will be
+ * released when the key is released.
  *
  * \param jwk The JWK to retrieve key data from
+ * \param err [out] An optional error object which can be used to get additional
+ *        information in the event of an error.
  * \returns The key data specific to the type of key
  */
 void *cjose_jwk_get_keydata(const cjose_jwk_t *jwk, cjose_err *err);

--- a/src/concatkdf.c
+++ b/src/concatkdf.c
@@ -114,7 +114,7 @@ uint8_t *cjose_concatkdf_derive(const size_t keylen,
 
     uint8_t *buffer = NULL;
     const EVP_MD *dgst = EVP_sha256();
-    EVP_MD_CTX *ctx = EVP_MD_CTX_create();
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
     if (NULL == ctx)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
@@ -166,7 +166,7 @@ uint8_t *cjose_concatkdf_derive(const size_t keylen,
     buffer = NULL;
 
 concatkdf_derive_finish:
-    EVP_MD_CTX_destroy(ctx);
+    EVP_MD_CTX_free(ctx);
     _cjose_cleanse_dealloc(buffer, keylen);
 
     return derived;

--- a/src/include/jwk_int.h
+++ b/src/include/jwk_int.h
@@ -9,19 +9,7 @@
 
 #include <jansson.h>
 
-#ifdef HAVE_OPENSSL_FEC_H
-
-#include <openssl/fec.h>
-#include <openssl/fecdh.h>
-#include <openssl/fecdsa.h>
-
-#else
-
-#include <openssl/ec.h>
-#include <openssl/ecdh.h>
-#include <openssl/ecdsa.h>
-
-#endif
+#include <openssl/evp.h>
 
 #ifndef SRC_JWK_INT_H
 #define SRC_JWK_INT_H
@@ -49,7 +37,8 @@ struct _cjose_jwk_int
 typedef struct _ec_keydata_int
 {
     cjose_jwk_ec_curve crv;
-    EC_KEY *key;
+    EVP_PKEY *key;
+    bool has_private;
 } ec_keydata;
 
 // OKP-specific keydata (RFC 8037): the EVP_PKEY holds the raw Ed25519,
@@ -58,11 +47,25 @@ typedef struct _okp_keydata_int
 {
     cjose_jwk_okp_curve crv;
     EVP_PKEY *key;
+    bool has_private;
 } okp_keydata;
 
-// RSA-specific keydata = OpenSSL RSA struct
-// (just uses RSA struct)
-void _cjose_jwk_rsa_get(RSA *rsa, BIGNUM **n, BIGNUM **e, BIGNUM **d);
+typedef struct _rsa_keydata_int
+{
+    EVP_PKEY *key;
+    bool has_private;
+    bool has_factors;
+    bool has_crt;
+    BIGNUM *p;
+    BIGNUM *q;
+    BIGNUM *dp;
+    BIGNUM *dq;
+    BIGNUM *qi;
+} rsa_keydata;
+
+static inline EVP_PKEY *_cjose_jwk_rsa_key(const cjose_jwk_t *jwk) { return ((rsa_keydata *)jwk->keydata)->key; }
+
+bool _cjose_jwk_rsa_has_private(const cjose_jwk_t *jwk);
 
 bool cjose_jwk_derive_ecdh_bits(
     const cjose_jwk_t *jwk_self, const cjose_jwk_t *jwk_peer, uint8_t **output, size_t *output_len, cjose_err *err);

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -10,9 +10,8 @@
 #include <cjose/jwe.h>
 #include <cjose/util.h>
 
-#include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
-#include <assert.h>
 #include <limits.h>
 #include <openssl/rand.h>
 #include <openssl/rsa.h>
@@ -632,6 +631,53 @@ static bool _cjose_jwe_decrypt_ek_dir(_jwe_int_recipient_t *recipient, cjose_jwe
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+static const EVP_CIPHER *_cjose_jwe_aes_kw_cipher(size_t key_len)
+{
+    switch (key_len)
+    {
+    case 16:
+        return EVP_aes_128_wrap();
+    case 24:
+        return EVP_aes_192_wrap();
+    case 32:
+        return EVP_aes_256_wrap();
+    default:
+        return NULL;
+    }
+}
+
+static bool _cjose_jwe_aes_kw_wrap(
+    const uint8_t *kek, size_t kek_len, const uint8_t *plain, size_t plain_len, uint8_t *wrapped, size_t *wrapped_len)
+{
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    int update_len = 0;
+    int final_len = 0;
+    const EVP_CIPHER *cipher = _cjose_jwe_aes_kw_cipher(kek_len);
+    bool result = ctx != NULL && cipher != NULL && EVP_EncryptInit_ex(ctx, cipher, NULL, kek, NULL) == 1
+                  && EVP_EncryptUpdate(ctx, wrapped, &update_len, plain, plain_len) == 1
+                  && EVP_EncryptFinal_ex(ctx, wrapped + update_len, &final_len) == 1;
+    if (result)
+        *wrapped_len = (size_t)update_len + final_len;
+    EVP_CIPHER_CTX_free(ctx);
+    return result;
+}
+
+static bool _cjose_jwe_aes_kw_unwrap(
+    const uint8_t *kek, size_t kek_len, const uint8_t *wrapped, size_t wrapped_len, uint8_t *plain, size_t *plain_len)
+{
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    int update_len = 0;
+    int final_len = 0;
+    const EVP_CIPHER *cipher = _cjose_jwe_aes_kw_cipher(kek_len);
+    bool result = ctx != NULL && cipher != NULL && EVP_DecryptInit_ex(ctx, cipher, NULL, kek, NULL) == 1
+                  && EVP_DecryptUpdate(ctx, plain, &update_len, wrapped, wrapped_len) == 1
+                  && EVP_DecryptFinal_ex(ctx, plain + update_len, &final_len) == 1;
+    if (result)
+        *plain_len = (size_t)update_len + final_len;
+    EVP_CIPHER_CTX_free(ctx);
+    return result;
+}
+
 static bool _cjose_jwe_encrypt_ek_aes_kw(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err)
 {
     if (NULL == jwe || NULL == jwk)
@@ -653,29 +699,18 @@ static bool _cjose_jwe_encrypt_ek_aes_kw(_jwe_int_recipient_t *recipient, cjose_
         return false;
     }
 
-    // create the AES encryption key from the shared key
-    AES_KEY akey;
-    if (AES_set_encrypt_key(jwk->keydata, jwk->keysize, &akey) < 0)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
-        return false;
-    }
-
     // allocate buffer for encrypted CEK (=cek_len + 8)
     if (!_cjose_jwe_malloc(jwe->cek_len + 8, false, &recipient->enc_key.raw, err))
     {
         return false;
     }
 
-    // AES wrap the CEK
-    int len = AES_wrap_key(&akey, NULL, recipient->enc_key.raw, jwe->cek, jwe->cek_len);
-    if (len <= 0)
+    if (!_cjose_jwe_aes_kw_wrap(jwk->keydata, jwk->keysize / 8, jwe->cek, jwe->cek_len, recipient->enc_key.raw,
+                                &recipient->enc_key.raw_len))
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         return false;
     }
-    recipient->enc_key.raw_len = len;
-
     return true;
 }
 
@@ -695,46 +730,30 @@ static bool _cjose_jwe_decrypt_ek_aes_kw(_jwe_int_recipient_t *recipient, cjose_
         return false;
     }
 
-    // create the AES decryption key from the shared key
-    AES_KEY akey;
-    if (AES_set_decrypt_key(jwk->keydata, jwk->keysize, &akey) < 0)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
-        return false;
-    }
-
     if (!jwe->fns.set_cek(jwe, NULL, false, err))
     {
         return false;
     }
 
-    // the wrapped key (RFC 3394) is always the plaintext CEK length plus 8 bytes;
-    // enforce this before calling AES_unwrap_key, which would otherwise copy the
-    // attacker-controlled encrypted_key into the fixed-size jwe->cek buffer
+    // The wrapped key (RFC 3394) is always the plaintext CEK length plus 8 bytes.
+    // Enforce this before unwrapping so the attacker-controlled encrypted key
+    // cannot be copied into the fixed-size jwe->cek buffer.
     if (recipient->enc_key.raw_len != jwe->cek_len + 8)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return false;
     }
 
-    // AES unwrap the CEK in to jwe->cek
-    int len = AES_unwrap_key(&akey, (const unsigned char *)NULL, jwe->cek, (const unsigned char *)recipient->enc_key.raw,
-                             recipient->enc_key.raw_len);
-    if (len <= 0)
+    if (!_cjose_jwe_aes_kw_unwrap(jwk->keydata, jwk->keysize / 8, recipient->enc_key.raw, recipient->enc_key.raw_len, jwe->cek,
+                                  &jwe->cek_len))
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         return false;
     }
-    jwe->cek_len = len;
-
     return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// encrypts the CEK with the RSA public key: with padding, one of OpenSSL's
-// RSA_*_PADDING modes, when oaep_md is NULL, and otherwise with OAEP using
-// oaep_md for both the hash and MGF1 (RSA-OAEP-256), which OpenSSL only offers
-// as a separate padding step
 static bool _cjose_jwe_encrypt_ek_rsa_padding(
     _jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, int padding, const EVP_MD *oaep_md, cjose_err *err)
 {
@@ -745,14 +764,7 @@ static bool _cjose_jwe_encrypt_ek_rsa_padding(
         return false;
     }
 
-    // jwk must have the necessary public parts set
-    BIGNUM *rsa_n = NULL, *rsa_e = NULL, *rsa_d = NULL;
-    _cjose_jwk_rsa_get((RSA *)jwk->keydata, &rsa_n, &rsa_e, &rsa_d);
-    if (NULL == rsa_e || NULL == rsa_n)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-        return false;
-    }
+    EVP_PKEY *key = _cjose_jwk_rsa_key(jwk);
 
     // generate random cek
     if (!jwe->fns.set_cek(jwe, NULL, true, err))
@@ -761,7 +773,7 @@ static bool _cjose_jwe_encrypt_ek_rsa_padding(
     }
 
     // the size of the ek will match the size of the RSA key
-    recipient->enc_key.raw_len = RSA_size((RSA *)jwk->keydata);
+    recipient->enc_key.raw_len = EVP_PKEY_get_size(key);
 
     // the CEK must leave room for the padding: 2 * hLen + 2 octets for OAEP
     // with the given digest (RFC 8017 section 7.1.1); the SHA-1 OAEP and the
@@ -780,44 +792,23 @@ static bool _cjose_jwe_encrypt_ek_rsa_padding(
         return false;
     }
 
-    if (NULL != oaep_md)
+    EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(key, NULL);
+    size_t encrypted_len = recipient->enc_key.raw_len;
+    if (ctx == NULL || EVP_PKEY_encrypt_init(ctx) != 1 || EVP_PKEY_CTX_set_rsa_padding(ctx, padding) != 1
+        || (oaep_md != NULL && (EVP_PKEY_CTX_set_rsa_oaep_md(ctx, oaep_md) != 1 || EVP_PKEY_CTX_set_rsa_mgf1_md(ctx, oaep_md) != 1))
+        || EVP_PKEY_encrypt(ctx, recipient->enc_key.raw, &encrypted_len, jwe->cek, jwe->cek_len) != 1
+        || encrypted_len != recipient->enc_key.raw_len)
     {
-        // pad the CEK into a scratch buffer of the modulus size with OAEP
-        // using oaep_md for the hash and for MGF1, then encrypt it raw
-        uint8_t *em = NULL;
-        if (!_cjose_jwe_malloc(recipient->enc_key.raw_len, false, &em, err))
-        {
-            return false;
-        }
-        bool ok
-            = (1
-               == RSA_padding_add_PKCS1_OAEP_mgf1(em, recipient->enc_key.raw_len, jwe->cek, jwe->cek_len, NULL, 0, oaep_md,
-                                                  oaep_md))
-              && (RSA_public_encrypt(recipient->enc_key.raw_len, em, recipient->enc_key.raw, (RSA *)jwk->keydata, RSA_NO_PADDING)
-                  == recipient->enc_key.raw_len);
-        _cjose_cleanse_dealloc(em, recipient->enc_key.raw_len);
-        if (!ok)
-        {
-            CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
-            return false;
-        }
-        return true;
-    }
-
-    // encrypt the CEK using RSA v1.5 or OAEP padding
-    if (RSA_public_encrypt(jwe->cek_len, jwe->cek, recipient->enc_key.raw, (RSA *)jwk->keydata, padding)
-        != recipient->enc_key.raw_len)
-    {
+        EVP_PKEY_CTX_free(ctx);
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         return false;
     }
+    EVP_PKEY_CTX_free(ctx);
 
     return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// decrypts the CEK with the RSA private key; padding and oaep_md as for
-// _cjose_jwe_encrypt_ek_rsa_padding
 static bool _cjose_jwe_decrypt_ek_rsa_padding(
     _jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, int padding, const EVP_MD *oaep_md, cjose_err *err)
 {
@@ -834,10 +825,8 @@ static bool _cjose_jwe_decrypt_ek_rsa_padding(
         return false;
     }
 
-    // jwk must have the necessary private parts set
-    BIGNUM *rsa_n = NULL, *rsa_e = NULL, *rsa_d = NULL;
-    _cjose_jwk_rsa_get((RSA *)jwk->keydata, &rsa_n, &rsa_e, &rsa_d);
-    if (NULL == rsa_e || NULL == rsa_n || NULL == rsa_d)
+    EVP_PKEY *key = _cjose_jwk_rsa_key(jwk);
+    if (!_cjose_jwk_rsa_has_private(jwk))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return false;
@@ -851,63 +840,34 @@ static bool _cjose_jwe_decrypt_ek_rsa_padding(
         return false;
     }
 
-    // a valid RSA encrypted key segment is exactly the size of the modulus;
-    // reject other lengths before they reach RSA_private_decrypt
-    size_t buflen = RSA_size((RSA *)jwk->keydata);
+    size_t buflen = EVP_PKEY_get_size(key);
     if (recipient->enc_key.raw_len != buflen)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return false;
     }
 
-    // decrypt into a scratch buffer; the recovered plaintext can be up to
-    // RSA_size bytes, larger than the pinned CEK buffer
+    // Decrypt into a scratch buffer; the recovered plaintext can be up to the
+    // RSA modulus size, larger than the pinned CEK buffer.
     uint8_t *buf = NULL;
     if (!_cjose_jwe_malloc(buflen, false, &buf, err))
     {
         return false;
     }
 
-    if (NULL != oaep_md)
+    EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(key, NULL);
+    size_t plain_len = buflen;
+    if (ctx == NULL || EVP_PKEY_decrypt_init(ctx) != 1 || EVP_PKEY_CTX_set_rsa_padding(ctx, padding) != 1
+        || (oaep_md != NULL && (EVP_PKEY_CTX_set_rsa_oaep_md(ctx, oaep_md) != 1 || EVP_PKEY_CTX_set_rsa_mgf1_md(ctx, oaep_md) != 1))
+        || EVP_PKEY_decrypt(ctx, buf, &plain_len, recipient->enc_key.raw, recipient->enc_key.raw_len) != 1
+        || plain_len != jwe->cek_len)
     {
-        // decrypt raw into the scratch buffer, then remove the OAEP padding
-        // with oaep_md for the hash and for MGF1 into a second one, and
-        // require the CEK size dictated by the enc header like below
-        uint8_t *msg = NULL;
-        if (!_cjose_jwe_malloc(buflen, false, &msg, err))
-        {
-            _cjose_cleanse_dealloc(buf, buflen);
-            return false;
-        }
-        int mlen = -1;
-        if (RSA_private_decrypt(recipient->enc_key.raw_len, recipient->enc_key.raw, buf, (RSA *)jwk->keydata, RSA_NO_PADDING)
-            == (int)buflen)
-        {
-            mlen = RSA_padding_check_PKCS1_OAEP_mgf1(msg, buflen, buf, buflen, buflen, NULL, 0, oaep_md, oaep_md);
-        }
-        bool ok = (-1 != mlen && (size_t)mlen == jwe->cek_len);
-        if (ok)
-        {
-            memcpy(jwe->cek, msg, jwe->cek_len);
-        }
-        _cjose_cleanse_dealloc(msg, buflen);
-        _cjose_cleanse_dealloc(buf, buflen);
-        if (!ok)
-        {
-            CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
-        }
-        return ok;
-    }
-
-    // decrypt the CEK using RSA v1.5 or OAEP padding and require that its
-    // length matches the CEK size dictated by the enc header (RFC 7518 sec 4.2/4.3)
-    int len = RSA_private_decrypt(recipient->enc_key.raw_len, recipient->enc_key.raw, buf, (RSA *)jwk->keydata, padding);
-    if (-1 == len || (size_t)len != jwe->cek_len)
-    {
+        EVP_PKEY_CTX_free(ctx);
         _cjose_cleanse_dealloc(buf, buflen);
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         return false;
     }
+    EVP_PKEY_CTX_free(ctx);
 
     memcpy(jwe->cek, buf, jwe->cek_len);
     _cjose_cleanse_dealloc(buf, buflen);
@@ -933,14 +893,14 @@ _cjose_jwe_decrypt_ek_rsa_oaep(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe
 static bool
 _cjose_jwe_encrypt_ek_rsa_oaep_256(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err)
 {
-    return _cjose_jwe_encrypt_ek_rsa_padding(recipient, jwe, jwk, RSA_NO_PADDING, EVP_sha256(), err);
+    return _cjose_jwe_encrypt_ek_rsa_padding(recipient, jwe, jwk, RSA_PKCS1_OAEP_PADDING, EVP_sha256(), err);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 static bool
 _cjose_jwe_decrypt_ek_rsa_oaep_256(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err)
 {
-    return _cjose_jwe_decrypt_ek_rsa_padding(recipient, jwe, jwk, RSA_NO_PADDING, EVP_sha256(), err);
+    return _cjose_jwe_decrypt_ek_rsa_padding(recipient, jwe, jwk, RSA_PKCS1_OAEP_PADDING, EVP_sha256(), err);
 }
 
 #ifdef HAVE_RSA_PKCS1_PADDING
@@ -1194,26 +1154,16 @@ static bool _cjose_jwe_encrypt_ek_ecdh_es_kw(
         goto cjose_encrypt_ek_ecdh_es_kw_finish;
     }
 
-    // wrap the CEK with the derived KEK
-    AES_KEY akey;
-    if (AES_set_encrypt_key(kek, kek_keysize * 8, &akey) < 0)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
-        goto cjose_encrypt_ek_ecdh_es_kw_finish;
-    }
-
     if (!_cjose_jwe_malloc(jwe->cek_len + 8, false, &recipient->enc_key.raw, err))
     {
         goto cjose_encrypt_ek_ecdh_es_kw_finish;
     }
 
-    int len = AES_wrap_key(&akey, NULL, recipient->enc_key.raw, jwe->cek, jwe->cek_len);
-    if (len <= 0)
+    if (!_cjose_jwe_aes_kw_wrap(kek, kek_keysize, jwe->cek, jwe->cek_len, recipient->enc_key.raw, &recipient->enc_key.raw_len))
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto cjose_encrypt_ek_ecdh_es_kw_finish;
     }
-    recipient->enc_key.raw_len = len;
     result = true;
 
 cjose_encrypt_ek_ecdh_es_kw_finish:
@@ -1282,35 +1232,25 @@ static bool _cjose_jwe_decrypt_ek_ecdh_es_kw(
         goto cjose_decrypt_ek_ecdh_es_kw_finish;
     }
 
-    AES_KEY akey;
-    if (AES_set_decrypt_key(kek, kek_keysize * 8, &akey) < 0)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
-        goto cjose_decrypt_ek_ecdh_es_kw_finish;
-    }
-
     if (!jwe->fns.set_cek(jwe, NULL, false, err))
     {
         goto cjose_decrypt_ek_ecdh_es_kw_finish;
     }
 
-    // the wrapped key (RFC 3394) is always the plaintext CEK length plus 8 bytes;
-    // enforce this before calling AES_unwrap_key, which would otherwise copy the
-    // attacker-controlled encrypted_key into the fixed-size jwe->cek buffer
+    // The wrapped key (RFC 3394) is always the plaintext CEK length plus 8 bytes.
+    // Enforce this before unwrapping so the attacker-controlled encrypted key
+    // cannot be copied into the fixed-size jwe->cek buffer.
     if (recipient->enc_key.raw_len != jwe->cek_len + 8)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto cjose_decrypt_ek_ecdh_es_kw_finish;
     }
 
-    int len = AES_unwrap_key(&akey, (const unsigned char *)NULL, jwe->cek, (const unsigned char *)recipient->enc_key.raw,
-                             recipient->enc_key.raw_len);
-    if (len <= 0)
+    if (!_cjose_jwe_aes_kw_unwrap(kek, kek_keysize, recipient->enc_key.raw, recipient->enc_key.raw_len, jwe->cek, &jwe->cek_len))
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto cjose_decrypt_ek_ecdh_es_kw_finish;
     }
-    jwe->cek_len = len;
     result = true;
 
 cjose_decrypt_ek_ecdh_es_kw_finish:

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -17,13 +17,14 @@
 #include <stdio.h>
 
 #include <openssl/bn.h>
-#include <openssl/err.h>
 #include <openssl/obj_mac.h>
+#include <openssl/core_names.h>
+#include <openssl/ec.h>
 #include <openssl/rand.h>
 #include <openssl/rsa.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
-#include <openssl/evp.h>
+#include <openssl/param_build.h>
 
 // internal data structures
 
@@ -52,113 +53,11 @@ static const char CJOSE_JWK_K_STR[] = "k";
 
 static const char *JWK_KTY_NAMES[] = { CJOSE_JWK_KTY_RSA_STR, CJOSE_JWK_KTY_EC_STR, CJOSE_JWK_KTY_OCT_STR, CJOSE_JWK_KTY_OKP_STR };
 
-void _cjose_jwk_rsa_get(RSA *rsa, BIGNUM **rsa_n, BIGNUM **rsa_e, BIGNUM **rsa_d)
+bool _cjose_jwk_rsa_has_private(const cjose_jwk_t *jwk)
 {
-    if (rsa == NULL)
-        return;
-    RSA_get0_key(rsa, (const BIGNUM **)rsa_n, (const BIGNUM **)rsa_e, (const BIGNUM **)rsa_d);
-}
-
-bool _cjose_jwk_rsa_set(RSA *rsa, uint8_t *n, size_t n_len, uint8_t *e, size_t e_len, uint8_t *d, size_t d_len)
-{
-    BIGNUM *rsa_n = NULL, *rsa_e = NULL, *rsa_d = NULL;
-
-    // RSA_set0_key doesn't work without each of those on the first call!
-    if ((n == NULL) || (n_len <= 0) || (e == NULL) || (e_len <= 0))
+    if (jwk == NULL || jwk->kty != CJOSE_JWK_KTY_RSA || jwk->keydata == NULL)
         return false;
-
-    if (n && n_len > 0)
-        rsa_n = BN_bin2bn(n, n_len, NULL);
-    if (e && e_len > 0)
-        rsa_e = BN_bin2bn(e, e_len, NULL);
-    if (d && d_len > 0)
-        rsa_d = BN_bin2bn(d, d_len, NULL);
-
-    if (1 != RSA_set0_key(rsa, rsa_n, rsa_e, rsa_d))
-    {
-        // the setter takes ownership only on success; free the BIGNUMs it
-        // refused (e.g. if a BN_bin2bn above failed) rather than leaking them
-        BN_free(rsa_n);
-        BN_free(rsa_e);
-        BN_free(rsa_d);
-        return false;
-    }
-    return true;
-}
-
-void _cjose_jwk_rsa_get_factors(RSA *rsa, BIGNUM **p, BIGNUM **q) { RSA_get0_factors(rsa, (const BIGNUM **)p, (const BIGNUM **)q); }
-
-bool _cjose_jwk_rsa_set_factors(RSA *rsa, uint8_t *p, size_t p_len, uint8_t *q, size_t q_len)
-{
-    BIGNUM *rsa_p = NULL, *rsa_q = NULL;
-
-    if (p && p_len > 0)
-        rsa_p = BN_bin2bn(p, p_len, NULL);
-    if (q && q_len > 0)
-        rsa_q = BN_bin2bn(q, q_len, NULL);
-
-    // no factors supplied: a valid (n, e, d)-only private key
-    if (NULL == rsa_p && NULL == rsa_q)
-        return true;
-
-    // p and q are required together; reject (and free) an incomplete pair
-    // instead of leaking the BIGNUM the setter refuses to take ownership of
-    if (NULL == rsa_p || NULL == rsa_q)
-    {
-        BN_free(rsa_p);
-        BN_free(rsa_q);
-        return false;
-    }
-
-    if (1 != RSA_set0_factors(rsa, rsa_p, rsa_q))
-    {
-        BN_free(rsa_p);
-        BN_free(rsa_q);
-        return false;
-    }
-    return true;
-}
-
-void _cjose_jwk_rsa_get_crt(RSA *rsa, BIGNUM **dmp1, BIGNUM **dmq1, BIGNUM **iqmp)
-{
-    RSA_get0_crt_params(rsa, (const BIGNUM **)dmp1, (const BIGNUM **)dmq1, (const BIGNUM **)iqmp);
-}
-
-bool _cjose_jwk_rsa_set_crt(
-    RSA *rsa, uint8_t *dmp1, size_t dmp1_len, uint8_t *dmq1, size_t dmq1_len, uint8_t *iqmp, size_t iqmp_len)
-{
-    BIGNUM *rsa_dmp1 = NULL, *rsa_dmq1 = NULL, *rsa_iqmp = NULL;
-
-    if (dmp1 && dmp1_len > 0)
-        rsa_dmp1 = BN_bin2bn(dmp1, dmp1_len, NULL);
-    if (dmq1 && dmq1_len > 0)
-        rsa_dmq1 = BN_bin2bn(dmq1, dmq1_len, NULL);
-    if (iqmp && iqmp_len > 0)
-        rsa_iqmp = BN_bin2bn(iqmp, iqmp_len, NULL);
-
-    // no CRT params supplied: nothing to set
-    if (NULL == rsa_dmp1 && NULL == rsa_dmq1 && NULL == rsa_iqmp)
-        return true;
-
-    // the CRT params are required together; reject (and free) an incomplete
-    // set instead of leaking the BIGNUMs the setter refuses to take ownership of
-    if (NULL == rsa_dmp1 || NULL == rsa_dmq1 || NULL == rsa_iqmp)
-    {
-        BN_free(rsa_dmp1);
-        BN_free(rsa_dmq1);
-        BN_free(rsa_iqmp);
-        return false;
-    }
-
-    if (1 != RSA_set0_crt_params(rsa, rsa_dmp1, rsa_dmq1, rsa_iqmp))
-    {
-        BN_free(rsa_dmp1);
-        BN_free(rsa_dmq1);
-        BN_free(rsa_iqmp);
-        return false;
-    }
-
-    return true;
+    return ((rsa_keydata *)jwk->keydata)->has_private;
 }
 
 // interface functions -- Generic
@@ -639,7 +538,55 @@ static inline bool _cjose_jwk_kty_from_name(const char *name, cjose_jwk_kty_t *k
     return retval;
 }
 
-static cjose_jwk_t *_cjose_jwk_EC_new(cjose_jwk_ec_curve crv, EC_KEY *ec, cjose_err *err)
+static const char *_cjose_jwk_ec_group_name_for_curve(cjose_jwk_ec_curve crv)
+{
+    const int nid = _cjose_jwk_ec_nid_for_curve(crv);
+    return nid == NID_undef ? NULL : OBJ_nid2sn(nid);
+}
+
+static EVP_PKEY *_cjose_jwk_EC_from_params(const char *group_name, const uint8_t *pub, size_t pub_len, const BIGNUM *priv)
+{
+    EVP_PKEY *key = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY_CTX *check_ctx = NULL;
+    OSSL_PARAM_BLD *bld = NULL;
+    OSSL_PARAM *params = NULL;
+
+    bld = OSSL_PARAM_BLD_new();
+    if (bld == NULL || OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_GROUP_NAME, (char *)group_name, 0) != 1
+        || OSSL_PARAM_BLD_push_octet_string(bld, OSSL_PKEY_PARAM_PUB_KEY, pub, pub_len) != 1
+        || (priv != NULL && OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PRIV_KEY, priv) != 1))
+    {
+        goto cleanup;
+    }
+
+    params = OSSL_PARAM_BLD_to_param(bld);
+    ctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
+    if (params == NULL || ctx == NULL || EVP_PKEY_fromdata_init(ctx) != 1
+        || EVP_PKEY_fromdata(ctx, &key, priv == NULL ? EVP_PKEY_PUBLIC_KEY : EVP_PKEY_KEYPAIR, params) != 1)
+    {
+        EVP_PKEY_free(key);
+        key = NULL;
+    }
+    else
+    {
+        check_ctx = EVP_PKEY_CTX_new_from_pkey(NULL, key, NULL);
+        if (check_ctx == NULL || (priv == NULL ? EVP_PKEY_public_check(check_ctx) : EVP_PKEY_check(check_ctx)) != 1)
+        {
+            EVP_PKEY_free(key);
+            key = NULL;
+        }
+    }
+
+cleanup:
+    EVP_PKEY_CTX_free(check_ctx);
+    EVP_PKEY_CTX_free(ctx);
+    OSSL_PARAM_free(params);
+    OSSL_PARAM_BLD_free(bld);
+    return key;
+}
+
+static cjose_jwk_t *_cjose_jwk_EC_new(cjose_jwk_ec_curve crv, EVP_PKEY *key, bool has_private, cjose_err *err)
 {
     ec_keydata *keydata = cjose_get_alloc()(sizeof(ec_keydata));
     if (!keydata)
@@ -648,7 +595,8 @@ static cjose_jwk_t *_cjose_jwk_EC_new(cjose_jwk_ec_curve crv, EC_KEY *ec, cjose_
         return NULL;
     }
     keydata->crv = crv;
-    keydata->key = ec;
+    keydata->key = key;
+    keydata->has_private = has_private;
 
     cjose_jwk_t *jwk = cjose_get_alloc()(sizeof(cjose_jwk_t));
     if (!jwk)
@@ -692,11 +640,11 @@ static void _cjose_jwk_EC_free(cjose_jwk_t *jwk)
 
     if (keydata)
     {
-        EC_KEY *ec = keydata->key;
+        EVP_PKEY *key = keydata->key;
         keydata->key = NULL;
-        if (ec)
+        if (key)
         {
-            EC_KEY_free(ec);
+            EVP_PKEY_free(key);
         }
         cjose_get_dealloc()(keydata);
     }
@@ -706,12 +654,13 @@ static void _cjose_jwk_EC_free(cjose_jwk_t *jwk)
 static bool _cjose_jwk_EC_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
 {
     ec_keydata *keydata = (ec_keydata *)jwk->keydata;
-    const EC_GROUP *params = NULL;
-    const EC_POINT *pub = NULL;
-    BIGNUM *bnX = NULL, *bnY = NULL;
+    EC_GROUP *group = NULL;
+    EC_POINT *point = NULL;
+    BIGNUM *bnX = NULL;
+    BIGNUM *bnY = NULL;
     uint8_t *buffer = NULL;
     char *b64u = NULL;
-    size_t len = 0, offset = 0;
+    size_t len = 0;
     json_t *field = NULL;
     bool result = false;
 
@@ -729,34 +678,33 @@ static bool _cjose_jwk_EC_public_fields(const cjose_jwk_t *jwk, json_t *json, cj
     json_decref(field);
     field = NULL;
 
-    // obtain the public key
-    pub = EC_KEY_get0_public_key(keydata->key);
-    params = EC_KEY_get0_group(keydata->key);
-    if (!pub || !params)
+    uint8_t pub[1 + 2 * 66];
+    size_t pub_len = 0;
+    group = EC_GROUP_new_by_curve_name(_cjose_jwk_ec_nid_for_curve(keydata->crv));
+    point = group == NULL ? NULL : EC_POINT_new(group);
+    bnX = BN_new();
+    bnY = BN_new();
+    if (EVP_PKEY_get_octet_string_param(keydata->key, OSSL_PKEY_PARAM_PUB_KEY, pub, sizeof(pub), &pub_len) != 1 || group == NULL
+        || point == NULL || bnX == NULL || bnY == NULL || EC_POINT_oct2point(group, point, pub, pub_len, NULL) != 1
+        || EC_POINT_get_affine_coordinates(group, point, bnX, bnY, NULL) != 1)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto _ec_to_string_cleanup;
     }
 
     buffer = cjose_get_alloc()(numsize);
-    bnX = BN_new();
-    bnY = BN_new();
-    if (!buffer || !bnX || !bnY)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
-        goto _ec_to_string_cleanup;
-    }
-
-    if (1 != EC_POINT_get_affine_coordinates_GFp(params, pub, bnX, bnY, NULL))
+    if (!buffer)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         goto _ec_to_string_cleanup;
     }
 
     // output the x coordinate
-    offset = numsize - BN_num_bytes(bnX);
-    memset(buffer, 0, numsize);
-    BN_bn2bin(bnX, (buffer + offset));
+    if (BN_bn2binpad(bnX, buffer, numsize) != numsize)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        goto _ec_to_string_cleanup;
+    }
     if (!cjose_base64url_encode(buffer, numsize, &b64u, &len, err))
     {
         goto _ec_to_string_cleanup;
@@ -773,9 +721,11 @@ static bool _cjose_jwk_EC_public_fields(const cjose_jwk_t *jwk, json_t *json, cj
     b64u = NULL;
 
     // output the y coordinate
-    offset = numsize - BN_num_bytes(bnY);
-    memset(buffer, 0, numsize);
-    BN_bn2bin(bnY, (buffer + offset));
+    if (BN_bn2binpad(bnY, buffer, numsize) != numsize)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        goto _ec_to_string_cleanup;
+    }
     if (!cjose_base64url_encode(buffer, numsize, &b64u, &len, err))
     {
         goto _ec_to_string_cleanup;
@@ -798,14 +748,6 @@ _ec_to_string_cleanup:
     {
         json_decref(field);
     }
-    if (bnX)
-    {
-        BN_free(bnX);
-    }
-    if (bnY)
-    {
-        BN_free(bnY);
-    }
     if (buffer)
     {
         cjose_get_dealloc()(buffer);
@@ -814,6 +756,10 @@ _ec_to_string_cleanup:
     {
         cjose_get_dealloc()(b64u);
     }
+    BN_free(bnX);
+    BN_free(bnY);
+    EC_POINT_free(point);
+    EC_GROUP_free(group);
 
     return result;
 }
@@ -821,7 +767,7 @@ _ec_to_string_cleanup:
 static bool _cjose_jwk_EC_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
 {
     ec_keydata *keydata = (ec_keydata *)jwk->keydata;
-    const BIGNUM *bnD = EC_KEY_get0_private_key(keydata->key);
+    BIGNUM *bnD = NULL;
     uint8_t *buffer = NULL;
     char *b64u = NULL;
     size_t len = 0, offset = 0;
@@ -831,9 +777,19 @@ static bool _cjose_jwk_EC_private_fields(const cjose_jwk_t *jwk, json_t *json, c
     // track expected binary data size
     uint8_t numsize = _cjose_jwk_ec_size_for_curve(keydata->crv, err);
 
-    // short circuit if 'd' is NULL or 0
-    if (!bnD || BN_is_zero(bnD))
+    // short circuit if this is a public-only key
+    if (!keydata->has_private)
     {
+        return true;
+    }
+    if (EVP_PKEY_get_bn_param(keydata->key, OSSL_PKEY_PARAM_PRIV_KEY, &bnD) != 1)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        return false;
+    }
+    if (BN_is_zero(bnD))
+    {
+        BN_clear_free(bnD);
         return true;
     }
 
@@ -868,6 +824,7 @@ _ec_to_string_cleanup:
     // _cjose_json_stringn failure path (where b64u would otherwise leak)
     _cjose_cleanse_dealloc(buffer, numsize);
     _cjose_cleanse_dealloc(b64u, len);
+    BN_clear_free(bnD);
 
     return result;
 }
@@ -877,27 +834,33 @@ _ec_to_string_cleanup:
 cjose_jwk_t *cjose_jwk_create_EC_random(cjose_jwk_ec_curve crv, cjose_err *err)
 {
     cjose_jwk_t *jwk = NULL;
-    EC_KEY *ec = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *key = NULL;
+    const char *group_name = _cjose_jwk_ec_group_name_for_curve(crv);
+    OSSL_PARAM params[] = { OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, (char *)group_name, 0), OSSL_PARAM_END };
 
-    ec = EC_KEY_new_by_curve_name(_cjose_jwk_ec_nid_for_curve(crv));
-    if (!ec)
+    if (!group_name)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto create_EC_failed;
     }
 
-    if (1 != EC_KEY_generate_key(ec))
+    ctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
+    if (ctx == NULL || EVP_PKEY_keygen_init(ctx) != 1 || EVP_PKEY_CTX_set_params(ctx, params) != 1
+        || EVP_PKEY_keygen(ctx, &key) != 1)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         goto create_EC_failed;
     }
 
-    jwk = _cjose_jwk_EC_new(crv, ec, err);
+    jwk = _cjose_jwk_EC_new(crv, key, true, err);
     if (!jwk)
     {
         goto create_EC_failed;
     }
 
+    key = NULL;
+    EVP_PKEY_CTX_free(ctx);
     return jwk;
 
 create_EC_failed:
@@ -906,11 +869,8 @@ create_EC_failed:
         cjose_get_dealloc()(jwk);
         jwk = NULL;
     }
-    if (ec)
-    {
-        EC_KEY_free(ec);
-        ec = NULL;
-    }
+    EVP_PKEY_free(key);
+    EVP_PKEY_CTX_free(ctx);
 
     return NULL;
 }
@@ -918,12 +878,14 @@ create_EC_failed:
 cjose_jwk_t *cjose_jwk_create_EC_spec(const cjose_jwk_ec_keyspec *spec, cjose_err *err)
 {
     cjose_jwk_t *jwk = NULL;
-    EC_KEY *ec = NULL;
-    EC_GROUP *params = NULL;
+    EVP_PKEY *key = NULL;
+    EC_GROUP *group = NULL;
     EC_POINT *Q = NULL;
     BIGNUM *bnD = NULL;
     BIGNUM *bnX = NULL;
     BIGNUM *bnY = NULL;
+    uint8_t pub[1 + 2 * 66];
+    size_t pub_len = 0;
 
     if (!spec)
     {
@@ -939,17 +901,11 @@ cjose_jwk_t *cjose_jwk_create_EC_spec(const cjose_jwk_ec_keyspec *spec, cjose_er
         return NULL;
     }
 
-    ec = EC_KEY_new_by_curve_name(_cjose_jwk_ec_nid_for_curve(spec->crv));
-    if (NULL == ec)
+    const char *group_name = _cjose_jwk_ec_group_name_for_curve(spec->crv);
+    group = EC_GROUP_new_by_curve_name(_cjose_jwk_ec_nid_for_curve(spec->crv));
+    if (NULL == group || NULL == group_name)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-        goto create_EC_failed;
-    }
-
-    params = (EC_GROUP *)EC_KEY_get0_group(ec);
-    if (NULL == params)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         goto create_EC_failed;
     }
 
@@ -962,20 +918,14 @@ cjose_jwk_t *cjose_jwk_create_EC_spec(const cjose_jwk_ec_keyspec *spec, cjose_er
             CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
             goto create_EC_failed;
         }
-        if (1 != EC_KEY_set_private_key(ec, bnD))
-        {
-            CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-            goto create_EC_failed;
-        }
-
         // calculate public key from private
-        Q = EC_POINT_new(params);
+        Q = EC_POINT_new(group);
         if (NULL == Q)
         {
             CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
             goto create_EC_failed;
         }
-        if (1 != EC_POINT_mul(params, Q, bnD, NULL, NULL, NULL))
+        if (1 != EC_POINT_mul(group, Q, bnD, NULL, NULL, NULL))
         {
             CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
             goto create_EC_failed;
@@ -987,7 +937,7 @@ cjose_jwk_t *cjose_jwk_create_EC_spec(const cjose_jwk_ec_keyspec *spec, cjose_er
     }
     if (hasPub)
     {
-        Q = EC_POINT_new(params);
+        Q = EC_POINT_new(group);
         if (NULL == Q)
         {
             CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
@@ -1002,33 +952,34 @@ cjose_jwk_t *cjose_jwk_create_EC_spec(const cjose_jwk_ec_keyspec *spec, cjose_er
             goto create_EC_failed;
         }
 
-        if (1 != EC_POINT_set_affine_coordinates_GFp(params, Q, bnX, bnY, NULL))
+        if (1 != EC_POINT_set_affine_coordinates(group, Q, bnX, bnY, NULL))
         {
             CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
             goto create_EC_failed;
         }
 
-        if (1 != EC_POINT_is_on_curve(params, Q, NULL))
+        if (1 != EC_POINT_is_on_curve(group, Q, NULL))
         {
             CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
             goto create_EC_failed;
         }
     }
 
-    // always set the public key
-    if (1 != EC_KEY_set_public_key(ec, Q))
+    pub_len = EC_POINT_point2oct(group, Q, POINT_CONVERSION_UNCOMPRESSED, pub, sizeof(pub), NULL);
+    if (pub_len != 1 + 2 * _cjose_jwk_ec_size_for_curve(spec->crv, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto create_EC_failed;
     }
 
-    if (1 != EC_KEY_check_key(ec))
+    key = _cjose_jwk_EC_from_params(group_name, pub, pub_len, bnD);
+    if (key == NULL)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto create_EC_failed;
     }
 
-    jwk = _cjose_jwk_EC_new(spec->crv, ec, err);
+    jwk = _cjose_jwk_EC_new(spec->crv, key, hasPriv, err);
     if (!jwk)
     {
         goto create_EC_failed;
@@ -1043,11 +994,7 @@ create_EC_failed:
         cjose_get_dealloc()(jwk);
         jwk = NULL;
     }
-    if (ec)
-    {
-        EC_KEY_free(ec);
-        ec = NULL;
-    }
+    EVP_PKEY_free(key);
 
 create_EC_cleanup:
     if (Q)
@@ -1055,6 +1002,7 @@ create_EC_cleanup:
         EC_POINT_free(Q);
         Q = NULL;
     }
+    EC_GROUP_free(group);
     if (bnD)
     {
         BN_free(bnD);
@@ -1185,7 +1133,7 @@ static inline bool _cjose_jwk_okp_curve_from_name(const char *name, cjose_jwk_ok
     return retval;
 }
 
-static cjose_jwk_t *_cjose_jwk_OKP_new(cjose_jwk_okp_curve crv, EVP_PKEY *pkey, cjose_err *err)
+static cjose_jwk_t *_cjose_jwk_OKP_new(cjose_jwk_okp_curve crv, EVP_PKEY *pkey, bool has_private, cjose_err *err)
 {
     okp_keydata *keydata = cjose_get_alloc()(sizeof(okp_keydata));
     if (!keydata)
@@ -1195,6 +1143,7 @@ static cjose_jwk_t *_cjose_jwk_OKP_new(cjose_jwk_okp_curve crv, EVP_PKEY *pkey, 
     }
     keydata->crv = crv;
     keydata->key = pkey;
+    keydata->has_private = has_private;
 
     cjose_jwk_t *jwk = cjose_get_alloc()(sizeof(cjose_jwk_t));
     if (!jwk)
@@ -1301,6 +1250,12 @@ static bool _cjose_jwk_OKP_private_fields(const cjose_jwk_t *jwk, json_t *json, 
     // the raw private key has the fixed size of the curve
     size_t numsize = _cjose_jwk_okp_size_for_curve(keydata->crv);
 
+    // Short circuit if the JWK was created without private key material.
+    if (!keydata->has_private)
+    {
+        return true;
+    }
+
     buffer = cjose_get_alloc()(numsize);
     if (!buffer)
     {
@@ -1308,15 +1263,11 @@ static bool _cjose_jwk_OKP_private_fields(const cjose_jwk_t *jwk, json_t *json, 
         goto _okp_to_string_cleanup;
     }
 
-    // short circuit if there is no private key; discard the error OpenSSL may
-    // queue for the missing key so it does not surface in a later cjose_err_message()
     len = numsize;
-    ERR_set_mark();
     rc = EVP_PKEY_get_raw_private_key(keydata->key, buffer, &len);
-    ERR_pop_to_mark();
     if (1 != rc)
     {
-        result = true;
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _okp_to_string_cleanup;
     }
     if (len != numsize)
@@ -1377,7 +1328,7 @@ cjose_jwk_t *cjose_jwk_create_OKP_random(cjose_jwk_okp_curve crv, cjose_err *err
         goto create_OKP_random_cleanup;
     }
 
-    jwk = _cjose_jwk_OKP_new(crv, pkey, err);
+    jwk = _cjose_jwk_OKP_new(crv, pkey, true, err);
     if (NULL == jwk)
     {
         goto create_OKP_random_cleanup;
@@ -1471,7 +1422,7 @@ cjose_jwk_t *cjose_jwk_create_OKP_spec(const cjose_jwk_okp_keyspec *spec, cjose_
         }
     }
 
-    jwk = _cjose_jwk_OKP_new(spec->crv, pkey, err);
+    jwk = _cjose_jwk_OKP_new(spec->crv, pkey, hasPriv, err);
     if (NULL == jwk)
     {
         goto create_OKP_spec_cleanup;
@@ -1507,22 +1458,56 @@ static bool _cjose_jwk_RSA_private_fields(const cjose_jwk_t *jwk, json_t *json, 
 
 static const key_fntable RSA_FNTABLE = { _cjose_jwk_RSA_free, _cjose_jwk_RSA_public_fields, _cjose_jwk_RSA_private_fields };
 
-static inline cjose_jwk_t *_cjose_jwk_RSA_new(RSA *rsa, cjose_err *err)
+static inline cjose_jwk_t *_cjose_jwk_RSA_new(EVP_PKEY *key,
+                                              bool has_private,
+                                              bool has_factors,
+                                              bool has_crt,
+                                              BIGNUM *p,
+                                              BIGNUM *q,
+                                              BIGNUM *dp,
+                                              BIGNUM *dq,
+                                              BIGNUM *qi,
+                                              cjose_err *err)
 {
+    rsa_keydata *keydata = cjose_get_alloc()(sizeof(rsa_keydata));
+    if (!keydata)
+    {
+        EVP_PKEY_free(key);
+        BN_clear_free(p);
+        BN_clear_free(q);
+        BN_clear_free(dp);
+        BN_clear_free(dq);
+        BN_clear_free(qi);
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        return NULL;
+    }
+    keydata->key = key;
+    keydata->has_private = has_private;
+    keydata->has_factors = has_factors;
+    keydata->has_crt = has_crt;
+    keydata->p = p;
+    keydata->q = q;
+    keydata->dp = dp;
+    keydata->dq = dq;
+    keydata->qi = qi;
     cjose_jwk_t *jwk = cjose_get_alloc()(sizeof(cjose_jwk_t));
     if (!jwk)
     {
-        // _cjose_jwk_RSA_new owns rsa on every path; free it here so the callers that
-        // `return _cjose_jwk_RSA_new(rsa, err)` do not leak it on allocation failure
-        RSA_free(rsa);
+        EVP_PKEY_free(key);
+        BN_clear_free(p);
+        BN_clear_free(q);
+        BN_clear_free(dp);
+        BN_clear_free(dq);
+        BN_clear_free(qi);
+        cjose_get_dealloc()(keydata);
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         return NULL;
     }
     memset(jwk, 0, sizeof(cjose_jwk_t));
     jwk->retained = 1;
     jwk->kty = CJOSE_JWK_KTY_RSA;
-    jwk->keysize = RSA_size(rsa) * 8;
-    jwk->keydata = rsa;
+    jwk->keysize = (size_t)EVP_PKEY_get_size(key) * 8;
+    jwk->keydata = keydata;
     jwk->fns = &RSA_FNTABLE;
 
     return jwk;
@@ -1530,16 +1515,22 @@ static inline cjose_jwk_t *_cjose_jwk_RSA_new(RSA *rsa, cjose_err *err)
 
 static void _cjose_jwk_RSA_free(cjose_jwk_t *jwk)
 {
-    RSA *rsa = (RSA *)jwk->keydata;
+    rsa_keydata *keydata = (rsa_keydata *)jwk->keydata;
     jwk->keydata = NULL;
-    if (rsa)
+    if (keydata)
     {
-        RSA_free(rsa);
+        EVP_PKEY_free(keydata->key);
+        BN_clear_free(keydata->p);
+        BN_clear_free(keydata->q);
+        BN_clear_free(keydata->dp);
+        BN_clear_free(keydata->dq);
+        BN_clear_free(keydata->qi);
+        cjose_get_dealloc()(keydata);
     }
     cjose_get_dealloc()(jwk);
 }
 
-static inline bool _cjose_jwk_RSA_json_field(BIGNUM *param, const char *name, json_t *json, cjose_err *err)
+static inline bool _cjose_jwk_RSA_json_field(const BIGNUM *param, const char *name, json_t *json, cjose_err *err)
 {
     json_t *field = NULL;
     uint8_t *data = NULL;
@@ -1587,62 +1578,114 @@ RSA_json_field_cleanup:
 
 static bool _cjose_jwk_RSA_public_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
 {
-    RSA *rsa = (RSA *)jwk->keydata;
+    EVP_PKEY *key = _cjose_jwk_rsa_key(jwk);
+    BIGNUM *rsa_n = NULL, *rsa_e = NULL;
+    bool result = false;
 
-    BIGNUM *rsa_n = NULL, *rsa_e = NULL, *rsa_d = NULL;
-    _cjose_jwk_rsa_get(rsa, &rsa_n, &rsa_e, &rsa_d);
+    if (EVP_PKEY_get_bn_param(key, OSSL_PKEY_PARAM_RSA_N, &rsa_n) != 1
+        || EVP_PKEY_get_bn_param(key, OSSL_PKEY_PARAM_RSA_E, &rsa_e) != 1)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        goto cleanup;
+    }
 
     if (!_cjose_jwk_RSA_json_field(rsa_e, "e", json, err))
     {
-        return false;
+        goto cleanup;
     }
     if (!_cjose_jwk_RSA_json_field(rsa_n, "n", json, err))
     {
-        return false;
+        goto cleanup;
     }
 
+    result = true;
+
+cleanup:
+    BN_free(rsa_n);
+    BN_free(rsa_e);
+    return result;
+}
+
+static bool _cjose_jwk_RSA_get_private_param(EVP_PKEY *key, const BIGNUM *stored, const char *name, BIGNUM **param, cjose_err *err)
+{
+    if (stored != NULL)
+    {
+        *param = BN_dup(stored);
+        if (*param == NULL)
+        {
+            CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+            return false;
+        }
+        return true;
+    }
+    if (EVP_PKEY_get_bn_param(key, name, param) != 1)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        return false;
+    }
     return true;
 }
 
 static bool _cjose_jwk_RSA_private_fields(const cjose_jwk_t *jwk, json_t *json, cjose_err *err)
 {
-    RSA *rsa = (RSA *)jwk->keydata;
-
-    BIGNUM *rsa_n = NULL, *rsa_e = NULL, *rsa_d = NULL;
-    _cjose_jwk_rsa_get(rsa, &rsa_n, &rsa_e, &rsa_d);
-
-    BIGNUM *rsa_p = NULL, *rsa_q = NULL;
-    _cjose_jwk_rsa_get_factors(rsa, &rsa_p, &rsa_q);
-
+    rsa_keydata *keydata = (rsa_keydata *)jwk->keydata;
+    EVP_PKEY *key = keydata->key;
+    BIGNUM *rsa_d = NULL, *rsa_p = NULL, *rsa_q = NULL;
     BIGNUM *rsa_dmp1 = NULL, *rsa_dmq1 = NULL, *rsa_iqmp = NULL;
-    _cjose_jwk_rsa_get_crt(rsa, &rsa_dmp1, &rsa_dmq1, &rsa_iqmp);
+    bool result = false;
+
+    if (!keydata->has_private)
+        return true;
+    if (EVP_PKEY_get_bn_param(key, OSSL_PKEY_PARAM_RSA_D, &rsa_d) != 1)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto cleanup;
+    }
+    if (keydata->has_factors
+        && (!_cjose_jwk_RSA_get_private_param(key, keydata->p, OSSL_PKEY_PARAM_RSA_FACTOR1, &rsa_p, err)
+            || !_cjose_jwk_RSA_get_private_param(key, keydata->q, OSSL_PKEY_PARAM_RSA_FACTOR2, &rsa_q, err)))
+        goto cleanup;
+    if (keydata->has_crt
+        && (!_cjose_jwk_RSA_get_private_param(key, keydata->dp, OSSL_PKEY_PARAM_RSA_EXPONENT1, &rsa_dmp1, err)
+            || !_cjose_jwk_RSA_get_private_param(key, keydata->dq, OSSL_PKEY_PARAM_RSA_EXPONENT2, &rsa_dmq1, err)
+            || !_cjose_jwk_RSA_get_private_param(key, keydata->qi, OSSL_PKEY_PARAM_RSA_COEFFICIENT1, &rsa_iqmp, err)))
+        goto cleanup;
 
     if (!_cjose_jwk_RSA_json_field(rsa_d, "d", json, err))
     {
-        return false;
+        goto cleanup;
     }
     if (!_cjose_jwk_RSA_json_field(rsa_p, "p", json, err))
     {
-        return false;
+        goto cleanup;
     }
     if (!_cjose_jwk_RSA_json_field(rsa_q, "q", json, err))
     {
-        return false;
+        goto cleanup;
     }
     if (!_cjose_jwk_RSA_json_field(rsa_dmp1, "dp", json, err))
     {
-        return false;
+        goto cleanup;
     }
     if (!_cjose_jwk_RSA_json_field(rsa_dmq1, "dq", json, err))
     {
-        return false;
+        goto cleanup;
     }
     if (!_cjose_jwk_RSA_json_field(rsa_iqmp, "qi", json, err))
     {
-        return false;
+        goto cleanup;
     }
 
-    return true;
+    result = true;
+
+cleanup:
+    BN_clear_free(rsa_d);
+    BN_clear_free(rsa_p);
+    BN_clear_free(rsa_q);
+    BN_clear_free(rsa_dmp1);
+    BN_clear_free(rsa_dmq1);
+    BN_clear_free(rsa_iqmp);
+    return result;
 }
 
 // interface functions -- RSA
@@ -1663,11 +1706,12 @@ cjose_jwk_t *cjose_jwk_create_RSA_random(size_t keysize, const uint8_t *e, size_
         elen = DEFAULT_E_LEN;
     }
 
-    RSA *rsa = NULL;
+    EVP_PKEY *key = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
     BIGNUM *bn = NULL;
 
-    rsa = RSA_new();
-    if (!rsa)
+    ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
+    if (!ctx)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         goto create_RSA_random_failed;
@@ -1680,24 +1724,24 @@ cjose_jwk_t *cjose_jwk_create_RSA_random(size_t keysize, const uint8_t *e, size_
         goto create_RSA_random_failed;
     }
 
-    if (0 == RSA_generate_key_ex(rsa, keysize, bn, NULL))
+    if (EVP_PKEY_keygen_init(ctx) != 1 || EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, keysize) != 1
+        || EVP_PKEY_CTX_set1_rsa_keygen_pubexp(ctx, bn) != 1 || EVP_PKEY_keygen(ctx, &key) != 1)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         goto create_RSA_random_failed;
     }
 
     BN_free(bn);
-    return _cjose_jwk_RSA_new(rsa, err);
+    EVP_PKEY_CTX_free(ctx);
+    return _cjose_jwk_RSA_new(key, true, true, true, NULL, NULL, NULL, NULL, NULL, err);
 
 create_RSA_random_failed:
     if (bn)
     {
         BN_free(bn);
     }
-    if (rsa)
-    {
-        RSA_free(rsa);
-    }
+    EVP_PKEY_free(key);
+    EVP_PKEY_CTX_free(ctx);
     return NULL;
 }
 
@@ -1732,45 +1776,84 @@ cjose_jwk_t *cjose_jwk_create_RSA_spec(const cjose_jwk_rsa_keyspec *spec, cjose_
     }
     BN_free(n_bn);
 
-    RSA *rsa = NULL;
-    rsa = RSA_new();
-    if (!rsa)
+    if (!hasPub || (hasPriv && (NULL == spec->e || 0 == spec->elen)))
     {
-        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return NULL;
     }
 
-    if (hasPriv)
+    bool has_factors = hasPriv && ((spec->p != NULL && spec->plen > 0) || (spec->q != NULL && spec->qlen > 0));
+    bool has_crt = hasPriv
+                   && ((spec->dp != NULL && spec->dplen > 0) || (spec->dq != NULL && spec->dqlen > 0)
+                       || (spec->qi != NULL && spec->qilen > 0));
+    if ((has_factors && (spec->p == NULL || spec->plen == 0 || spec->q == NULL || spec->qlen == 0))
+        || (has_crt
+            && (spec->dp == NULL || spec->dplen == 0 || spec->dq == NULL || spec->dqlen == 0 || spec->qi == NULL
+                || spec->qilen == 0)))
     {
-        if (!_cjose_jwk_rsa_set(rsa, spec->n, spec->nlen, spec->e, spec->elen, spec->d, spec->dlen))
-        {
-            CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-            goto create_RSA_spec_failed;
-        }
-        if (!_cjose_jwk_rsa_set_factors(rsa, spec->p, spec->plen, spec->q, spec->qlen)
-            || !_cjose_jwk_rsa_set_crt(rsa, spec->dp, spec->dplen, spec->dq, spec->dqlen, spec->qi, spec->qilen))
-        {
-            CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-            goto create_RSA_spec_failed;
-        }
-    }
-    else if (hasPub)
-    {
-        if (!_cjose_jwk_rsa_set(rsa, spec->n, spec->nlen, spec->e, spec->elen, NULL, 0))
-        {
-            CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-            goto create_RSA_spec_failed;
-        }
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return NULL;
     }
 
-    return _cjose_jwk_RSA_new(rsa, err);
+    EVP_PKEY *key = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
+    OSSL_PARAM_BLD *bld = NULL;
+    OSSL_PARAM *params = NULL;
+    BIGNUM *n = BN_bin2bn(spec->n, spec->nlen, NULL);
+    BIGNUM *e = BN_bin2bn(spec->e, spec->elen, NULL);
+    BIGNUM *d = hasPriv ? BN_bin2bn(spec->d, spec->dlen, NULL) : NULL;
+    BIGNUM *p = has_factors ? BN_bin2bn(spec->p, spec->plen, NULL) : NULL;
+    BIGNUM *q = has_factors ? BN_bin2bn(spec->q, spec->qlen, NULL) : NULL;
+    BIGNUM *dp = has_crt ? BN_bin2bn(spec->dp, spec->dplen, NULL) : NULL;
+    BIGNUM *dq = has_crt ? BN_bin2bn(spec->dq, spec->dqlen, NULL) : NULL;
+    BIGNUM *qi = has_crt ? BN_bin2bn(spec->qi, spec->qilen, NULL) : NULL;
+    bool has_complete_crt = has_factors && has_crt;
+
+    bld = OSSL_PARAM_BLD_new();
+    if (n == NULL || e == NULL || (hasPriv && d == NULL) || (has_factors && (p == NULL || q == NULL))
+        || (has_crt && (dp == NULL || dq == NULL || qi == NULL)) || bld == NULL
+        || OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_N, n) != 1 || OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_E, e) != 1
+        || (d != NULL && OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_D, d) != 1)
+        || (has_complete_crt && OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_FACTOR1, p) != 1)
+        || (has_complete_crt && OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_FACTOR2, q) != 1)
+        || (has_complete_crt && OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_EXPONENT1, dp) != 1)
+        || (has_complete_crt && OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_EXPONENT2, dq) != 1)
+        || (has_complete_crt && OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_COEFFICIENT1, qi) != 1))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        goto create_RSA_spec_failed;
+    }
+
+    params = OSSL_PARAM_BLD_to_param(bld);
+    ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
+    if (params == NULL || ctx == NULL || EVP_PKEY_fromdata_init(ctx) != 1
+        || EVP_PKEY_fromdata(ctx, &key, hasPriv ? EVP_PKEY_KEYPAIR : EVP_PKEY_PUBLIC_KEY, params) != 1)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        goto create_RSA_spec_failed;
+    }
+
+    OSSL_PARAM_free(params);
+    OSSL_PARAM_BLD_free(bld);
+    EVP_PKEY_CTX_free(ctx);
+    BN_free(n);
+    BN_free(e);
+    BN_clear_free(d);
+    return _cjose_jwk_RSA_new(key, hasPriv, has_factors, has_crt, p, q, dp, dq, qi, err);
 
 create_RSA_spec_failed:
-    if (rsa)
-    {
-        RSA_free(rsa);
-    }
-
+    EVP_PKEY_free(key);
+    EVP_PKEY_CTX_free(ctx);
+    OSSL_PARAM_free(params);
+    OSSL_PARAM_BLD_free(bld);
+    BN_free(n);
+    BN_free(e);
+    BN_clear_free(d);
+    BN_clear_free(p);
+    BN_clear_free(q);
+    BN_clear_free(dp);
+    BN_clear_free(dq);
+    BN_clear_free(qi);
     return NULL;
 }
 
@@ -2252,20 +2335,13 @@ static bool _cjose_jwk_evp_key_from_ec_key(const cjose_jwk_t *jwk, EVP_PKEY **ke
         goto _cjose_jwk_evp_key_from_ec_key_fail;
     }
 
-    // create a blank EVP_PKEY
-    *key = EVP_PKEY_new();
-    if (NULL == *key)
+    EVP_PKEY *jwk_key = ((ec_keydata *)(jwk->keydata))->key;
+    if (NULL == jwk_key || 1 != EVP_PKEY_up_ref(jwk_key))
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _cjose_jwk_evp_key_from_ec_key_fail;
     }
-
-    // assign the EVP_PKEY to reference the jwk's internal EC_KEY structure
-    if (1 != EVP_PKEY_set1_EC_KEY(*key, ((struct _ec_keydata_int *)(jwk->keydata))->key))
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
-        goto _cjose_jwk_evp_key_from_ec_key_fail;
-    }
+    *key = jwk_key;
 
     // happy path
     return true;

--- a/src/jws.c
+++ b/src/jws.c
@@ -15,8 +15,8 @@
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
 #include <openssl/bn.h>
-#include <openssl/err.h>
-#include <openssl/hmac.h>
+#include <openssl/core_names.h>
+#include <openssl/ecdsa.h>
 
 #include "include/jwk_int.h"
 #include "include/header_int.h"
@@ -213,15 +213,13 @@ static bool _cjose_jws_build_dig_sha(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
         goto _cjose_jws_build_dig_sha_cleanup;
     }
 
-    // instantiate and initialize a new mac digest context
-    ctx = EVP_MD_CTX_create();
+    // instantiate and initialize a new digest context
+    ctx = EVP_MD_CTX_new();
     if (NULL == ctx)
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _cjose_jws_build_dig_sha_cleanup;
     }
-    EVP_MD_CTX_init(ctx);
-
     // create digest as DIGEST(B64U(HEADER).B64U(DATA))
     if (EVP_DigestInit_ex(ctx, digest_alg, NULL) != 1)
     {
@@ -255,7 +253,7 @@ static bool _cjose_jws_build_dig_sha(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
 _cjose_jws_build_dig_sha_cleanup:
     if (NULL != ctx)
     {
-        EVP_MD_CTX_destroy(ctx);
+        EVP_MD_CTX_free(ctx);
     }
 
     return retval;
@@ -265,7 +263,8 @@ _cjose_jws_build_dig_sha_cleanup:
 static bool _cjose_jws_build_dig_hmac_sha(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err)
 {
     bool retval = false;
-    HMAC_CTX *ctx = NULL;
+    EVP_MAC *mac = NULL;
+    EVP_MAC_CTX *ctx = NULL;
 
     // ensure jwk is OCT: only then is keydata the raw key material
     if (jwk->kty != CJOSE_JWK_KTY_OCT)
@@ -320,36 +319,43 @@ static bool _cjose_jws_build_dig_hmac_sha(cjose_jws_t *jws, const cjose_jwk_t *j
         goto _cjose_jws_build_dig_hmac_sha_cleanup;
     }
 
-    // instantiate and initialize a new mac digest context
-    ctx = HMAC_CTX_new();
+    mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
+    if (NULL == mac)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto _cjose_jws_build_dig_hmac_sha_cleanup;
+    }
+    ctx = EVP_MAC_CTX_new(mac);
     if (NULL == ctx)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         goto _cjose_jws_build_dig_hmac_sha_cleanup;
     }
 
-    // create digest as DIGEST(B64U(HEADER).B64U(DATA))
-    if (HMAC_Init_ex(ctx, jwk->keydata, jwk->keysize / 8, digest_alg, NULL) != 1)
+    OSSL_PARAM params[]
+        = { OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_DIGEST, (char *)EVP_MD_get0_name(digest_alg), 0), OSSL_PARAM_END };
+    size_t mac_len = 0;
+    if (EVP_MAC_init(ctx, jwk->keydata, jwk->keysize / 8, params) != 1)
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _cjose_jws_build_dig_hmac_sha_cleanup;
     }
-    if (HMAC_Update(ctx, (const unsigned char *)jws->hdr_b64u, jws->hdr_b64u_len) != 1)
+    if (EVP_MAC_update(ctx, (const unsigned char *)jws->hdr_b64u, jws->hdr_b64u_len) != 1)
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _cjose_jws_build_dig_hmac_sha_cleanup;
     }
-    if (HMAC_Update(ctx, (const unsigned char *)".", 1) != 1)
+    if (EVP_MAC_update(ctx, (const unsigned char *)".", 1) != 1)
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _cjose_jws_build_dig_hmac_sha_cleanup;
     }
-    if (HMAC_Update(ctx, (const unsigned char *)jws->dat_b64u, jws->dat_b64u_len) != 1)
+    if (EVP_MAC_update(ctx, (const unsigned char *)jws->dat_b64u, jws->dat_b64u_len) != 1)
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _cjose_jws_build_dig_hmac_sha_cleanup;
     }
-    if (HMAC_Final(ctx, jws->dig, NULL) != 1)
+    if (EVP_MAC_final(ctx, jws->dig, &mac_len, jws->dig_len) != 1 || mac_len != jws->dig_len)
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _cjose_jws_build_dig_hmac_sha_cleanup;
@@ -359,171 +365,94 @@ static bool _cjose_jws_build_dig_hmac_sha(cjose_jws_t *jws, const cjose_jwk_t *j
     retval = true;
 
 _cjose_jws_build_dig_hmac_sha_cleanup:
-    if (NULL != ctx)
-    {
-        HMAC_CTX_free(ctx);
-    }
+    EVP_MAC_CTX_free(ctx);
+    EVP_MAC_free(mac);
 
     return retval;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-static bool _cjose_jws_build_sig_ps(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err)
+static const EVP_MD *_cjose_jws_rsa_digest(const char *alg)
 {
-    bool retval = false;
-    uint8_t *em = NULL;
-    size_t em_len = 0;
+    if (strcmp(alg, CJOSE_HDR_ALG_PS256) == 0 || strcmp(alg, CJOSE_HDR_ALG_RS256) == 0)
+        return EVP_sha256();
+    if (strcmp(alg, CJOSE_HDR_ALG_PS384) == 0 || strcmp(alg, CJOSE_HDR_ALG_RS384) == 0)
+        return EVP_sha384();
+    if (strcmp(alg, CJOSE_HDR_ALG_PS512) == 0 || strcmp(alg, CJOSE_HDR_ALG_RS512) == 0)
+        return EVP_sha512();
+    return NULL;
+}
 
-    // ensure jwk is private RSA
+static bool _cjose_jws_rsa_sign(cjose_jws_t *jws, const cjose_jwk_t *jwk, const EVP_MD *digest_alg, int padding, cjose_err *err)
+{
+    EVP_PKEY_CTX *ctx = NULL;
+
     if (jwk->kty != CJOSE_JWK_KTY_RSA)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-        goto _cjose_jws_build_sig_ps_cleanup;
+        return false;
     }
-    RSA *rsa = (RSA *)jwk->keydata;
-    BIGNUM *rsa_n = NULL, *rsa_e = NULL, *rsa_d = NULL;
-    _cjose_jwk_rsa_get(rsa, &rsa_n, &rsa_e, &rsa_d);
-    if (!rsa || !rsa_e || !rsa_n || !rsa_d)
+
+    EVP_PKEY *key = _cjose_jwk_rsa_key(jwk);
+    if (!_cjose_jwk_rsa_has_private(jwk))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return false;
     }
+    ctx = EVP_PKEY_CTX_new(key, NULL);
+    if (ctx == NULL || EVP_PKEY_sign_init(ctx) != 1 || EVP_PKEY_CTX_set_rsa_padding(ctx, padding) != 1
+        || EVP_PKEY_CTX_set_signature_md(ctx, digest_alg) != 1
+        || (padding == RSA_PKCS1_PSS_PADDING
+            && (EVP_PKEY_CTX_set_rsa_mgf1_md(ctx, digest_alg) != 1
+                || EVP_PKEY_CTX_set_rsa_pss_saltlen(ctx, RSA_PSS_SALTLEN_DIGEST) != 1))
+        || EVP_PKEY_sign(ctx, NULL, &jws->sig_len, jws->dig, jws->dig_len) != 1)
+    {
+        EVP_PKEY_CTX_free(ctx);
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        return false;
+    }
+    jws->sig = cjose_get_alloc()(jws->sig_len);
+    if (jws->sig == NULL)
+    {
+        EVP_PKEY_CTX_free(ctx);
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        return false;
+    }
+    if (EVP_PKEY_sign(ctx, jws->sig, &jws->sig_len, jws->dig, jws->dig_len) != 1)
+    {
+        EVP_PKEY_CTX_free(ctx);
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        return false;
+    }
+    EVP_PKEY_CTX_free(ctx);
+    if (!cjose_base64url_encode(jws->sig, jws->sig_len, &jws->sig_b64u, &jws->sig_b64u_len, err))
+        return false;
+    return true;
+}
 
-    // make sure we have an alg header
+static bool _cjose_jws_build_sig_ps(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err)
+{
     json_t *alg_obj = json_object_get(jws->hdr, CJOSE_HDR_ALG);
-    if (NULL == alg_obj)
+    const EVP_MD *digest_alg = alg_obj == NULL ? NULL : _cjose_jws_rsa_digest(json_string_value(alg_obj));
+    if (digest_alg == NULL)
     {
-        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        CJOSE_ERROR(err, alg_obj == NULL ? CJOSE_ERR_INVALID_ARG : CJOSE_ERR_CRYPTO);
         return false;
     }
-    const char *alg = json_string_value(alg_obj);
-
-    // build digest using SHA-256/384/512 digest algorithm
-    const EVP_MD *digest_alg = NULL;
-    if (strcmp(alg, CJOSE_HDR_ALG_PS256) == 0)
-        digest_alg = EVP_sha256();
-    else if (strcmp(alg, CJOSE_HDR_ALG_PS384) == 0)
-        digest_alg = EVP_sha384();
-    else if (strcmp(alg, CJOSE_HDR_ALG_PS512) == 0)
-        digest_alg = EVP_sha512();
-
-    if (NULL == digest_alg)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
-        goto _cjose_jws_build_sig_ps_cleanup;
-    }
-
-    // apply EMSA-PSS encoding (RFC-3447, 8.1.1, step 1)
-    // (RSA_padding_add_PKCS1_PSS includes PKCS1_MGF1, -1 => saltlen = hashlen)
-    em_len = RSA_size((RSA *)jwk->keydata);
-    em = (uint8_t *)cjose_get_alloc()(em_len);
-    if (NULL == em)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
-        goto _cjose_jws_build_sig_ps_cleanup;
-    }
-    if (RSA_padding_add_PKCS1_PSS((RSA *)jwk->keydata, em, jws->dig, digest_alg, -1) != 1)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
-        goto _cjose_jws_build_sig_ps_cleanup;
-    }
-
-    // sign the digest (RFC-3447, 8.1.1, step 2)
-    jws->sig_len = em_len;
-    jws->sig = (uint8_t *)cjose_get_alloc()(jws->sig_len);
-    if (NULL == jws->sig)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
-        goto _cjose_jws_build_sig_ps_cleanup;
-    }
-
-    if (RSA_private_encrypt(em_len, em, jws->sig, (RSA *)jwk->keydata, RSA_NO_PADDING) != jws->sig_len)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
-        goto _cjose_jws_build_sig_ps_cleanup;
-    }
-
-    // base64url encode signed digest
-    if (!cjose_base64url_encode((const uint8_t *)jws->sig, jws->sig_len, &jws->sig_b64u, &jws->sig_b64u_len, err))
-    {
-        goto _cjose_jws_build_sig_ps_cleanup;
-    }
-
-    // if we got this far - success
-    retval = true;
-
-_cjose_jws_build_sig_ps_cleanup:
-    cjose_get_dealloc()(em);
-
-    return retval;
+    return _cjose_jws_rsa_sign(jws, jwk, digest_alg, RSA_PKCS1_PSS_PADDING, err);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 static bool _cjose_jws_build_sig_rs(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err)
 {
-    // ensure jwk is private RSA
-    if (jwk->kty != CJOSE_JWK_KTY_RSA)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-        return false;
-    }
-    RSA *rsa = (RSA *)jwk->keydata;
-    BIGNUM *rsa_n = NULL, *rsa_e = NULL, *rsa_d = NULL;
-    _cjose_jwk_rsa_get(rsa, &rsa_n, &rsa_e, &rsa_d);
-    if (!rsa || !rsa_e || !rsa_n || !rsa_d)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-        return false;
-    }
-
-    // allocate buffer for signature
-    jws->sig_len = RSA_size((RSA *)jwk->keydata);
-    jws->sig = (uint8_t *)cjose_get_alloc()(jws->sig_len);
-    if (NULL == jws->sig)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
-        return false;
-    }
-
-    // make sure we have an alg header
     json_t *alg_obj = json_object_get(jws->hdr, CJOSE_HDR_ALG);
-    if (NULL == alg_obj)
+    const EVP_MD *digest_alg = alg_obj == NULL ? NULL : _cjose_jws_rsa_digest(json_string_value(alg_obj));
+    if (digest_alg == NULL)
     {
-        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        CJOSE_ERROR(err, alg_obj == NULL ? CJOSE_ERR_INVALID_ARG : CJOSE_ERR_CRYPTO);
         return false;
     }
-    const char *alg = json_string_value(alg_obj);
-
-    // build digest using SHA-256/384/512 digest algorithm
-    int digest_alg = -1;
-    if (strcmp(alg, CJOSE_HDR_ALG_RS256) == 0)
-        digest_alg = NID_sha256;
-    else if (strcmp(alg, CJOSE_HDR_ALG_RS384) == 0)
-        digest_alg = NID_sha384;
-    else if (strcmp(alg, CJOSE_HDR_ALG_RS512) == 0)
-        digest_alg = NID_sha512;
-    if (-1 == digest_alg)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
-        return false;
-    }
-
-    unsigned int siglen;
-    if (RSA_sign(digest_alg, jws->dig, jws->dig_len, jws->sig, &siglen, (RSA *)jwk->keydata) != 1)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
-        return false;
-    }
-    jws->sig_len = siglen;
-
-    // base64url encode signed digest
-    if (!cjose_base64url_encode((const uint8_t *)jws->sig, jws->sig_len, &jws->sig_b64u, &jws->sig_b64u_len, err))
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
-        return false;
-    }
-
-    return true;
+    return _cjose_jws_rsa_sign(jws, jwk, digest_alg, RSA_PKCS1_PADDING, err);
 }
 
 static bool _cjose_jws_build_sig_hmac_sha(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err)
@@ -568,9 +497,37 @@ static bool _cjose_jws_build_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, cj
     }
 
     ec_keydata *keydata = (ec_keydata *)jwk->keydata;
-    EC_KEY *ec = keydata->key;
-
-    ECDSA_SIG *ecdsa_sig = ECDSA_do_sign(jws->dig, jws->dig_len, ec);
+    EVP_PKEY_CTX *ctx = NULL;
+    ECDSA_SIG *ecdsa_sig = NULL;
+    uint8_t *der = NULL;
+    size_t der_len = 0;
+    const EVP_MD *digest_alg = NULL;
+    if (strcmp(alg, CJOSE_HDR_ALG_ES256) == 0 || strcmp(alg, CJOSE_HDR_ALG_ES256K) == 0)
+        digest_alg = EVP_sha256();
+    else if (strcmp(alg, CJOSE_HDR_ALG_ES384) == 0)
+        digest_alg = EVP_sha384();
+    else if (strcmp(alg, CJOSE_HDR_ALG_ES512) == 0)
+        digest_alg = EVP_sha512();
+    if (!keydata->has_private)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+    ctx = EVP_PKEY_CTX_new(keydata->key, NULL);
+    if (digest_alg == NULL || ctx == NULL || EVP_PKEY_sign_init(ctx) != 1 || EVP_PKEY_CTX_set_signature_md(ctx, digest_alg) != 1
+        || EVP_PKEY_sign(ctx, NULL, &der_len, jws->dig, jws->dig_len) != 1)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto _cjose_jws_build_sig_ec_cleanup;
+    }
+    der = cjose_get_alloc()(der_len);
+    if (der == NULL || EVP_PKEY_sign(ctx, der, &der_len, jws->dig, jws->dig_len) != 1)
+    {
+        CJOSE_ERROR(err, der == NULL ? CJOSE_ERR_NO_MEMORY : CJOSE_ERR_CRYPTO);
+        goto _cjose_jws_build_sig_ec_cleanup;
+    }
+    const unsigned char *der_pos = der;
+    ecdsa_sig = d2i_ECDSA_SIG(NULL, &der_pos, der_len);
     if (NULL == ecdsa_sig)
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
@@ -624,6 +581,8 @@ static bool _cjose_jws_build_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, cj
     retval = true;
 
 _cjose_jws_build_sig_ec_cleanup:
+    EVP_PKEY_CTX_free(ctx);
+    cjose_get_dealloc()(der);
     if (ecdsa_sig)
         ECDSA_SIG_free(ecdsa_sig);
 
@@ -913,8 +872,7 @@ cjose_jws_t *cjose_jws_import(const char *cser, size_t cser_len, cjose_err *err)
 static bool _cjose_jws_verify_sig_ps(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err)
 {
     bool retval = false;
-    uint8_t *em = NULL;
-    int em_len = 0;
+    EVP_PKEY_CTX *ctx = NULL;
 
     // ensure jwk is RSA
     if (jwk->kty != CJOSE_JWK_KTY_RSA)
@@ -947,29 +905,17 @@ static bool _cjose_jws_verify_sig_ps(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
         goto _cjose_jws_verify_sig_ps_cleanup;
     }
 
-    // allocate buffer for encoded message
-    em_len = RSA_size((RSA *)jwk->keydata);
-    if (em_len <= 0 || jws->sig_len != (size_t)em_len)
+    EVP_PKEY *key = _cjose_jwk_rsa_key(jwk);
+    if (jws->sig_len != (size_t)EVP_PKEY_get_size(key))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto _cjose_jws_verify_sig_ps_cleanup;
     }
-    em = (uint8_t *)cjose_get_alloc()((size_t)em_len);
-    if (NULL == em)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
-        goto _cjose_jws_verify_sig_ps_cleanup;
-    }
-
-    // decrypt signature
-    if (RSA_public_decrypt(em_len, jws->sig, em, (RSA *)jwk->keydata, RSA_NO_PADDING) != em_len)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
-        goto _cjose_jws_verify_sig_ps_cleanup;
-    }
-
-    // verify decrypted signature data against PSS encoded digest
-    if (RSA_verify_PKCS1_PSS((RSA *)jwk->keydata, jws->dig, digest_alg, em, -1) != 1)
+    ctx = EVP_PKEY_CTX_new(key, NULL);
+    if (ctx == NULL || EVP_PKEY_verify_init(ctx) != 1 || EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_PSS_PADDING) != 1
+        || EVP_PKEY_CTX_set_signature_md(ctx, digest_alg) != 1 || EVP_PKEY_CTX_set_rsa_mgf1_md(ctx, digest_alg) != 1
+        || EVP_PKEY_CTX_set_rsa_pss_saltlen(ctx, RSA_PSS_SALTLEN_DIGEST) != 1
+        || EVP_PKEY_verify(ctx, jws->sig, jws->sig_len, jws->dig, jws->dig_len) != 1)
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _cjose_jws_verify_sig_ps_cleanup;
@@ -979,7 +925,7 @@ static bool _cjose_jws_verify_sig_ps(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
     retval = true;
 
 _cjose_jws_verify_sig_ps_cleanup:
-    cjose_get_dealloc()(em);
+    EVP_PKEY_CTX_free(ctx);
 
     return retval;
 }
@@ -988,6 +934,7 @@ _cjose_jws_verify_sig_ps_cleanup:
 static bool _cjose_jws_verify_sig_rs(cjose_jws_t *jws, const cjose_jwk_t *jwk, cjose_err *err)
 {
     bool retval = false;
+    EVP_PKEY_CTX *ctx = NULL;
 
     // ensure jwk is RSA
     if (jwk->kty != CJOSE_JWK_KTY_RSA)
@@ -1005,21 +952,18 @@ static bool _cjose_jws_verify_sig_rs(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
     }
     const char *alg = json_string_value(alg_obj);
 
-    // build digest using SHA-256/384/512 digest algorithm
-    int digest_alg = -1;
-    if (strcmp(alg, CJOSE_HDR_ALG_RS256) == 0)
-        digest_alg = NID_sha256;
-    else if (strcmp(alg, CJOSE_HDR_ALG_RS384) == 0)
-        digest_alg = NID_sha384;
-    else if (strcmp(alg, CJOSE_HDR_ALG_RS512) == 0)
-        digest_alg = NID_sha512;
-    if (-1 == digest_alg)
+    const EVP_MD *digest_alg = _cjose_jws_rsa_digest(alg);
+    if (digest_alg == NULL)
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _cjose_jws_verify_sig_rs_cleanup;
     }
 
-    if (RSA_verify(digest_alg, jws->dig, jws->dig_len, jws->sig, jws->sig_len, (RSA *)jwk->keydata) != 1)
+    EVP_PKEY *key = _cjose_jwk_rsa_key(jwk);
+    ctx = EVP_PKEY_CTX_new(key, NULL);
+    if (ctx == NULL || EVP_PKEY_verify_init(ctx) != 1 || EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_PADDING) != 1
+        || EVP_PKEY_CTX_set_signature_md(ctx, digest_alg) != 1
+        || EVP_PKEY_verify(ctx, jws->sig, jws->sig_len, jws->dig, jws->dig_len) != 1)
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _cjose_jws_verify_sig_rs_cleanup;
@@ -1029,7 +973,7 @@ static bool _cjose_jws_verify_sig_rs(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
     retval = true;
 
 _cjose_jws_verify_sig_rs_cleanup:
-
+    EVP_PKEY_CTX_free(ctx);
     return retval;
 }
 
@@ -1079,7 +1023,8 @@ static bool _cjose_jws_verify_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
     }
 
     ec_keydata *keydata = (ec_keydata *)jwk->keydata;
-    EC_KEY *ec = keydata->key;
+    EVP_PKEY_CTX *ctx = NULL;
+    uint8_t *der = NULL;
 
     // the JWS ECDSA signature is the fixed-length concatenation R || S, each
     // the curve's coordinate size (RFC 7518 section 3.4); reject any other
@@ -1131,7 +1076,30 @@ static bool _cjose_jws_verify_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
     BN_bin2bn(jws->sig + key_len, key_len, ps);
     ECDSA_SIG_set0(ecdsa_sig, pr, ps); // takes ownership of pr and ps
 
-    if (ECDSA_do_verify(jws->dig, jws->dig_len, ecdsa_sig, ec) != 1)
+    int der_len = i2d_ECDSA_SIG(ecdsa_sig, NULL);
+    if (der_len <= 0)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto _cjose_jws_verify_sig_ec_cleanup;
+    }
+    der = cjose_get_alloc()((size_t)der_len);
+    if (der == NULL)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        goto _cjose_jws_verify_sig_ec_cleanup;
+    }
+    unsigned char *der_pos = der;
+    const char *alg = json_string_value(json_object_get(jws->hdr, CJOSE_HDR_ALG));
+    const EVP_MD *digest_alg = NULL;
+    if (strcmp(alg, CJOSE_HDR_ALG_ES256) == 0 || strcmp(alg, CJOSE_HDR_ALG_ES256K) == 0)
+        digest_alg = EVP_sha256();
+    else if (strcmp(alg, CJOSE_HDR_ALG_ES384) == 0)
+        digest_alg = EVP_sha384();
+    else if (strcmp(alg, CJOSE_HDR_ALG_ES512) == 0)
+        digest_alg = EVP_sha512();
+    ctx = EVP_PKEY_CTX_new(keydata->key, NULL);
+    if (digest_alg == NULL || i2d_ECDSA_SIG(ecdsa_sig, &der_pos) != der_len || ctx == NULL || EVP_PKEY_verify_init(ctx) != 1
+        || EVP_PKEY_CTX_set_signature_md(ctx, digest_alg) != 1 || EVP_PKEY_verify(ctx, der, der_len, jws->dig, jws->dig_len) != 1)
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _cjose_jws_verify_sig_ec_cleanup;
@@ -1141,6 +1109,8 @@ static bool _cjose_jws_verify_sig_ec(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
     retval = true;
 
 _cjose_jws_verify_sig_ec_cleanup:
+    EVP_PKEY_CTX_free(ctx);
+    cjose_get_dealloc()(der);
     if (ecdsa_sig)
         ECDSA_SIG_free(ecdsa_sig);
 
@@ -1267,26 +1237,9 @@ static bool _cjose_jws_build_sig_eddsa(cjose_jws_t *jws, const cjose_jwk_t *jwk,
 
     okp_keydata *keydata = (okp_keydata *)jwk->keydata;
 
-    // signing needs the private key: OpenSSL 1.1.1 and 3.0.0 to 3.0.7 sign
-    // with the missing private key of a public-only key instead of failing
-    // (3.0.8 added the guard), so refuse it here rather than rely on OpenSSL;
-    // 1.1.1 only reports the absence of the private key when asked to copy
-    // it out, so copy it into a scratch buffer that is wiped right after
-    size_t priv_len = 0;
-    if (1 != EVP_PKEY_get_raw_private_key(keydata->key, NULL, &priv_len) || 0 == priv_len)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-        return false;
-    }
-    uint8_t *priv = (uint8_t *)cjose_get_alloc()(priv_len);
-    if (NULL == priv)
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
-        return false;
-    }
-    int has_priv = EVP_PKEY_get_raw_private_key(keydata->key, priv, &priv_len);
-    _cjose_cleanse_dealloc(priv, priv_len);
-    if (1 != has_priv)
+    // OpenSSL 3.0.0 through 3.0.7 may sign with a public-only key instead of
+    // failing (3.0.8 added the guard), so enforce the JWK's key material here.
+    if (!keydata->has_private)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return false;

--- a/test/check_header.c
+++ b/test/check_header.c
@@ -10,12 +10,7 @@
 #include <check.h>
 #include <cjose/cjose.h>
 #include <jansson.h>
-#include "include/jwk_int.h"
-#include "include/jwe_int.h"
 #include "include/header_int.h"
-#include <openssl/rsa.h>
-#include <openssl/err.h>
-#include <openssl/rand.h>
 
 START_TEST(test_cjose_header_new_release)
 {

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -13,7 +13,6 @@
 #include "include/jwe_int.h"
 #include "include/util_int.h"
 #include <openssl/rsa.h>
-#include <openssl/err.h>
 #include <openssl/rand.h>
 #include <cjose/error.h>
 
@@ -1077,7 +1076,7 @@ END_TEST
 // build a compact JWE from a valid AES-KW JWE but with the encrypted_key segment
 // replaced by an oversized (attacker-controlled) base64url blob, then confirm that
 // importing parses fine but decryption fails gracefully instead of overflowing the
-// fixed-size CEK buffer in AES_unwrap_key (RFC 3394 wrapped key is always cek_len + 8)
+// fixed-size CEK buffer (RFC 3394 wrapped key is always cek_len + 8)
 static void _decrypt_oversized_aes_kw_ek(const char *alg, const char *enc, const char *key)
 {
     cjose_err err;
@@ -1655,14 +1654,21 @@ START_TEST(test_cjose_jwe_decrypt_rsa_wrong_cek_length)
 
     // recover the real 32-byte A256GCM CEK by unwrapping the encrypted_key
     // segment with the private key
-    RSA *rsa = (RSA *)jwk->keydata;
-    int ek_len = RSA_size(rsa);
+    EVP_PKEY *rsa = _cjose_jwk_rsa_key(jwk);
+    size_t ek_len = EVP_PKEY_get_size(rsa);
     uint8_t *orig_ek = NULL;
     size_t orig_ek_len = 0;
     ck_assert(cjose_base64url_decode(first_dot + 1, second_dot - first_dot - 1, &orig_ek, &orig_ek_len, &err));
-    ck_assert_int_eq(ek_len, orig_ek_len);
+    ck_assert_uint_eq(ek_len, orig_ek_len);
     uint8_t cek[256];
-    ck_assert_int_eq(32, RSA_private_decrypt(orig_ek_len, orig_ek, cek, rsa, RSA_PKCS1_OAEP_PADDING));
+    size_t cek_len = sizeof(cek);
+    EVP_PKEY_CTX *rsa_ctx = EVP_PKEY_CTX_new(rsa, NULL);
+    ck_assert(NULL != rsa_ctx);
+    ck_assert_int_eq(1, EVP_PKEY_decrypt_init(rsa_ctx));
+    ck_assert_int_eq(1, EVP_PKEY_CTX_set_rsa_padding(rsa_ctx, RSA_PKCS1_OAEP_PADDING));
+    ck_assert_int_eq(1, EVP_PKEY_decrypt(rsa_ctx, cek, &cek_len, orig_ek, orig_ek_len));
+    ck_assert_uint_eq(32, cek_len);
+    EVP_PKEY_CTX_free(rsa_ctx);
 
     // RSA-OAEP-encrypt that CEK followed by 8 trailing bytes (40 bytes in
     // total) with the same public key
@@ -1671,7 +1677,14 @@ START_TEST(test_cjose_jwe_decrypt_rsa_wrong_cek_length)
     memset(bad_cek + 32, 0x42, sizeof(bad_cek) - 32);
     uint8_t *ek = (uint8_t *)malloc(ek_len);
     ck_assert(NULL != ek);
-    ck_assert(RSA_public_encrypt(sizeof(bad_cek), bad_cek, ek, rsa, RSA_PKCS1_OAEP_PADDING) == ek_len);
+    size_t encrypted_len = ek_len;
+    rsa_ctx = EVP_PKEY_CTX_new(rsa, NULL);
+    ck_assert(NULL != rsa_ctx);
+    ck_assert_int_eq(1, EVP_PKEY_encrypt_init(rsa_ctx));
+    ck_assert_int_eq(1, EVP_PKEY_CTX_set_rsa_padding(rsa_ctx, RSA_PKCS1_OAEP_PADDING));
+    ck_assert_int_eq(1, EVP_PKEY_encrypt(rsa_ctx, ek, &encrypted_len, bad_cek, sizeof(bad_cek)));
+    ck_assert_uint_eq(ek_len, encrypted_len);
+    EVP_PKEY_CTX_free(rsa_ctx);
 
     char *ek_b64u = NULL;
     size_t ek_b64u_len = 0;

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -109,16 +109,27 @@ START_TEST(test_cjose_jwk_create_RSA_spec)
     ck_assert(2048 == jwk->keysize);
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
-    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+    ck_assert(NULL != cjose_jwk_get_keydata(jwk, &err));
     cjose_jwk_release(jwk);
 
-    // only private is not possible after the OpenSSL 1.1.x changes because e & n always need to be set
-
-    // minimal private
+    // CRT parameters without the factors are accepted and preserved.
     cjose_get_dealloc()(specPriv.p);
     specPriv.p = NULL;
     cjose_get_dealloc()(specPriv.q);
     specPriv.q = NULL;
+    jwk = cjose_jwk_create_RSA_spec(&specPriv, &err);
+    ck_assert(NULL != jwk);
+    char *json = cjose_jwk_to_json(jwk, true, &err);
+    ck_assert(NULL != json);
+    ck_assert(NULL != strstr(json, RSA_dp));
+    ck_assert(NULL != strstr(json, RSA_dq));
+    ck_assert(NULL != strstr(json, RSA_qi));
+    cjose_get_dealloc()(json);
+    cjose_jwk_release(jwk);
+
+    // RSA private keys still require the public n and e components.
+
+    // minimal private
     cjose_get_dealloc()(specPriv.dp);
     specPriv.dp = NULL;
     cjose_get_dealloc()(specPriv.dq);
@@ -132,7 +143,7 @@ START_TEST(test_cjose_jwk_create_RSA_spec)
     ck_assert(2048 == jwk->keysize);
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
-    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+    ck_assert(NULL != cjose_jwk_get_keydata(jwk, &err));
     cjose_jwk_release(jwk);
 
     cjose_get_dealloc()(specPriv.n);
@@ -154,13 +165,38 @@ START_TEST(test_cjose_jwk_create_RSA_spec)
     ck_assert(2048 == jwk->keysize);
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
-    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+    ck_assert(NULL != cjose_jwk_get_keydata(jwk, &err));
     cjose_jwk_release(jwk);
 
     cjose_get_dealloc()(specPub.n);
     specPub.n = NULL;
     cjose_get_dealloc()(specPub.e);
     specPub.e = NULL;
+}
+END_TEST
+
+START_TEST(test_cjose_jwk_create_RSA_spec_byte_rounded_keysize)
+{
+    cjose_err err;
+    cjose_jwk_t *jwk = NULL;
+    uint8_t n[257] = { 0 };
+    uint8_t e[] = { 0x01, 0x00, 0x01 };
+    cjose_jwk_rsa_keyspec spec = { 0 };
+
+    // A 2049-bit modulus occupies 257 bytes. Preserve RSA_size() * 8
+    // semantics, which report the byte-rounded size rather than BN_num_bits().
+    n[0] = 0x01;
+    n[sizeof(n) - 1] = 0x01;
+    spec.n = n;
+    spec.nlen = sizeof(n);
+    spec.e = e;
+    spec.elen = sizeof(e);
+
+    jwk = cjose_jwk_create_RSA_spec(&spec, &err);
+    ck_assert_msg(NULL != jwk, "failed to create 2049-bit RSA JWK: %s", err.message);
+    ck_assert(2056 == cjose_jwk_get_keysize(jwk, &err));
+
+    cjose_jwk_release(jwk);
 }
 END_TEST
 
@@ -178,7 +214,7 @@ START_TEST(test_cjose_jwk_create_RSA_random)
     ck_assert(2048 == jwk->keysize);
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
-    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+    ck_assert(NULL != cjose_jwk_get_keydata(jwk, &err));
 
     cjose_jwk_release(jwk);
 
@@ -189,7 +225,7 @@ START_TEST(test_cjose_jwk_create_RSA_random)
     ck_assert(2048 == jwk->keysize);
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
-    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+    ck_assert(NULL != cjose_jwk_get_keydata(jwk, &err));
 
     cjose_jwk_release(jwk);
 }
@@ -217,7 +253,7 @@ START_TEST(test_cjose_jwk_create_EC_P256_spec)
     ck_assert(256 == jwk->keysize);
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
-    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+    ck_assert(NULL != cjose_jwk_get_keydata(jwk, &err));
     ck_assert(CJOSE_JWK_EC_P_256 == cjose_jwk_EC_get_curve(jwk, &err));
     cjose_get_dealloc()(spec.d);
     cjose_get_dealloc()(spec.x);
@@ -227,6 +263,24 @@ START_TEST(test_cjose_jwk_create_EC_P256_spec)
     cjose_jwk_release(jwk);
 }
 END_TEST
+
+START_TEST(test_cjose_jwk_create_EC_rejects_out_of_range_private)
+{
+    // The P-256 group order plus one. Multiplication wraps this scalar to the
+    // generator, but the private scalar itself is invalid and must be rejected.
+    uint8_t invalid_d[] = { 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                            0xbc, 0xe6, 0xfa, 0xad, 0xa7, 0x17, 0x9e, 0x84, 0xf3, 0xb9, 0xca, 0xc2, 0xfc, 0x63, 0x25, 0x52 };
+    cjose_jwk_ec_keyspec spec = { 0 };
+    spec.crv = CJOSE_JWK_EC_P_256;
+    spec.d = invalid_d;
+    spec.dlen = sizeof(invalid_d);
+
+    cjose_err err;
+    ck_assert(NULL == cjose_jwk_create_EC_spec(&spec, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+}
+END_TEST
+
 START_TEST(test_cjose_jwk_create_EC_P256_random)
 {
     cjose_err err;
@@ -238,7 +292,7 @@ START_TEST(test_cjose_jwk_create_EC_P256_random)
     ck_assert(256 == jwk->keysize);
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
-    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+    ck_assert(NULL != cjose_jwk_get_keydata(jwk, &err));
     ck_assert(CJOSE_JWK_EC_P_256 == cjose_jwk_EC_get_curve(jwk, &err));
 
     // cleanup
@@ -268,7 +322,7 @@ START_TEST(test_cjose_jwk_create_EC_secp256k1_spec)
     ck_assert(256 == jwk->keysize);
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
-    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+    ck_assert(NULL != cjose_jwk_get_keydata(jwk, &err));
     ck_assert(CJOSE_JWK_EC_SECP_256K1 == cjose_jwk_EC_get_curve(jwk, &err));
 
     char *json = cjose_jwk_to_json(jwk, true, &err);
@@ -324,7 +378,7 @@ START_TEST(test_cjose_jwk_create_EC_P384_spec)
     ck_assert(384 == jwk->keysize);
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
-    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+    ck_assert(NULL != cjose_jwk_get_keydata(jwk, &err));
     ck_assert(CJOSE_JWK_EC_P_384 == cjose_jwk_EC_get_curve(jwk, &err));
     cjose_get_dealloc()(spec.d);
     cjose_get_dealloc()(spec.x);
@@ -345,7 +399,7 @@ START_TEST(test_cjose_jwk_create_EC_P384_random)
     ck_assert(384 == jwk->keysize);
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
-    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+    ck_assert(NULL != cjose_jwk_get_keydata(jwk, &err));
     ck_assert(CJOSE_JWK_EC_P_384 == cjose_jwk_EC_get_curve(jwk, &err));
 
     // cleanup
@@ -375,7 +429,7 @@ START_TEST(test_cjose_jwk_create_EC_P521_spec)
     ck_assert(521 == jwk->keysize);
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
-    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+    ck_assert(NULL != cjose_jwk_get_keydata(jwk, &err));
     ck_assert(CJOSE_JWK_EC_P_521 == cjose_jwk_EC_get_curve(jwk, &err));
     cjose_get_dealloc()(spec.d);
     cjose_get_dealloc()(spec.x);
@@ -396,7 +450,7 @@ START_TEST(test_cjose_jwk_create_EC_P521_random)
     ck_assert(521 == jwk->keysize);
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
-    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+    ck_assert(NULL != cjose_jwk_get_keydata(jwk, &err));
     ck_assert(CJOSE_JWK_EC_P_521 == cjose_jwk_EC_get_curve(jwk, &err));
 
     // cleanup
@@ -420,8 +474,9 @@ START_TEST(test_cjose_jwk_create_oct_spec)
     ck_assert(klen * 8 == jwk->keysize);
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
-    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
-    ck_assert_bin_eq(k, jwk->keydata, klen);
+    const uint8_t *keydata = cjose_jwk_get_keydata(jwk, &err);
+    ck_assert(NULL != keydata);
+    ck_assert_bin_eq(k, keydata, klen);
     cjose_get_dealloc()(k);
 
     // cleanup
@@ -439,7 +494,7 @@ START_TEST(test_cjose_jwk_create_oct_random)
     ck_assert(128 == jwk->keysize);
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
-    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+    ck_assert(NULL != cjose_jwk_get_keydata(jwk, &err));
 
     // cleanup
     cjose_jwk_release(jwk);
@@ -485,7 +540,7 @@ static void _test_cjose_jwk_create_OKP_spec(cjose_jwk_okp_curve crv, size_t keys
     ck_assert(keysize == jwk->keysize);
     ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
     ck_assert(NULL != jwk->keydata);
-    ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+    ck_assert(NULL != cjose_jwk_get_keydata(jwk, &err));
     ck_assert(crv == cjose_jwk_OKP_get_curve(jwk, &err));
     // an OKP key is not an EC key
     ck_assert(CJOSE_JWK_EC_INVALID == cjose_jwk_EC_get_curve(jwk, &err));
@@ -630,7 +685,7 @@ START_TEST(test_cjose_jwk_create_OKP_random)
         ck_assert(curves[i].keysize == jwk->keysize);
         ck_assert(cjose_jwk_get_keysize(jwk, &err) == jwk->keysize);
         ck_assert(NULL != jwk->keydata);
-        ck_assert(cjose_jwk_get_keydata(jwk, &err) == jwk->keydata);
+        ck_assert(NULL != cjose_jwk_get_keydata(jwk, &err));
         ck_assert(curves[i].crv == cjose_jwk_OKP_get_curve(jwk, &err));
 
         char *json = cjose_jwk_to_json(jwk, true, &err);
@@ -1965,10 +2020,12 @@ Suite *cjose_jwk_suite(void)
     tcase_set_timeout(tc_jwk, 120.0);
     tcase_add_test(tc_jwk, test_cjose_jwk_name_for_kty);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_RSA_spec);
+    tcase_add_test(tc_jwk, test_cjose_jwk_create_RSA_spec_byte_rounded_keysize);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_RSA_random);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_RSA_random_weak_keysize);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_RSA_spec_weak_modulus);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_P256_spec);
+    tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_rejects_out_of_range_private);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_P256_random);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_secp256k1_spec);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_secp256k1_random);

--- a/test/check_jws.c
+++ b/test/check_jws.c
@@ -85,18 +85,6 @@ static const char *JWS_COMMON
       "whF9FnGng7bmU8qjNPiXCWfQ-n74gopAVzd3KDJ5ai7q66voRc9pCKJVbsaIMHIqcl9OPiMdY5Hz3_PgBalR2632HOdpUlIMvnMOL3EQICvyBwxaYPbhMcCpEc3_"
       "4K-sywOGiCSp9KlaLcRq0knZtAT0ynJszaiOwfR-W18PEFLfGclpeR6e_gop9mq69t36wK7KRUjrQ";
 
-static cjose_alloc_fn_t _jws_saved_alloc = NULL;
-static size_t _jws_fail_alloc_size = 0;
-
-static void *_jws_fail_selected_alloc(size_t size)
-{
-    if (size == _jws_fail_alloc_size)
-    {
-        return NULL;
-    }
-    return _jws_saved_alloc(size);
-}
-
 static const char *_self_get_jwk_by_alg(const char *alg)
 {
     if ((strcmp(alg, CJOSE_HDR_ALG_HS256) == 0) || (strcmp(alg, CJOSE_HDR_ALG_HS384) == 0)
@@ -436,8 +424,8 @@ START_TEST(test_cjose_jws_ed25519_rejects_wrong_key)
     }
 
     // signing needs the private key: the library refuses a public-only key
-    // itself, since OpenSSL 1.1.1 and 3.0.0 to 3.0.7 sign with the missing
-    // private key instead of failing (3.0.8 added the guard)
+    // itself, since OpenSSL 3.0.0 through 3.0.7 signs with the missing private
+    // key instead of failing (3.0.8 added the guard)
     cjose_jwk_t *ed448_pub = cjose_jwk_import(JWK_ED448_PUB, strlen(JWK_ED448_PUB), &err);
     ck_assert(NULL != ed448_pub);
     const struct
@@ -1419,35 +1407,6 @@ START_TEST(test_cjose_jws_verify_ps_sig_bad_length)
 }
 END_TEST
 
-START_TEST(test_cjose_jws_verify_ps_alloc_failure)
-{
-    cjose_err err;
-    cjose_jwk_t *jwk = cjose_jwk_import(JWK_COMMON, strlen(JWK_COMMON), &err);
-    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
-
-    cjose_jws_t *jws = cjose_jws_import(JWS_COMMON, strlen(JWS_COMMON), &err);
-    ck_assert_msg(NULL != jws, "cjose_jws_import failed: %s", err.message);
-
-    cjose_alloc_fn_t saved_alloc = cjose_get_alloc();
-    cjose_realloc_fn_t saved_realloc = cjose_get_realloc();
-    cjose_dealloc_fn_t saved_dealloc = cjose_get_dealloc();
-    _jws_saved_alloc = saved_alloc;
-    _jws_fail_alloc_size = jws->sig_len;
-    cjose_set_alloc_funcs(_jws_fail_selected_alloc, saved_realloc, saved_dealloc);
-
-    bool verified = cjose_jws_verify(jws, jwk, &err);
-    cjose_set_alloc_funcs(saved_alloc, saved_realloc, saved_dealloc);
-    _jws_saved_alloc = NULL;
-    _jws_fail_alloc_size = 0;
-
-    ck_assert_msg(!verified, "cjose_jws_verify succeeded when its encoded-message allocation failed");
-    ck_assert_msg(err.code == CJOSE_ERR_NO_MEMORY, "expected CJOSE_ERR_NO_MEMORY, got (%i:%s)", err.code, err.message);
-
-    cjose_jws_release(jws);
-    cjose_jwk_release(jwk);
-}
-END_TEST
-
 // regression: the JWS ECDSA signature must be exactly R || S for the key's
 // curve; _cjose_jws_verify_sig_ec used sig_len / 2 without a length check,
 // so a valid signature with a trailing octet appended still verified
@@ -1573,7 +1532,6 @@ Suite *cjose_jws_suite(void)
     tcase_add_test(tc_jws, test_cjose_jws_verify_bad_params);
     tcase_add_test(tc_jws, test_cjose_jws_none);
     tcase_add_test(tc_jws, test_cjose_jws_verify_ps_sig_bad_length);
-    tcase_add_test(tc_jws, test_cjose_jws_verify_ps_alloc_failure);
     tcase_add_test(tc_jws, test_cjose_jws_verify_ec_sig_bad_length);
     suite_add_tcase(suite, tc_jws);
 


### PR DESCRIPTION
## Summary

Complete the OpenSSL 3.0 migration by removing compatibility workarounds and replacing deprecated APIs with their supported OpenSSL 3 equivalents.

- Remove the `OPENSSL_API_COMPAT` definition.
- Replace deprecated RSA, EC, HMAC, AES key-wrap, and digest APIs with EVP and provider-based APIs.
- Use `OSSL_PARAM` for asymmetric key construction and component access.
- Preserve existing JWK import/export behavior, including partial RSA parameters and byte-rounded RSA key sizes.
- Remove the obsolete Cisco Fundamental EC configuration probe.
- Document asymmetric `cjose_jwk_get_keydata()` results as borrowed, implementation-specific opaque data.
- Remove redundant compatibility checks, initialization calls, and unused includes.

This is strictly an OpenSSL 3.0 migration. The public API and existing functionality remain unchanged.

## Testing

- Built with `OPENSSL_NO_DEPRECATED` and deprecated declarations treated as errors.
- Full test suite passed with RSA1_5 disabled.
- Full test suite passed with RSA1_5 enabled.
- ASan and UBSan checks passed.