### PR TITLE
Build with OPENSSL_NO_DEPRECATED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,10 @@ set_target_properties(cjose_objects PROPERTIES
     C_STANDARD_REQUIRED ON
     C_EXTENSIONS OFF)
 
+# cjose uses the OpenSSL 3 APIs only. Hiding every API that OpenSSL has
+# deprecated turns a reintroduced legacy call into a compile error on every
+# platform, instead of a warning that only -Werror builds reject.
+target_compile_definitions(cjose_objects PRIVATE OPENSSL_NO_DEPRECATED)
 if(CJOSE_ENABLE_RSA1_5)
     target_compile_definitions(cjose_objects PRIVATE HAVE_RSA_PKCS1_PADDING=1)
 endif()
@@ -380,6 +384,7 @@ if(CJOSE_BUILD_TESTS)
             C_STANDARD 17
             C_STANDARD_REQUIRED ON
             C_EXTENSIONS OFF)
+        target_compile_definitions(check_cjose PRIVATE OPENSSL_NO_DEPRECATED)
         if(CJOSE_ENABLE_RSA1_5)
             target_compile_definitions(check_cjose PRIVATE HAVE_RSA_PKCS1_PADDING=1)
         endif()


### PR DESCRIPTION
## Summary

Define `OPENSSL_NO_DEPRECATED` for the library objects and for `check_cjose`.

Since #181 the library uses the OpenSSL 3 APIs only. With `OPENSSL_NO_DEPRECATED` every API that OpenSSL has deprecated disappears from its headers, so a reintroduced legacy call (an `RSA_*`, `EC_KEY_*`, `HMAC_CTX_*` or `AES_*` function, say) fails to compile on every platform. Without it such a call is a `-Wdeprecated-declarations` warning that only the `-Werror` / `/WX` configurations reject and that a downstream build with relaxed warnings lets through. The definition is `PRIVATE` to both targets: it changes how cjose is compiled, not what consumers of `cjose::cjose` see.

## Testing

- `-pedantic -Wall -Werror` builds and the full `check_cjose` run with `CJOSE_ENABLE_RSA1_5` OFF and ON against the system OpenSSL 3.5.5.
- The same build and test run against source builds of OpenSSL 3.0.0 and 3.0.2 (`-DOPENSSL_ROOT_DIR`), so the 3.0.0 floor in `find_package` holds with the definition in place.
- The `clang-format` target produces no diff.
- Negative check: a file calling `RSA_new()` compiles with four deprecation warnings without the definition and fails with `unknown type name 'RSA'` / `implicit declaration of function 'RSA_new'` with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
