### PR TITLE
Add the A128GCMKW, A192GCMKW and A256GCMKW key encryption algorithms (RFC 7518 section 4.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ JWE key management algorithms (`alg`):
 | `RSA-OAEP-256` | RSAES OAEP with SHA-256 and MGF1 with SHA-256 | |
 | `RSA1_5` | RSAES-PKCS1-v1_5 | build option `CJOSE_ENABLE_RSA1_5` |
 | `A128KW`, `A192KW`, `A256KW` | AES Key Wrap | |
+| `A128GCMKW`, `A192GCMKW`, `A256GCMKW` | AES GCM key wrapping | |
 | `dir` | direct use of a shared symmetric key | |
 | `ECDH-ES` | ECDH-ES direct key agreement | |
 | `ECDH-ES+A128KW`, `ECDH-ES+A192KW`, `ECDH-ES+A256KW` | ECDH-ES with AES Key Wrap | |

--- a/include/cjose/header.h
+++ b/include/cjose/header.h
@@ -42,6 +42,10 @@ extern "C" {
 #define CJOSE_HDR_APU "apu"
 #define CJOSE_HDR_APV "apv"
 
+/** For the AES GCM key wrapping algorithms, the initialization vector and the authentication tag of the encrypted key. */
+#define CJOSE_HDR_IV "iv"
+#define CJOSE_HDR_TAG "tag"
+
 /** The JWA algorithm attribute value for none. */
 #define CJOSE_HDR_ALG_NONE "none"
 
@@ -61,6 +65,11 @@ extern "C" {
 #define CJOSE_HDR_ALG_A128KW "A128KW"
 #define CJOSE_HDR_ALG_A192KW "A192KW"
 #define CJOSE_HDR_ALG_A256KW "A256KW"
+
+/** The JWE algorithm attribute value for A128GCMKW, A192GCMKW and A256GCMKW (AES GCM key wrapping, RFC 7518 section 4.7). */
+#define CJOSE_HDR_ALG_A128GCMKW "A128GCMKW"
+#define CJOSE_HDR_ALG_A192GCMKW "A192GCMKW"
+#define CJOSE_HDR_ALG_A256GCMKW "A256GCMKW"
 
 /** The JWE algorithm attribute value for ECDH-ES with A128KW, A192KW or A256KW key wrapping. */
 #define CJOSE_HDR_ALG_ECDH_ES_A128KW "ECDH-ES+A128KW"

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -39,6 +39,12 @@ static bool _cjose_jwe_encrypt_ek_aes_kw(_jwe_int_recipient_t *recipient, cjose_
 static bool _cjose_jwe_decrypt_ek_aes_kw(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err);
 
 static bool
+_cjose_jwe_encrypt_ek_aes_gcm_kw(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err);
+
+static bool
+_cjose_jwe_decrypt_ek_aes_gcm_kw(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err);
+
+static bool
 _cjose_jwe_encrypt_ek_rsa_oaep(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err);
 
 static bool
@@ -318,6 +324,52 @@ static const char *_cjose_jwe_get_from_headers(cjose_header_t *protected_header,
     return NULL;
 }
 
+// like _cjose_jwe_get_from_headers, but returns the JSON value so that a
+// parameter can be checked for its expected type (borrowed reference)
+static json_t *_cjose_jwe_get_json_from_headers(cjose_header_t *protected_header,
+                                                cjose_header_t *unprotected_header,
+                                                cjose_header_t *personal_header,
+                                                const char *key)
+{
+    cjose_header_t *headers[] = { personal_header, unprotected_header, protected_header };
+    for (int i = 0; i < 3; i++)
+    {
+        if (NULL == headers[i])
+        {
+            continue;
+        }
+        json_t *obj = json_object_get((json_t *)headers[i], key);
+        if (NULL != obj)
+        {
+            return obj;
+        }
+    }
+    return NULL;
+}
+
+// the header object a per-recipient parameter (like the "iv" and "tag" of the
+// AES GCM key wrapping algorithms) is written to when encrypting: the protected
+// header for a single recipient, so that the compact serialization carries it,
+// and the recipient's own header otherwise. The caller's header objects are
+// never modified: the JWE holds a deep copy of the protected header already and
+// gets one of the recipient header here.
+static json_t *_cjose_jwe_recipient_param_target(cjose_jwe_t *jwe, _jwe_int_recipient_t *recipient, cjose_err *err)
+{
+    if (jwe->to_count < 2)
+    {
+        return jwe->hdr;
+    }
+    json_t *copy = (NULL == recipient->unprotected) ? json_object() : json_deep_copy(recipient->unprotected);
+    if (NULL == copy)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        return NULL;
+    }
+    json_decref(recipient->unprotected);
+    recipient->unprotected = copy;
+    return copy;
+}
+
 static bool _cjose_jwe_validate_enc(cjose_jwe_t *jwe, cjose_header_t *protected_header, cjose_err *err)
 {
 
@@ -361,7 +413,7 @@ static bool _cjose_jwe_validate_alg(cjose_header_t *protected_header,
                                     _jwe_int_recipient_t *recipient,
                                     cjose_err *err)
 {
-    static const char *const supported_crit_headers[] = { "alg", "enc", "cty", "epk", "apu", "apv" };
+    static const char *const supported_crit_headers[] = { "alg", "enc", "cty", "epk", "apu", "apv", "iv", "tag" };
 
     if (!_cjose_header_validate_crit(protected_header, supported_crit_headers,
                                      sizeof(supported_crit_headers) / sizeof(supported_crit_headers[0]), err)
@@ -455,6 +507,13 @@ static bool _cjose_jwe_validate_alg(cjose_header_t *protected_header,
     {
         recipient->fns.encrypt_ek = _cjose_jwe_encrypt_ek_aes_kw;
         recipient->fns.decrypt_ek = _cjose_jwe_decrypt_ek_aes_kw;
+    }
+
+    if ((strcmp(alg, CJOSE_HDR_ALG_A128GCMKW) == 0) || (strcmp(alg, CJOSE_HDR_ALG_A192GCMKW) == 0)
+        || (strcmp(alg, CJOSE_HDR_ALG_A256GCMKW) == 0))
+    {
+        recipient->fns.encrypt_ek = _cjose_jwe_encrypt_ek_aes_gcm_kw;
+        recipient->fns.decrypt_ek = _cjose_jwe_decrypt_ek_aes_gcm_kw;
     }
 
     // ensure required builders have been assigned
@@ -751,6 +810,226 @@ static bool _cjose_jwe_decrypt_ek_aes_kw(_jwe_int_recipient_t *recipient, cjose_
         return false;
     }
     return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// AES GCM key wrapping (RFC 7518 section 4.7): the CEK is encrypted with AES GCM
+// under a key encryption key of the size the "alg" names, with a random 96-bit
+// IV and no additional authenticated data; the IV and the 128-bit tag travel as
+// the "iv" and "tag" header parameters of the recipient
+#define CJOSE_JWE_AES_GCM_KW_IV_LEN 12
+#define CJOSE_JWE_AES_GCM_KW_TAG_LEN 16
+
+static size_t _cjose_jwe_aes_gcm_kw_keylen(const char *alg)
+{
+    if (NULL == alg)
+    {
+        return 0;
+    }
+    if (0 == strcmp(alg, CJOSE_HDR_ALG_A128GCMKW))
+    {
+        return 16;
+    }
+    if (0 == strcmp(alg, CJOSE_HDR_ALG_A192GCMKW))
+    {
+        return 24;
+    }
+    if (0 == strcmp(alg, CJOSE_HDR_ALG_A256GCMKW))
+    {
+        return 32;
+    }
+    return 0;
+}
+
+static const EVP_CIPHER *_cjose_jwe_aes_gcm_cipher(size_t key_len)
+{
+    switch (key_len)
+    {
+    case 16:
+        return EVP_aes_128_gcm();
+    case 24:
+        return EVP_aes_192_gcm();
+    case 32:
+        return EVP_aes_256_gcm();
+    default:
+        return NULL;
+    }
+}
+
+// the key encryption key of the AES GCM key wrapping algorithms is a symmetric
+// key of exactly the size the "alg" names
+static size_t
+_cjose_jwe_aes_gcm_kw_kek_len(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err)
+{
+    const char *alg
+        = _cjose_jwe_get_from_headers(jwe->hdr, jwe->shared_hdr, (cjose_header_t *)recipient->unprotected, CJOSE_HDR_ALG);
+    const size_t kek_len = _cjose_jwe_aes_gcm_kw_keylen(alg);
+    if (0 == kek_len || CJOSE_JWK_KTY_OCT != jwk->kty || NULL == jwk->keydata || jwk->keysize != kek_len * 8)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return 0;
+    }
+    return kek_len;
+}
+
+static bool
+_cjose_jwe_encrypt_ek_aes_gcm_kw(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err)
+{
+    EVP_CIPHER_CTX *ctx = NULL;
+    uint8_t iv[CJOSE_JWE_AES_GCM_KW_IV_LEN];
+    uint8_t tag[CJOSE_JWE_AES_GCM_KW_TAG_LEN];
+    char *iv_b64u = NULL;
+    char *tag_b64u = NULL;
+    size_t b64u_len = 0;
+    int len = 0;
+    int final_len = 0;
+    bool result = false;
+
+    if (NULL == jwe || NULL == jwk)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
+    const size_t kek_len = _cjose_jwe_aes_gcm_kw_kek_len(recipient, jwe, jwk, err);
+    if (0 == kek_len)
+    {
+        return false;
+    }
+
+    // generate random CEK
+    if (!jwe->fns.set_cek(jwe, NULL, true, err))
+    {
+        return false;
+    }
+
+    if (RAND_bytes(iv, sizeof(iv)) != 1)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        return false;
+    }
+
+    // AES GCM does not expand its input: the encrypted key is as long as the CEK
+    cjose_get_dealloc()(recipient->enc_key.raw);
+    recipient->enc_key.raw = NULL;
+    recipient->enc_key.raw_len = 0;
+    if (!_cjose_jwe_malloc(jwe->cek_len, false, &recipient->enc_key.raw, err))
+    {
+        return false;
+    }
+    recipient->enc_key.raw_len = jwe->cek_len;
+
+    ctx = EVP_CIPHER_CTX_new();
+    if (NULL == ctx || EVP_EncryptInit_ex(ctx, _cjose_jwe_aes_gcm_cipher(kek_len), NULL, jwk->keydata, iv) != 1
+        || EVP_EncryptUpdate(ctx, recipient->enc_key.raw, &len, jwe->cek, jwe->cek_len) != 1 || (size_t)len != jwe->cek_len
+        || EVP_EncryptFinal_ex(ctx, NULL, &final_len) != 1 || 0 != final_len
+        || EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, sizeof(tag), tag) != 1)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto cjose_encrypt_ek_aes_gcm_kw_finish;
+    }
+
+    // publish the IV and the tag with the recipient
+    json_t *target = _cjose_jwe_recipient_param_target(jwe, recipient, err);
+    if (NULL == target || !cjose_base64url_encode(iv, sizeof(iv), &iv_b64u, &b64u_len, err)
+        || !cjose_header_set((cjose_header_t *)target, CJOSE_HDR_IV, iv_b64u, err)
+        || !cjose_base64url_encode(tag, sizeof(tag), &tag_b64u, &b64u_len, err)
+        || !cjose_header_set((cjose_header_t *)target, CJOSE_HDR_TAG, tag_b64u, err))
+    {
+        goto cjose_encrypt_ek_aes_gcm_kw_finish;
+    }
+
+    result = true;
+
+cjose_encrypt_ek_aes_gcm_kw_finish:
+
+    EVP_CIPHER_CTX_free(ctx);
+    cjose_get_dealloc()(iv_b64u);
+    cjose_get_dealloc()(tag_b64u);
+
+    return result;
+}
+
+static bool
+_cjose_jwe_decrypt_ek_aes_gcm_kw(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err)
+{
+    EVP_CIPHER_CTX *ctx = NULL;
+    uint8_t *iv = NULL;
+    size_t iv_len = 0;
+    uint8_t *tag = NULL;
+    size_t tag_len = 0;
+    int len = 0;
+    int final_len = 0;
+    bool result = false;
+
+    if (NULL == jwe || NULL == jwk)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
+    const size_t kek_len = _cjose_jwe_aes_gcm_kw_kek_len(recipient, jwe, jwk, err);
+    if (0 == kek_len)
+    {
+        return false;
+    }
+
+    // the "iv" and "tag" parameters must be present with the recipient and
+    // have their fixed sizes: check that before touching the encrypted key
+    json_t *iv_obj
+        = _cjose_jwe_get_json_from_headers(jwe->hdr, jwe->shared_hdr, (cjose_header_t *)recipient->unprotected, CJOSE_HDR_IV);
+    json_t *tag_obj
+        = _cjose_jwe_get_json_from_headers(jwe->hdr, jwe->shared_hdr, (cjose_header_t *)recipient->unprotected, CJOSE_HDR_TAG);
+    if (!json_is_string(iv_obj) || !json_is_string(tag_obj))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+    if (!cjose_base64url_decode(json_string_value(iv_obj), strlen(json_string_value(iv_obj)), &iv, &iv_len, err)
+        || !cjose_base64url_decode(json_string_value(tag_obj), strlen(json_string_value(tag_obj)), &tag, &tag_len, err))
+    {
+        goto cjose_decrypt_ek_aes_gcm_kw_finish;
+    }
+    if (CJOSE_JWE_AES_GCM_KW_IV_LEN != iv_len || CJOSE_JWE_AES_GCM_KW_TAG_LEN != tag_len)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        goto cjose_decrypt_ek_aes_gcm_kw_finish;
+    }
+
+    // the CEK buffer has the size the enc header dictates and the encrypted
+    // key must be exactly that long, so an attacker-controlled encrypted key
+    // can never be written past it
+    if (!jwe->fns.set_cek(jwe, NULL, false, err))
+    {
+        goto cjose_decrypt_ek_aes_gcm_kw_finish;
+    }
+    if (recipient->enc_key.raw_len != jwe->cek_len)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        goto cjose_decrypt_ek_aes_gcm_kw_finish;
+    }
+
+    ctx = EVP_CIPHER_CTX_new();
+    if (NULL == ctx || EVP_DecryptInit_ex(ctx, _cjose_jwe_aes_gcm_cipher(kek_len), NULL, jwk->keydata, iv) != 1
+        || EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG, (int)tag_len, tag) != 1
+        || EVP_DecryptUpdate(ctx, jwe->cek, &len, recipient->enc_key.raw, recipient->enc_key.raw_len) != 1
+        || (size_t)len != jwe->cek_len || EVP_DecryptFinal_ex(ctx, NULL, &final_len) != 1)
+    {
+        // the tag did not verify: do not leave the unauthenticated output behind
+        _cjose_release_cek(&jwe->cek, jwe->cek_len);
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto cjose_decrypt_ek_aes_gcm_kw_finish;
+    }
+
+    result = true;
+
+cjose_decrypt_ek_aes_gcm_kw_finish:
+
+    EVP_CIPHER_CTX_free(ctx);
+    cjose_get_dealloc()(iv);
+    cjose_get_dealloc()(tag);
+
+    return result;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1907,7 +2186,9 @@ static bool _cjose_jwe_validate_decrypt_key(_jwe_int_recipient_t *recipient,
     }
 
     if (((0 == strcmp(alg, CJOSE_HDR_ALG_A128KW)) || (0 == strcmp(alg, CJOSE_HDR_ALG_A192KW))
-         || (0 == strcmp(alg, CJOSE_HDR_ALG_A256KW)) || (0 == strcmp(alg, CJOSE_HDR_ALG_DIR)))
+         || (0 == strcmp(alg, CJOSE_HDR_ALG_A256KW)) || (0 == strcmp(alg, CJOSE_HDR_ALG_A128GCMKW))
+         || (0 == strcmp(alg, CJOSE_HDR_ALG_A192GCMKW)) || (0 == strcmp(alg, CJOSE_HDR_ALG_A256GCMKW))
+         || (0 == strcmp(alg, CJOSE_HDR_ALG_DIR)))
         && jwk->kty != CJOSE_JWK_KTY_OCT)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -897,6 +897,19 @@ _cjose_jwe_encrypt_ek_aes_gcm_kw(_jwe_int_recipient_t *recipient, cjose_jwe_t *j
         return false;
     }
 
