### PR TITLE
Migrate project to strict C17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,9 +106,9 @@ set(CJOSE_EXPORTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake/exports")
 add_library(cjose_objects OBJECT ${CJOSE_SOURCES} ${CJOSE_INTERNAL_HEADERS})
 set_target_properties(cjose_objects PROPERTIES
     POSITION_INDEPENDENT_CODE ON
-    C_STANDARD 99
+    C_STANDARD 17
     C_STANDARD_REQUIRED ON
-    C_EXTENSIONS ON)
+    C_EXTENSIONS OFF)
 
 if(CJOSE_ENABLE_RSA1_5)
     target_compile_definitions(cjose_objects PRIVATE HAVE_RSA_PKCS1_PADDING=1)
@@ -377,9 +377,9 @@ if(CJOSE_BUILD_TESTS)
             ${CJOSE_PLATFORM_LIBRARIES})
 
         set_target_properties(check_cjose PROPERTIES
-            C_STANDARD 99
+            C_STANDARD 17
             C_STANDARD_REQUIRED ON
-            C_EXTENSIONS ON)
+            C_EXTENSIONS OFF)
         if(CJOSE_ENABLE_RSA1_5)
             target_compile_definitions(check_cjose PRIVATE HAVE_RSA_PKCS1_PADDING=1)
         endif()

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ serialization, with one or more recipients.
 ### Build Tools ###
 
 * CMake (>= 3.22)
-* A C99 compiler (LLVM/Clang >= 5.1, GCC >= 4.5 or MSVC >= 14)
+* A C17 compiler (LLVM/Clang >= 6.0, GCC >= 8.1 or MSVC >= 19.28)
 * Check (>= 0.12.0) - unit testing (e.g. check-devel)
 * Doxygen (>= 1.8) - API documentation (optional)
 * clang-format - source formatting (optional)

--- a/src/error.c
+++ b/src/error.c
@@ -9,18 +9,6 @@
 #include <openssl/err.h>
 #include "cjose/error.h"
 
-// thread-local storage specifier: MSVC spells it __declspec(thread),
-// GCC/Clang use __thread, C11 has _Thread_local
-#if defined(_MSC_VER)
-#define CJOSE_THREAD_LOCAL __declspec(thread)
-#elif defined(__GNUC__) || defined(__clang__)
-#define CJOSE_THREAD_LOCAL __thread
-#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
-#define CJOSE_THREAD_LOCAL _Thread_local
-#else
-#define CJOSE_THREAD_LOCAL
-#endif
-
 ////////////////////////////////////////////////////////////////////////////////
 static const char *_ERR_MSG_TABLE[] = { "no error", "invalid argument", "invalid state", "out of memory", "crypto error" };
 
@@ -33,7 +21,7 @@ const char *cjose_err_message(cjose_errcode code)
         // for crypto errors, return the most recent openssl error as message;
         // render it into a thread-local buffer since ERR_error_string with a
         // NULL buffer returns a static buffer shared across threads
-        static CJOSE_THREAD_LOCAL char buf[256];
+        static _Thread_local char buf[256];
         unsigned long err = ERR_get_error();
         while (0 != err)
         {

--- a/src/include/util_int.h
+++ b/src/include/util_int.h
@@ -11,17 +11,13 @@
 #include <cjose/error.h>
 
 #include <jansson.h>
+#include <stddef.h>
 #include <string.h>
-
-#ifdef _WIN32
-#include <BaseTsd.h>
-typedef SSIZE_T ssize_t;
-#endif
 
 // NOTE: unlike POSIX strndup this copies exactly len bytes (len < 0 means
 // strlen(str)); it does not stop at an embedded NUL, so len must not exceed
 // strlen(str) or the copy over-reads str.
-char *_cjose_strndup(const char *str, ssize_t len, cjose_err *err);
+char *_cjose_strndup(const char *str, ptrdiff_t len, cjose_err *err);
 json_t *_cjose_json_stringn(const char *value, size_t len, cjose_err *err);
 
 void *cjose_alloc3_default(size_t n, const char *file, int line);

--- a/src/util.c
+++ b/src/util.c
@@ -107,7 +107,7 @@ void _cjose_cleanse_dealloc(void *ptr, size_t len)
 
 int cjose_const_memcmp(const uint8_t *a, const uint8_t *b, const size_t size) { return CRYPTO_memcmp(a, b, size); }
 
-char *_cjose_strndup(const char *str, ssize_t len, cjose_err *err)
+char *_cjose_strndup(const char *str, ptrdiff_t len, cjose_err *err)
 {
     if (NULL == str)
     {

--- a/test/check_cjose.h
+++ b/test/check_cjose.h
@@ -7,10 +7,6 @@
 
 #include <check.h>
 
-#ifdef _WIN32
-#define random rand
-#endif
-
 Suite *cjose_version_suite(void);
 Suite *cjose_util_suite(void);
 Suite *cjose_base64_suite(void);

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -475,7 +475,7 @@ START_TEST(test_cjose_jwe_self_encrypt_self_decrypt_many)
     // encrypt and decrypt a whole lot of randomly sized payloads
     for (int i = 0; i < 100; ++i)
     {
-        size_t len = (size_t)(random() % 1024) + 1;
+        size_t len = (size_t)(rand() % 1024) + 1;
         uint8_t *plain = malloc(len);
         ck_assert_msg(RAND_bytes(plain, len) == 1, "RAND_bytes failed");
         plain[len - 1] = 0;

--- a/test/check_jws.c
+++ b/test/check_jws.c
@@ -587,7 +587,7 @@ START_TEST(test_cjose_jws_self_sign_self_verify_many)
     // sign and verify a whole lot of randomly sized payloads
     for (int i = 0; i < 100; ++i)
     {
-        size_t len = (size_t)(random() % 1024) + 1;
+        size_t len = (size_t)(rand() % 1024) + 1;
         uint8_t *plain = malloc(len);
         ck_assert_msg(RAND_bytes(plain, len) == 1, "RAND_bytes failed");
         plain[len - 1] = 0;


### PR DESCRIPTION
- Require C17 for library and test targets, with compiler extensions disabled.
- Replace compiler-specific thread-local storage with standard `_Thread_local`.
- Replace private `ssize_t`/Windows `SSIZE_T` usage with standard `ptrdiff_t`.
- Replace POSIX-only `random()` test usage with standard `rand()`.
- Update build prerequisites to require a C17 compiler.