+    // the "iv" and "tag" parameters are produced here: if the caller supplied
+    // either of them in one of its header objects, the parameter would end up
+    // in two of the three header locations, which RFC 7516 section 7.2.1 does
+    // not allow, and the wrong one could be picked up when decrypting
+    if (NULL != _cjose_jwe_get_json_from_headers(jwe->hdr, jwe->shared_hdr, (cjose_header_t *)recipient->unprotected, CJOSE_HDR_IV)
+        || NULL
+               != _cjose_jwe_get_json_from_headers(jwe->hdr, jwe->shared_hdr, (cjose_header_t *)recipient->unprotected,
+                                                   CJOSE_HDR_TAG))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
     // generate random CEK
     if (!jwe->fns.set_cek(jwe, NULL, true, err))
     {

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -666,6 +666,71 @@ START_TEST(test_cjose_jwe_aes_gcm_kw_multiple_recipients)
 }
 END_TEST
 
+// the "iv" and "tag" parameters are produced by the encryption: a caller that
+// supplies them itself would get the same name in two header locations, which
+// RFC 7516 section 7.2.1 does not allow
+START_TEST(test_cjose_jwe_aes_gcm_kw_caller_supplied_params)
+{
+    cjose_err err;
+    static const uint8_t plain[] = "Setec Astronomy";
+    static const char *const params[] = { CJOSE_HDR_IV, CJOSE_HDR_TAG };
+
+    cjose_jwk_t *jwk16 = cjose_jwk_import(JWK_OCT_16, strlen(JWK_OCT_16), &err);
+    cjose_jwk_t *jwk32 = cjose_jwk_import(JWK_OCT_32, strlen(JWK_OCT_32), &err);
+    ck_assert(NULL != jwk16 && NULL != jwk32);
+
+    for (size_t p = 0; p < sizeof(params) / sizeof(params[0]); p++)
+    {
+        // in the protected header, with a single recipient
+        memset(&err, 0, sizeof(err));
+        cjose_header_t *hdr = cjose_header_new(&err);
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128GCMKW, &err));
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+        ck_assert(cjose_header_set(hdr, params[p], "AAAAAAAAAAAAAAAA", &err));
+        ck_assert_msg(NULL == cjose_jwe_encrypt(jwk16, hdr, plain, sizeof(plain) - 1, &err), "caller supplied %s accepted",
+                      params[p]);
+        ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+        cjose_header_release(hdr);
+
+        // in the shared unprotected header
+        memset(&err, 0, sizeof(err));
+        hdr = cjose_header_new(&err);
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128GCMKW, &err));
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+        cjose_header_t *shared = cjose_header_new(&err);
+        ck_assert(cjose_header_set(shared, params[p], "AAAAAAAAAAAAAAAA", &err));
+        cjose_jwe_recipient_t one[] = { { jwk16, NULL } };
+        ck_assert_msg(NULL == cjose_jwe_encrypt_multi(one, 1, hdr, shared, plain, sizeof(plain) - 1, &err), "shared %s accepted",
+                      params[p]);
+        ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+        cjose_header_release(shared);
+
+        // in a per-recipient header, with several recipients
+        memset(&err, 0, sizeof(err));
+        cjose_header_t *hdr16 = cjose_header_new(&err);
+        ck_assert(cjose_header_set(hdr16, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128GCMKW, &err));
+        cjose_header_t *hdr32 = cjose_header_new(&err);
+        ck_assert(cjose_header_set(hdr32, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A256GCMKW, &err));
+        ck_assert(cjose_header_set(hdr32, params[p], "AAAAAAAAAAAAAAAA", &err));
+        cjose_header_t *shared_enc = cjose_header_new(&err);
+        ck_assert(cjose_header_set(shared_enc, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+        cjose_jwe_recipient_t two[] = { { jwk16, hdr16 }, { jwk32, hdr32 } };
+        ck_assert_msg(NULL == cjose_jwe_encrypt_multi(two, 2, shared_enc, NULL, plain, sizeof(plain) - 1, &err),
+                      "per-recipient %s accepted", params[p]);
+        ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+        // the first recipient, which carried no parameter of its own, is untouched
+        ck_assert(NULL == cjose_header_get(hdr16, CJOSE_HDR_IV, &err));
+        cjose_header_release(hdr16);
+        cjose_header_release(hdr32);
+        cjose_header_release(shared_enc);
+        cjose_header_release(hdr);
+    }
+
+    cjose_jwk_release(jwk16);
+    cjose_jwk_release(jwk32);
+}
+END_TEST
+
 START_TEST(test_cjose_jwe_self_encrypt_self_decrypt_empty)
 {
     static const uint8_t plain[] = "";
@@ -2326,6 +2391,7 @@ Suite *cjose_jwe_suite(void)
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_self_encrypt_self_decrypt);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_bad_params);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_multiple_recipients);
+    tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_caller_supplied_params);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_interop);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes_gcm);

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -451,6 +451,221 @@ START_TEST(test_cjose_jwe_ecdh_es_kw_self_encrypt_self_decrypt)
 }
 END_TEST
 
+START_TEST(test_cjose_jwe_aes_gcm_kw_self_encrypt_self_decrypt)
+{
+    static const uint8_t plain[] = "Setec Astronomy";
+
+    _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_A128GCMKW, CJOSE_HDR_ENC_A128GCM, JWK_OCT_16, plain, sizeof(plain) - 1);
+    _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_A128GCMKW, CJOSE_HDR_ENC_A256CBC_HS512, JWK_OCT_16, plain, sizeof(plain) - 1);
+    _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_A192GCMKW, CJOSE_HDR_ENC_A192GCM, JWK_OCT_24, plain, sizeof(plain) - 1);
+    _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_A192GCMKW, CJOSE_HDR_ENC_A128CBC_HS256, JWK_OCT_24, plain, sizeof(plain) - 1);
+    _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_A256GCMKW, CJOSE_HDR_ENC_A256GCM, JWK_OCT_32, plain, sizeof(plain) - 1);
+    _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_A256GCMKW, CJOSE_HDR_ENC_A192CBC_HS384, JWK_OCT_32, plain, sizeof(plain) - 1);
+}
+END_TEST
+
+// re-encode the compact serialization with the protected header modified by
+// the given function; the AAD changes with it, but the checks under test run
+// before the content is authenticated
+static char *_jwe_with_modified_header(const char *compact, void (*modify)(json_t *hdr))
+{
+    cjose_err err;
+    const char *dot = strchr(compact, '.');
+    ck_assert(NULL != dot);
+    uint8_t *raw = NULL;
+    size_t raw_len = 0;
+    ck_assert(cjose_base64url_decode(compact, dot - compact, &raw, &raw_len, &err));
+    json_t *hdr = json_loadb((const char *)raw, raw_len, 0, NULL);
+    ck_assert(NULL != hdr);
+    modify(hdr);
+    char *hdr_str = json_dumps(hdr, JSON_COMPACT);
+    ck_assert(NULL != hdr_str);
+    char *hdr_b64u = NULL;
+    size_t hdr_b64u_len = 0;
+    ck_assert(cjose_base64url_encode((const uint8_t *)hdr_str, strlen(hdr_str), &hdr_b64u, &hdr_b64u_len, &err));
+    char *result = malloc(hdr_b64u_len + strlen(dot) + 1);
+    ck_assert(NULL != result);
+    memcpy(result, hdr_b64u, hdr_b64u_len);
+    strcpy(result + hdr_b64u_len, dot);
+    cjose_get_dealloc()(hdr_b64u);
+    cjose_get_dealloc()(hdr_str);
+    json_decref(hdr);
+    cjose_get_dealloc()(raw);
+    return result;
+}
+
+static void _jwe_hdr_short_iv(json_t *hdr) { json_object_set_new(hdr, CJOSE_HDR_IV, json_string("AAAAAAAAAAA")); }
+static void _jwe_hdr_short_tag(json_t *hdr) { json_object_set_new(hdr, CJOSE_HDR_TAG, json_string("AAAAAAAAAAAAAAAAAAAA")); }
+static void _jwe_hdr_drop_tag(json_t *hdr) { json_object_del(hdr, CJOSE_HDR_TAG); }
+static void _jwe_hdr_integer_iv(json_t *hdr) { json_object_set_new(hdr, CJOSE_HDR_IV, json_integer(12)); }
+static void _jwe_hdr_flip_tag(json_t *hdr)
+{
+    const char *tag = json_string_value(json_object_get(hdr, CJOSE_HDR_TAG));
+    char copy[64];
+    ck_assert(NULL != tag && strlen(tag) < sizeof(copy));
+    strcpy(copy, tag);
+    copy[0] = ('A' == copy[0]) ? 'B' : 'A';
+    json_object_set_new(hdr, CJOSE_HDR_TAG, json_string(copy));
+}
+
+// the "iv" and "tag" parameters live with the recipient and are checked
+// before the encrypted key is touched
+static void _decrypt_aes_gcm_kw_expect(const char *compact, const char *key, cjose_errcode expected)
+{
+    cjose_err err;
+    memset(&err, 0, sizeof(err));
+    cjose_jwk_t *jwk = cjose_jwk_import(key, strlen(key), &err);
+    ck_assert(NULL != jwk);
+    cjose_jwe_t *jwe = cjose_jwe_import(compact, strlen(compact), &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_import failed: %s", err.message);
+    size_t plain_len = 0;
+    uint8_t *plain = cjose_jwe_decrypt(jwe, jwk, &plain_len, &err);
+    ck_assert_msg(NULL == plain, "cjose_jwe_decrypt succeeded unexpectedly");
+    ck_assert_int_eq(expected, err.code);
+    cjose_jwe_release(jwe);
+    cjose_jwk_release(jwk);
+}
+
+START_TEST(test_cjose_jwe_aes_gcm_kw_bad_params)
+{
+    cjose_err err;
+    static const uint8_t plain[] = "Setec Astronomy";
+
+    cjose_header_t *hdr = cjose_header_new(&err);
+    ck_assert(NULL != hdr);
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128GCMKW, &err));
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+
+    // the key encryption key must be an oct key of the size the alg names
+    cjose_jwk_t *jwk32 = cjose_jwk_import(JWK_OCT_32, strlen(JWK_OCT_32), &err);
+    ck_assert(NULL != jwk32);
+    ck_assert(NULL == cjose_jwe_encrypt(jwk32, hdr, plain, sizeof(plain) - 1, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    cjose_jwk_t *ec = cjose_jwk_import(JWK_EC, strlen(JWK_EC), &err);
+    ck_assert(NULL != ec);
+    ck_assert(NULL == cjose_jwe_encrypt(ec, hdr, plain, sizeof(plain) - 1, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+
+    // a good JWE, whose protected header carries the "iv" and "tag" parameters
+    cjose_jwk_t *jwk16 = cjose_jwk_import(JWK_OCT_16, strlen(JWK_OCT_16), &err);
+    ck_assert(NULL != jwk16);
+    cjose_jwe_t *jwe = cjose_jwe_encrypt(jwk16, hdr, plain, sizeof(plain) - 1, &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed: %s", err.message);
+    ck_assert(NULL != cjose_header_get(cjose_jwe_get_protected(jwe), CJOSE_HDR_IV, &err));
+    ck_assert(NULL != cjose_header_get(cjose_jwe_get_protected(jwe), CJOSE_HDR_TAG, &err));
+    char *compact = cjose_jwe_export(jwe, &err);
+    ck_assert(NULL != compact);
+    cjose_jwe_release(jwe);
+
+    // ... is refused with the wrong key size, the wrong key type and a
+    // tampered, missing, short or non-string parameter
+    _decrypt_aes_gcm_kw_expect(compact, JWK_OCT_32, CJOSE_ERR_INVALID_ARG);
+    _decrypt_aes_gcm_kw_expect(compact, JWK_EC, CJOSE_ERR_INVALID_ARG);
+    struct
+    {
+        void (*modify)(json_t *);
+        cjose_errcode expected;
+    } cases[] = {
+        { _jwe_hdr_flip_tag, CJOSE_ERR_CRYPTO },        { _jwe_hdr_drop_tag, CJOSE_ERR_INVALID_ARG },
+        { _jwe_hdr_short_iv, CJOSE_ERR_INVALID_ARG },   { _jwe_hdr_short_tag, CJOSE_ERR_INVALID_ARG },
+        { _jwe_hdr_integer_iv, CJOSE_ERR_INVALID_ARG },
+    };
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++)
+    {
+        char *modified = _jwe_with_modified_header(compact, cases[i].modify);
+        _decrypt_aes_gcm_kw_expect(modified, JWK_OCT_16, cases[i].expected);
+        free(modified);
+    }
+
+    // an encrypted key of any other length than the CEK is refused up front
+    size_t len = strlen(compact);
+    char *longer = malloc(len + 12);
+    ck_assert(NULL != longer);
+    const char *ek_end = strchr(strchr(compact, '.') + 1, '.');
+    size_t prefix = ek_end - compact;
+    memcpy(longer, compact, prefix);
+    memcpy(longer + prefix, "AAAAAAAAAAA", 11);
+    strcpy(longer + prefix + 11, ek_end);
+    _decrypt_aes_gcm_kw_expect(longer, JWK_OCT_16, CJOSE_ERR_INVALID_ARG);
+    free(longer);
+
+    cjose_get_dealloc()(compact);
+    cjose_jwk_release(jwk16);
+    cjose_jwk_release(jwk32);
+    cjose_jwk_release(ec);
+    cjose_header_release(hdr);
+}
+END_TEST
+
+// with several recipients the "iv" and "tag" of each go into its own header
+START_TEST(test_cjose_jwe_aes_gcm_kw_multiple_recipients)
+{
+    cjose_err err;
+    static const uint8_t plain[] = "Setec Astronomy";
+
+    cjose_jwk_t *jwk16 = cjose_jwk_import(JWK_OCT_16, strlen(JWK_OCT_16), &err);
+    cjose_jwk_t *jwk32 = cjose_jwk_import(JWK_OCT_32, strlen(JWK_OCT_32), &err);
+    ck_assert(NULL != jwk16 && NULL != jwk32);
+    ck_assert(cjose_jwk_set_kid(jwk16, "k16", 3, &err));
+    ck_assert(cjose_jwk_set_kid(jwk32, "k32", 3, &err));
+
+    cjose_header_t *protected_header = cjose_header_new(&err);
+    ck_assert(cjose_header_set(protected_header, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A128GCM, &err));
+    cjose_header_t *hdr16 = cjose_header_new(&err);
+    ck_assert(cjose_header_set(hdr16, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128GCMKW, &err));
+    ck_assert(cjose_header_set(hdr16, CJOSE_HDR_KID, "k16", &err));
+    cjose_header_t *hdr32 = cjose_header_new(&err);
+    ck_assert(cjose_header_set(hdr32, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A256GCMKW, &err));
+    ck_assert(cjose_header_set(hdr32, CJOSE_HDR_KID, "k32", &err));
+    cjose_jwe_recipient_t recipients[] = { { jwk16, hdr16 }, { jwk32, hdr32 } };
+
+    cjose_jwe_t *jwe = cjose_jwe_encrypt_multi(recipients, 2, protected_header, NULL, plain, sizeof(plain) - 1, &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt_multi failed: %s", err.message);
+    // the caller's headers are left alone
+    ck_assert(NULL == cjose_header_get(hdr16, CJOSE_HDR_IV, &err));
+    ck_assert(NULL == cjose_header_get(protected_header, CJOSE_HDR_IV, &err));
+    char *json = cjose_jwe_export_json(jwe, &err);
+    ck_assert_msg(NULL != json, "cjose_jwe_export_json failed: %s", err.message);
+    cjose_jwe_release(jwe);
+
+    json_t *form = json_loads(json, 0, NULL);
+    ck_assert(NULL != form);
+    json_t *recs = json_object_get(form, "recipients");
+    ck_assert(json_is_array(recs) && 2 == json_array_size(recs));
+    for (size_t i = 0; i < 2; i++)
+    {
+        json_t *header = json_object_get(json_array_get(recs, i), "header");
+        ck_assert(json_is_string(json_object_get(header, CJOSE_HDR_IV)));
+        ck_assert(json_is_string(json_object_get(header, CJOSE_HDR_TAG)));
+    }
+    json_decref(form);
+
+    // each recipient decrypts on its own
+    cjose_jwe_recipient_t rec16[] = { { jwk16, NULL }, { NULL, NULL } };
+    cjose_jwe_recipient_t rec32[] = { { jwk32, NULL }, { NULL, NULL } };
+    cjose_jwe_recipient_t *locators[] = { rec16, rec32 };
+    for (size_t i = 0; i < 2; i++)
+    {
+        jwe = cjose_jwe_import_json(json, strlen(json), &err);
+        ck_assert_msg(NULL != jwe, "cjose_jwe_import_json failed: %s", err.message);
+        size_t plain_len = 0;
+        uint8_t *plain2 = cjose_jwe_decrypt_multi(jwe, cjose_multi_key_locator, locators[i], &plain_len, &err);
+        ck_assert_msg(NULL != plain2, "cjose_jwe_decrypt_multi failed (%zu): %s", i, err.message);
+        ck_assert_int_eq(sizeof(plain) - 1, plain_len);
+        ck_assert(0 == memcmp(plain, plain2, plain_len));
+        cjose_get_dealloc()(plain2);
+        cjose_jwe_release(jwe);
+    }
+
+    cjose_get_dealloc()(json);
+    cjose_header_release(hdr16);
+    cjose_header_release(hdr32);
+    cjose_header_release(protected_header);
+    cjose_jwk_release(jwk16);
+    cjose_jwk_release(jwk32);
+}
+END_TEST
+
 START_TEST(test_cjose_jwe_self_encrypt_self_decrypt_empty)
 {
     static const uint8_t plain[] = "";
@@ -1956,6 +2171,30 @@ static const char *JWE_JSON_RSA_OAEP_256
       "kLDnnVrPaHUEUL79-KWMa-8tZ-SN0aHc2SuKQGNtNZsawMO05A\",\"header\":{\"alg\":\"RSA-OAEP\",\"kid\":\"oaep\"}}],\"tag\""
       ":\"Qc5-QsMtp9mUGBa7L0BXaA\"}";
 
+// AES GCM key wrapping JWEs produced by python-jwcrypto with the JWK_OCT_16,
+// JWK_OCT_24 and JWK_OCT_32 keys over PLAINTEXT_RSA_OAEP_256: three compact
+// serializations and a JSON serialization carrying "iv" and "tag" in the
+// per-recipient header
+static const char *JWE_A128GCMKW_A256GCM
+    = "eyJhbGciOiJBMTI4R0NNS1ciLCJlbmMiOiJBMjU2R0NNIiwiaXYiOiJMQmhoNUFHZENkV0pfQmlGIiwidGFnIjoicGhBMTJUeDl6"
+      "RkhheEdPTnJHVXA3dyJ9.uhEgAJmgwWenubxqB5CoL7YAjwElRrBZoHTMN-mL-yA.OXsulVhRLairug-w.XNgbp7c1mP_f_QlWrA"
+      "9cQGhvacOK6NUJRJqNJObmVJGyNiH1Yid28DDvR6apWhepIl0NV0EkL12kvRe9ote9.wiJ-Q5nNu22TlMWoM_sL9g";
+static const char *JWE_A192GCMKW_A128CBC_HS256
+    = "eyJhbGciOiJBMTkyR0NNS1ciLCJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiaXYiOiJGTTl3YXBZTThUMFBOYXlfIiwidGFnIjoiMzNN"
+      "X3lpUXNwMHhpMEJXaDZZZVAwUSJ9.49QP3-SdJsWD_nEUN6ka59Ov3Z_2OlOaY2yAu4MbflA.PnGQh3ngHXIGvBR_2Sl-fA.3WKM"
+      "taH-VJUa4R__qtgjPUy2497u9NWjureWGaSxxB-ES9NgT83jpIM2Erx6hiOg-M-sfxMrKcBL4z-DWXl4rA.eEwnBj13oretdyScV"
+      "xJ45A";
+static const char *JWE_A256GCMKW_A256CBC_HS512
+    = "eyJhbGciOiJBMjU2R0NNS1ciLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwiaXYiOiJLRGRTZFZINUtoN1Q0cG5jIiwidGFnIjoieXNy"
+      "cm5uZVRmMkdRVDRMenZ4M2hHUSJ9.OuaUOMHkZl7oY9R1zVZVoGiaD6i9Mcpb6CeCsThzXZt7vgeCQWvsXxBE-eAYqTdvy6COKT8"
+      "3dV4kFp38IFRjfg.Gvgfo5lY_nw0_jvFrzGLBQ.cY1VYnnymEeY3SAHgDlW_8aCsz15bHY0magfUxAs5BpC_tm3wO2uxYJhPNRmg"
+      "PHuwJRCuxmbIfOAqC3R_R2tag.jXD4DClG41phS6M5F5rDht2FZ2QM11EOB-q6ymSLq9g";
+static const char *JWE_JSON_A256GCMKW
+    = "{\"ciphertext\":\"Famyc9uLPYVY1Wvc2_KlX8zJl7m0QzrJSYGIeVqAkm1IMdyN2m97i_vZl6KgGzKq2ZR0VzZX7_7rb8AD2pH6\""
+      ",\"encrypted_key\":\"CWy4y1ebAzgFfqTbPMghLQ\",\"header\":{\"iv\":\"wPnqa0PDy2Uxy1pP\",\"tag\":\"2FbgAiF9nTBIadcDp"
+      "pThRg\"},\"iv\":\"X2V4hXch6jcWGfbw\",\"protected\":\"eyJhbGciOiAiQTI1NkdDTUtXIiwgImVuYyI6ICJBMTI4R0NNIn0\",\"t"
+      "ag\":\"Of1_hDbaoJadMjP7c0h4zg\"}";
+
 START_TEST(test_cjose_jwe_rsa_oaep_256)
 {
     cjose_err err;
@@ -2022,6 +2261,53 @@ START_TEST(test_cjose_jwe_rsa_oaep_256)
 }
 END_TEST
 
+START_TEST(test_cjose_jwe_aes_gcm_kw_interop)
+{
+    cjose_err err;
+    struct
+    {
+        const char *jwe;
+        const char *key;
+        const char *alg;
+    } vectors[] = {
+        { JWE_A128GCMKW_A256GCM, JWK_OCT_16, CJOSE_HDR_ALG_A128GCMKW },
+        { JWE_A192GCMKW_A128CBC_HS256, JWK_OCT_24, CJOSE_HDR_ALG_A192GCMKW },
+        { JWE_A256GCMKW_A256CBC_HS512, JWK_OCT_32, CJOSE_HDR_ALG_A256GCMKW },
+    };
+    for (size_t i = 0; i < sizeof(vectors) / sizeof(vectors[0]); i++)
+    {
+        cjose_jwk_t *jwk = cjose_jwk_import(vectors[i].key, strlen(vectors[i].key), &err);
+        ck_assert(NULL != jwk);
+        cjose_jwe_t *jwe = cjose_jwe_import(vectors[i].jwe, strlen(vectors[i].jwe), &err);
+        ck_assert_msg(NULL != jwe, "cjose_jwe_import failed (%zu): %s", i, err.message);
+        ck_assert_str_eq(vectors[i].alg, cjose_header_get(cjose_jwe_get_protected(jwe), CJOSE_HDR_ALG, &err));
+        size_t plain_len = 0;
+        uint8_t *plain = cjose_jwe_decrypt(jwe, jwk, &plain_len, &err);
+        ck_assert_msg(NULL != plain, "cjose_jwe_decrypt failed (%zu): %s", i, err.message);
+        ck_assert_int_eq(strlen(PLAINTEXT_RSA_OAEP_256), plain_len);
+        ck_assert(0 == memcmp(PLAINTEXT_RSA_OAEP_256, plain, plain_len));
+        cjose_get_dealloc()(plain);
+        cjose_jwe_release(jwe);
+        cjose_jwk_release(jwk);
+    }
+
+    // the JSON serialization keeps "iv" and "tag" in the recipient's header
+    cjose_jwk_t *jwk = cjose_jwk_import(JWK_OCT_32, strlen(JWK_OCT_32), &err);
+    ck_assert(NULL != jwk);
+    cjose_jwe_t *jwe = cjose_jwe_import_json(JWE_JSON_A256GCMKW, strlen(JWE_JSON_A256GCMKW), &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_import_json failed: %s", err.message);
+    ck_assert(NULL == cjose_header_get(cjose_jwe_get_protected(jwe), CJOSE_HDR_IV, &err));
+    size_t plain_len = 0;
+    uint8_t *plain = cjose_jwe_decrypt(jwe, jwk, &plain_len, &err);
+    ck_assert_msg(NULL != plain, "cjose_jwe_decrypt failed: %s", err.message);
+    ck_assert_int_eq(strlen(PLAINTEXT_RSA_OAEP_256), plain_len);
+    ck_assert(0 == memcmp(PLAINTEXT_RSA_OAEP_256, plain, plain_len));
+    cjose_get_dealloc()(plain);
+    cjose_jwe_release(jwe);
+    cjose_jwk_release(jwk);
+}
+END_TEST
+
 Suite *cjose_jwe_suite(void)
 {
     Suite *suite = suite_create("jwe");
@@ -2037,6 +2323,10 @@ Suite *cjose_jwe_suite(void)
     tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt_large);
     tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt_many);
     tcase_add_test(tc_jwe, test_cjose_jwe_ecdh_es_kw_self_encrypt_self_decrypt);
+    tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_self_encrypt_self_decrypt);
+    tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_bad_params);
+    tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_multiple_recipients);
+    tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_interop);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes_gcm);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes_kw_oversized_ek);


### PR DESCRIPTION
## Summary

Adds the AES GCM key wrapping algorithms `A128GCMKW`, `A192GCMKW` and `A256GCMKW` of RFC 7518 section 4.7. The CEK is encrypted with AES GCM under an `oct` key of exactly the size the `alg` names, with a random 96-bit IV and no additional authenticated data; the IV and the 128-bit authentication tag travel as the `iv` and `tag` header parameters of the recipient.

- **Parameter placement.** With one recipient the parameters go into the protected header, so the compact serialization carries them (the same choice as `epk` for ECDH-ES). With several recipients each recipient's `iv` and `tag` go into its own header, so `cjose_jwe_encrypt_multi` works with a different key encryption key per recipient. On decrypt they are read through the recipient, shared and protected headers in that order, which is where other implementations put them in the JSON serialization. The caller's header objects are never modified: the JWE already keeps a deep copy of the protected header and now takes one of a recipient header it writes to.
- **Checks before OpenSSL is called.** The key must be an `oct` key of the algorithm's size, the IV must be 12 octets and the tag 16, and the encrypted key must be exactly as long as the CEK the `enc` header dictates, so an attacker-controlled encrypted key can never be written past the CEK buffer. A failed tag verification wipes the unauthenticated CEK output.
- **API.** New macro-only constants `CJOSE_HDR_ALG_A128GCMKW`, `CJOSE_HDR_ALG_A192GCMKW`, `CJOSE_HDR_ALG_A256GCMKW`, `CJOSE_HDR_IV` and `CJOSE_HDR_TAG` (no compat symbols, no export-list changes, per the convention set by `CJOSE_HDR_ALG_ES256K`); `iv` and `tag` are accepted in `crit`. A README row.
- **Tests.** Round trips over all six content encryption algorithms; python-jwcrypto vectors (three compact serializations and a JSON serialization with the parameters in the recipient header); a two-recipient JSON round trip that also checks the caller's headers stay untouched; negative cases for the wrong key size and type, a tampered, missing, short or non-string `iv`/`tag`, and an encrypted key of the wrong length.

With this and the PBES2 family, which follows in a separate PR, cjose covers every algorithm of RFC 7518 (refs OpenIDC/cjose#28).

## Testing

- `-pedantic -Wall -Werror` build and the full `check_cjose` run (122 checks) with `CJOSE_ENABLE_RSA1_5` OFF and ON against OpenSSL 3.5.5.
- valgrind on the `jwe` suite: no leaks, no errors.
- The `clang-format` target produces no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
