### PR TITLE
Add X25519 and X448 to the ECDH-ES key agreement (RFC 8037 section 3.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ JWE key management algorithms (`alg`):
 | `A128KW`, `A192KW`, `A256KW` | AES Key Wrap | |
 | `A128GCMKW`, `A192GCMKW`, `A256GCMKW` | AES GCM key wrapping | |
 | `dir` | direct use of a shared symmetric key | |
-| `ECDH-ES` | ECDH-ES direct key agreement | |
-| `ECDH-ES+A128KW`, `ECDH-ES+A192KW`, `ECDH-ES+A256KW` | ECDH-ES with AES Key Wrap | |
+| `ECDH-ES` | ECDH-ES direct key agreement, with an EC key or an OKP `X25519` or `X448` key | |
+| `ECDH-ES+A128KW`, `ECDH-ES+A192KW`, `ECDH-ES+A256KW` | ECDH-ES with AES Key Wrap, with an EC key or an OKP `X25519` or `X448` key | |
 
 JWE content encryption algorithms (`enc`):
 

--- a/include/cjose/jwk.h
+++ b/include/cjose/jwk.h
@@ -449,8 +449,8 @@ cjose_jwk_t *cjose_jwk_import_json(cjose_header_t *json, cjose_err *err);
  * Note: on successful return of a jwk_ecdh_ephemeral_key, the caller becomes
  * responsible for releasing that JWK wuth the cjose_jwk_release() command.
  *
- * \param jwk_self [in] The caller's own EC key pair.
- * \param jwk_peer [in] The peer's EC public key.
+ * \param jwk_self [in] The caller's own key pair: an EC key, or an OKP key on X25519 or X448.
+ * \param jwk_peer [in] The peer's public key, of the same type and on the same curve.
  * \param salt [in] An optional salt to apply to the HMAC calculation. Unless FIPS mode is required this can be empty.
  * \param salt_len [in] The length of the optional salt.
  * \param err [out] An optional error object which can be used to get additional

--- a/src/include/jwk_int.h
+++ b/src/include/jwk_int.h
@@ -70,6 +70,9 @@ bool _cjose_jwk_rsa_has_private(const cjose_jwk_t *jwk);
 // ECDH-ES runs on EC keys and on OKP X25519 and X448 keys (RFC 8037 section 3.2)
 bool _cjose_jwk_is_ecdh_key(const cjose_jwk_t *jwk);
 bool _cjose_jwk_ecdh_curve_match(const cjose_jwk_t *a, const cjose_jwk_t *b);
+// true when an EC or OKP key carries its private part; RFC 7518 section 4.6.1.1
+// allows only public parameters in the "epk" header
+bool _cjose_jwk_ecdh_has_private(const cjose_jwk_t *jwk);
 cjose_jwk_t *_cjose_jwk_ecdh_ephemeral_key(const cjose_jwk_t *jwk, cjose_err *err);
 
 bool cjose_jwk_derive_ecdh_bits(

--- a/src/include/jwk_int.h
+++ b/src/include/jwk_int.h
@@ -67,6 +67,11 @@ static inline EVP_PKEY *_cjose_jwk_rsa_key(const cjose_jwk_t *jwk) { return ((rs
 
 bool _cjose_jwk_rsa_has_private(const cjose_jwk_t *jwk);
 
+// ECDH-ES runs on EC keys and on OKP X25519 and X448 keys (RFC 8037 section 3.2)
+bool _cjose_jwk_is_ecdh_key(const cjose_jwk_t *jwk);
+bool _cjose_jwk_ecdh_curve_match(const cjose_jwk_t *a, const cjose_jwk_t *b);
+cjose_jwk_t *_cjose_jwk_ecdh_ephemeral_key(const cjose_jwk_t *jwk, cjose_err *err);
+
 bool cjose_jwk_derive_ecdh_bits(
     const cjose_jwk_t *jwk_self, const cjose_jwk_t *jwk_peer, uint8_t **output, size_t *output_len, cjose_err *err);
 

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -1361,8 +1361,9 @@ static bool _cjose_jwe_decrypt_ek_ecdh_es(_jwe_int_recipient_t *recipient, cjose
         goto cjose_decrypt_ek_ecdh_es_finish;
     }
 
-    // the ephemeral key must be of the recipient key's type and on its curve
-    if (!_cjose_jwk_ecdh_curve_match(jwk, epk_jwk))
+    // the ephemeral key must be of the recipient key's type and on its curve,
+    // and RFC 7518 section 4.6.1.1 allows it to carry public parameters only
+    if (!_cjose_jwk_ecdh_curve_match(jwk, epk_jwk) || _cjose_jwk_ecdh_has_private(epk_jwk))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto cjose_decrypt_ek_ecdh_es_finish;
@@ -1534,8 +1535,9 @@ static bool _cjose_jwe_decrypt_ek_ecdh_es_kw(
         goto cjose_decrypt_ek_ecdh_es_kw_finish;
     }
 
-    // the ephemeral key must be of the recipient key's type and on its curve
-    if (!_cjose_jwk_ecdh_curve_match(jwk, epk_jwk))
+    // the ephemeral key must be of the recipient key's type and on its curve,
+    // and RFC 7518 section 4.6.1.1 allows it to carry public parameters only
+    if (!_cjose_jwk_ecdh_curve_match(jwk, epk_jwk) || _cjose_jwk_ecdh_has_private(epk_jwk))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto cjose_decrypt_ek_ecdh_es_kw_finish;

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -384,6 +384,26 @@ static bool _cjose_jwe_reject_generated_param(cjose_jwe_t *jwe, _jwe_int_recipie
     return true;
 }
 
+// RFC 7518 section 4.6.1.1: the "epk" header holds the public key parameters of
+// the ephemeral key and nothing else, so a private member is refused on sight,
+// whatever the import would make of its value
+static bool _cjose_jwe_epk_is_public(const char *epk_json, cjose_err *err)
+{
+    json_t *epk = json_loads(epk_json, 0, NULL);
+    if (NULL == epk)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+    const bool result = (NULL == json_object_get(epk, "d"));
+    json_decref(epk);
+    if (!result)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+    }
+    return result;
+}
+
 static bool _cjose_jwe_alg_is_ecdh_es(const char *alg)
 {
     return (NULL != alg)
@@ -1347,7 +1367,10 @@ static bool _cjose_jwe_decrypt_ek_ecdh_es(_jwe_int_recipient_t *recipient, cjose
     char *epk_json = cjose_header_get_raw(jwe->hdr, CJOSE_HDR_EPK, err);
     if (NULL != epk_json)
     {
-        epk_jwk = cjose_jwk_import(epk_json, strlen(epk_json), err);
+        if (_cjose_jwe_epk_is_public(epk_json, err))
+        {
+            epk_jwk = cjose_jwk_import(epk_json, strlen(epk_json), err);
+        }
     }
     else if (CJOSE_ERR_NONE == err->code)
     {
@@ -1521,7 +1544,10 @@ static bool _cjose_jwe_decrypt_ek_ecdh_es_kw(
     epk_json = cjose_header_get_raw(jwe->hdr, CJOSE_HDR_EPK, err);
     if (NULL != epk_json)
     {
-        epk_jwk = cjose_jwk_import(epk_json, strlen(epk_json), err);
+        if (_cjose_jwe_epk_is_public(epk_json, err))
+        {
+            epk_jwk = cjose_jwk_import(epk_json, strlen(epk_json), err);
+        }
     }
     else if (CJOSE_ERR_NONE == err->code)
     {

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -1249,7 +1249,7 @@ static bool _cjose_jwe_encrypt_ek_ecdh_es(_jwe_int_recipient_t *recipient, cjose
     }
 
     // generate and export random EPK
-    epk_jwk = cjose_jwk_create_EC_random(cjose_jwk_EC_get_curve(jwk, err), err);
+    epk_jwk = _cjose_jwk_ecdh_ephemeral_key(jwk, err);
     if (NULL == epk_jwk)
     {
         // error details already set
@@ -1361,7 +1361,8 @@ static bool _cjose_jwe_decrypt_ek_ecdh_es(_jwe_int_recipient_t *recipient, cjose
         goto cjose_decrypt_ek_ecdh_es_finish;
     }
 
-    if (cjose_jwk_EC_get_curve(jwk, err) != cjose_jwk_EC_get_curve(epk_jwk, err))
+    // the ephemeral key must be of the recipient key's type and on its curve
+    if (!_cjose_jwk_ecdh_curve_match(jwk, epk_jwk))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto cjose_decrypt_ek_ecdh_es_finish;
@@ -1437,7 +1438,7 @@ static bool _cjose_jwe_encrypt_ek_ecdh_es_kw(
     }
 
     // generate and export random EPK
-    epk_jwk = cjose_jwk_create_EC_random(cjose_jwk_EC_get_curve(jwk, err), err);
+    epk_jwk = _cjose_jwk_ecdh_ephemeral_key(jwk, err);
     if (NULL == epk_jwk)
     {
         // error details already set
@@ -1533,7 +1534,8 @@ static bool _cjose_jwe_decrypt_ek_ecdh_es_kw(
         goto cjose_decrypt_ek_ecdh_es_kw_finish;
     }
 
-    if (cjose_jwk_EC_get_curve(jwk, err) != cjose_jwk_EC_get_curve(epk_jwk, err))
+    // the ephemeral key must be of the recipient key's type and on its curve
+    if (!_cjose_jwk_ecdh_curve_match(jwk, epk_jwk))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto cjose_decrypt_ek_ecdh_es_kw_finish;
@@ -2239,7 +2241,7 @@ static bool _cjose_jwe_validate_decrypt_key(_jwe_int_recipient_t *recipient,
         return false;
     }
 
-    if (_cjose_jwe_alg_is_ecdh_es(alg) && jwk->kty != CJOSE_JWK_KTY_EC)
+    if (_cjose_jwe_alg_is_ecdh_es(alg) && !_cjose_jwk_is_ecdh_key(jwk))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return false;

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -1976,9 +1976,12 @@ static cjose_jwk_t *_cjose_jwk_import_EC(json_t *jwk_json, cjose_err *err)
         goto import_EC_cleanup;
     }
 
-    // get the decoded value of the private key d
+    // get the decoded value of the private key d; a "d" that is present but
+    // carries no value is a malformed key, not a public one (the OKP import
+    // makes the same distinction)
     d_buflen = (size_t)_cjose_jwk_ec_size_for_curve(crv, err);
-    if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_D_STR, &d_buffer, &d_buflen, err))
+    if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_D_STR, &d_buffer, &d_buflen, err)
+        || (NULL != json_object_get(jwk_json, CJOSE_JWK_D_STR) && NULL == d_buffer))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         goto import_EC_cleanup;

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -2326,33 +2326,72 @@ cjose_jwk_t *cjose_jwk_import_json(cjose_header_t *json, cjose_err *err)
 //////////////// ECDH ////////////////
 // internal data & functions -- ECDH derivation
 
-static bool _cjose_jwk_evp_key_from_ec_key(const cjose_jwk_t *jwk, EVP_PKEY **key, cjose_err *err)
+// ECDH-ES key agreement runs on EC keys and on the OKP X25519 and X448 keys
+// (RFC 8037 section 3.2); the Ed25519 and Ed448 signature keys do not qualify
+bool _cjose_jwk_is_ecdh_key(const cjose_jwk_t *jwk)
 {
-    // validate that the jwk is of type EC and we have a valid out-param
-    if (NULL == jwk || CJOSE_JWK_KTY_EC != jwk->kty || NULL == jwk->keydata || NULL == key || NULL != *key)
+    if (NULL == jwk || NULL == jwk->keydata)
+    {
+        return false;
+    }
+    if (CJOSE_JWK_KTY_EC == jwk->kty)
+    {
+        return true;
+    }
+    if (CJOSE_JWK_KTY_OKP == jwk->kty)
+    {
+        const cjose_jwk_okp_curve crv = ((okp_keydata *)jwk->keydata)->crv;
+        return CJOSE_JWK_OKP_X25519 == crv || CJOSE_JWK_OKP_X448 == crv;
+    }
+    return false;
+}
+
+// whether two keys can perform ECDH-ES with each other: the same key type on
+// the same curve
+bool _cjose_jwk_ecdh_curve_match(const cjose_jwk_t *a, const cjose_jwk_t *b)
+{
+    if (!_cjose_jwk_is_ecdh_key(a) || !_cjose_jwk_is_ecdh_key(b) || a->kty != b->kty)
+    {
+        return false;
+    }
+    if (CJOSE_JWK_KTY_EC == a->kty)
+    {
+        return ((ec_keydata *)a->keydata)->crv == ((ec_keydata *)b->keydata)->crv;
+    }
+    return ((okp_keydata *)a->keydata)->crv == ((okp_keydata *)b->keydata)->crv;
+}
+
+// a fresh ephemeral key of the type and curve of the given key
+cjose_jwk_t *_cjose_jwk_ecdh_ephemeral_key(const cjose_jwk_t *jwk, cjose_err *err)
+{
+    if (!_cjose_jwk_is_ecdh_key(jwk))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-        goto _cjose_jwk_evp_key_from_ec_key_fail;
+        return NULL;
     }
+    if (CJOSE_JWK_KTY_EC == jwk->kty)
+    {
+        return cjose_jwk_create_EC_random(((ec_keydata *)jwk->keydata)->crv, err);
+    }
+    return cjose_jwk_create_OKP_random(((okp_keydata *)jwk->keydata)->crv, err);
+}
 
-    EVP_PKEY *jwk_key = ((ec_keydata *)(jwk->keydata))->key;
+// the EVP_PKEY of an ECDH-ES key, with a reference the caller releases
+static bool _cjose_jwk_evp_key_for_ecdh(const cjose_jwk_t *jwk, EVP_PKEY **key, cjose_err *err)
+{
+    if (!_cjose_jwk_is_ecdh_key(jwk) || NULL == key || NULL != *key)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+    EVP_PKEY *jwk_key = (CJOSE_JWK_KTY_EC == jwk->kty) ? ((ec_keydata *)jwk->keydata)->key : ((okp_keydata *)jwk->keydata)->key;
     if (NULL == jwk_key || 1 != EVP_PKEY_up_ref(jwk_key))
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
-        goto _cjose_jwk_evp_key_from_ec_key_fail;
+        return false;
     }
     *key = jwk_key;
-
-    // happy path
     return true;
-
-// fail path
-_cjose_jwk_evp_key_from_ec_key_fail:
-
-    EVP_PKEY_free(*key);
-    *key = NULL;
-
-    return false;
 }
 
 cjose_jwk_t *cjose_jwk_derive_ecdh_secret(
@@ -2422,14 +2461,21 @@ bool cjose_jwk_derive_ecdh_bits(
     uint8_t *secret = NULL;
     size_t secret_len = 0;
 
+    // both keys must be of the same type on the same curve
+    if (!_cjose_jwk_ecdh_curve_match(jwk_self, jwk_peer))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
     // get EVP_KEY from jwk_self
-    if (!_cjose_jwk_evp_key_from_ec_key(jwk_self, &pkey_self, err))
+    if (!_cjose_jwk_evp_key_for_ecdh(jwk_self, &pkey_self, err))
     {
         goto _cjose_jwk_derive_bits_fail;
     }
 
     // get EVP_KEY from jwk_peer
-    if (!_cjose_jwk_evp_key_from_ec_key(jwk_peer, &pkey_peer, err))
+    if (!_cjose_jwk_evp_key_for_ecdh(jwk_peer, &pkey_peer, err))
     {
         goto _cjose_jwk_derive_bits_fail;
     }

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -2361,6 +2361,19 @@ bool _cjose_jwk_ecdh_curve_match(const cjose_jwk_t *a, const cjose_jwk_t *b)
     return ((okp_keydata *)a->keydata)->crv == ((okp_keydata *)b->keydata)->crv;
 }
 
+bool _cjose_jwk_ecdh_has_private(const cjose_jwk_t *jwk)
+{
+    if (!_cjose_jwk_is_ecdh_key(jwk))
+    {
+        return false;
+    }
+    if (CJOSE_JWK_KTY_EC == jwk->kty)
+    {
+        return ((ec_keydata *)jwk->keydata)->has_private;
+    }
+    return ((okp_keydata *)jwk->keydata)->has_private;
+}
+
 // a fresh ephemeral key of the type and curve of the given key
 cjose_jwk_t *_cjose_jwk_ecdh_ephemeral_key(const cjose_jwk_t *jwk, cjose_err *err)
 {

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -2654,6 +2654,24 @@ static char *_jwe_with_epk(const char *compact, const char *epk_json)
     return result;
 }
 
+static void _ecdh_decrypt_ok(const char *compact, const char *key, const uint8_t *expected, size_t expected_len)
+{
+    cjose_err err;
+    memset(&err, 0, sizeof(err));
+    cjose_jwk_t *jwk = cjose_jwk_import(key, strlen(key), &err);
+    ck_assert(NULL != jwk);
+    cjose_jwe_t *jwe = cjose_jwe_import(compact, strlen(compact), &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_import failed: %s", err.message);
+    size_t plain_len = 0;
+    uint8_t *plain = cjose_jwe_decrypt(jwe, jwk, &plain_len, &err);
+    ck_assert_msg(NULL != plain, "cjose_jwe_decrypt failed: %s", err.message);
+    ck_assert_int_eq(expected_len, plain_len);
+    ck_assert(0 == memcmp(expected, plain, plain_len));
+    cjose_get_dealloc()(plain);
+    cjose_jwe_release(jwe);
+    cjose_jwk_release(jwk);
+}
+
 static void _ecdh_decrypt_expect(const char *compact, const char *key, cjose_errcode expected)
 {
     cjose_err err;
@@ -2669,6 +2687,44 @@ static void _ecdh_decrypt_expect(const char *compact, const char *key, cjose_err
     cjose_jwe_release(jwe);
     cjose_jwk_release(jwk);
 }
+
+// RFC 7518 section 4.6.1.1: the "epk" header carries public key parameters
+// only, for EC keys as well as for the OKP curves
+START_TEST(test_cjose_jwe_ecdh_es_private_epk)
+{
+    cjose_err err;
+    static const uint8_t plain[] = "Setec Astronomy";
+
+    cjose_header_t *hdr = cjose_header_new(&err);
+    ck_assert(NULL != hdr);
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_ECDH_ES_A128KW, &err));
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A128CBC_HS256, &err));
+
+    cjose_jwk_t *ec = cjose_jwk_import(JWK_EC, strlen(JWK_EC), &err);
+    ck_assert(NULL != ec);
+    cjose_jwe_t *jwe = cjose_jwe_encrypt(ec, hdr, plain, sizeof(plain) - 1, &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed: %s", err.message);
+    char *compact = cjose_jwe_export(jwe, &err);
+    ck_assert(NULL != compact);
+    cjose_jwe_release(jwe);
+
+    // the public ephemeral key the encryption published still decrypts
+    _ecdh_decrypt_ok(compact, JWK_EC, plain, sizeof(plain) - 1);
+
+    // the same key with its private part in "epk" is refused
+    char *private_epk = cjose_jwk_to_json(ec, true, &err);
+    ck_assert(NULL != private_epk);
+    ck_assert(NULL != strstr(private_epk, "\"d\""));
+    char *modified = _jwe_with_epk(compact, private_epk);
+    _ecdh_decrypt_expect(modified, JWK_EC, CJOSE_ERR_INVALID_ARG);
+    free(modified);
+
+    cjose_get_dealloc()(private_epk);
+    cjose_get_dealloc()(compact);
+    cjose_jwk_release(ec);
+    cjose_header_release(hdr);
+}
+END_TEST
 
 START_TEST(test_cjose_jwe_ecdh_es_okp_bad_params)
 {
@@ -2711,7 +2767,11 @@ START_TEST(test_cjose_jwe_ecdh_es_okp_bad_params)
     char *ec_epk = cjose_jwk_to_json(ec, false, &err);
     char *x448_epk = cjose_jwk_to_json(x448, false, &err);
     ck_assert(NULL != ec_epk && NULL != x448_epk);
-    const char *epks[] = { ec_epk, x448_epk, "{\"kty\":\"OKP\",\"crv\":\"X25519\",\"x\":\"AAAA\"}" };
+    // ... or one that carries the private part, which RFC 7518 section 4.6.1.1
+    // does not allow in the "epk" header
+    char *x25519_private_epk = cjose_jwk_to_json(x25519, true, &err);
+    ck_assert(NULL != x25519_private_epk);
+    const char *epks[] = { ec_epk, x448_epk, "{\"kty\":\"OKP\",\"crv\":\"X25519\",\"x\":\"AAAA\"}", x25519_private_epk };
     for (size_t i = 0; i < sizeof(epks) / sizeof(epks[0]); i++)
     {
         char *modified = _jwe_with_epk(compact, epks[i]);
@@ -2719,6 +2779,7 @@ START_TEST(test_cjose_jwe_ecdh_es_okp_bad_params)
         free(modified);
     }
 
+    cjose_get_dealloc()(x25519_private_epk);
     cjose_get_dealloc()(ec_epk);
     cjose_get_dealloc()(x448_epk);
     cjose_get_dealloc()(compact);
@@ -2893,6 +2954,7 @@ Suite *cjose_jwe_suite(void)
     tcase_add_test(tc_jwe, test_cjose_jwe_ecdh_es_okp_self_encrypt_self_decrypt);
     tcase_add_test(tc_jwe, test_cjose_jwe_ecdh_es_okp_interop);
     tcase_add_test(tc_jwe, test_cjose_jwe_ecdh_es_okp_bad_params);
+    tcase_add_test(tc_jwe, test_cjose_jwe_ecdh_es_private_epk);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes_gcm);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes_kw_oversized_ek);

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -2711,14 +2711,26 @@ START_TEST(test_cjose_jwe_ecdh_es_private_epk)
     // the public ephemeral key the encryption published still decrypts
     _ecdh_decrypt_ok(compact, JWK_EC, plain, sizeof(plain) - 1);
 
-    // the same key with its private part in "epk" is refused
+    // the same key with its private part in "epk" is refused, and so is one
+    // that merely names "d", which the import would otherwise read as a public
+    // key (RFC 7518 section 4.6.1.1 allows public parameters only)
     char *private_epk = cjose_jwk_to_json(ec, true, &err);
-    ck_assert(NULL != private_epk);
-    ck_assert(NULL != strstr(private_epk, "\"d\""));
-    char *modified = _jwe_with_epk(compact, private_epk);
-    _ecdh_decrypt_expect(modified, JWK_EC, CJOSE_ERR_INVALID_ARG);
-    free(modified);
+    char *public_epk = cjose_jwk_to_json(ec, false, &err);
+    ck_assert(NULL != private_epk && NULL != public_epk);
+    ck_assert(NULL != strstr(private_epk, "\"d\"") && NULL == strstr(public_epk, "\"d\""));
+    char empty_d[512], null_d[512];
+    ck_assert(strlen(public_epk) < sizeof(empty_d) - 16);
+    snprintf(empty_d, sizeof(empty_d), "%.*s,\"d\":\"\"}", (int)strlen(public_epk) - 1, public_epk);
+    snprintf(null_d, sizeof(null_d), "%.*s,\"d\":null}", (int)strlen(public_epk) - 1, public_epk);
+    const char *bad_epks[] = { private_epk, empty_d, null_d };
+    for (size_t i = 0; i < sizeof(bad_epks) / sizeof(bad_epks[0]); i++)
+    {
+        char *modified = _jwe_with_epk(compact, bad_epks[i]);
+        _ecdh_decrypt_expect(modified, JWK_EC, CJOSE_ERR_INVALID_ARG);
+        free(modified);
+    }
 
+    cjose_get_dealloc()(public_epk);
     cjose_get_dealloc()(private_epk);
     cjose_get_dealloc()(compact);
     cjose_jwk_release(ec);
@@ -2771,7 +2783,13 @@ START_TEST(test_cjose_jwe_ecdh_es_okp_bad_params)
     // does not allow in the "epk" header
     char *x25519_private_epk = cjose_jwk_to_json(x25519, true, &err);
     ck_assert(NULL != x25519_private_epk);
-    const char *epks[] = { ec_epk, x448_epk, "{\"kty\":\"OKP\",\"crv\":\"X25519\",\"x\":\"AAAA\"}", x25519_private_epk };
+    static const char *const X25519_PUB
+        = "\"kty\":\"OKP\",\"crv\":\"X25519\",\"x\":\"gJ2aLU9SQ7QA9UhajNXbHjoN4DXkpeJyqJpR9NlAmW0\"";
+    char okp_empty_d[256], okp_null_d[256];
+    snprintf(okp_empty_d, sizeof(okp_empty_d), "{%s,\"d\":\"\"}", X25519_PUB);
+    snprintf(okp_null_d, sizeof(okp_null_d), "{%s,\"d\":null}", X25519_PUB);
+    const char *epks[]
+        = { ec_epk, x448_epk, "{\"kty\":\"OKP\",\"crv\":\"X25519\",\"x\":\"AAAA\"}", x25519_private_epk, okp_empty_d, okp_null_d };
     for (size_t i = 0; i < sizeof(epks) / sizeof(epks[0]); i++)
     {
         char *modified = _jwe_with_epk(compact, epks[i]);

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -2518,6 +2518,218 @@ static const char *JWE_JSON_RSA_OAEP_256
       "kLDnnVrPaHUEUL79-KWMa-8tZ-SN0aHc2SuKQGNtNZsawMO05A\",\"header\":{\"alg\":\"RSA-OAEP\",\"kid\":\"oaep\"}}],\"tag\""
       ":\"Qc5-QsMtp9mUGBa7L0BXaA\"}";
 
+// OKP X25519, X448 and Ed25519 keys and ECDH-ES JWEs produced by python-jwcrypto
+// with the X25519 and X448 keys over PLAINTEXT_RSA_OAEP_256 (RFC 8037 section 3.2)
+static const char *JWK_OKP_X25519
+    = "{\"crv\":\"X25519\",\"d\":\"qHAB5F3M9hxL7ZDQ8TcyOUBNevDnJ5EVMEnWnF3xCFk\",\"kty\":\"OKP\",\"x\":\"gJ2aLU9SQ7QA9Uhaj"
+      "NXbHjoN4DXkpeJyqJpR9NlAmW0\"}";
+static const char *JWK_OKP_X448
+    = "{\"crv\":\"X448\",\"d\":\"pCvG4F8Bj5_mxnXq3nBfCgpKgHzlWPaVDTqwJM_XB4iJqL5zSCZp55wc0Q0idGh1cKWAzFr206w\",\"kty"
+      "\":\"OKP\",\"x\":\"VD1oTZcbrZf0ZoIyfWaYNLmCa1Ox2ATbs4vB9CTQP4gleQ0GDQWT1_3-MivY6lXH5sNGeyzcVYQ\"}";
+static const char *JWK_OKP_ED25519
+    = "{\"crv\":\"Ed25519\",\"d\":\"VMrqr6gioP37bFszQqnpMAAvKh3iAtMMJvNbamEitGw\",\"kty\":\"OKP\",\"x\":\"6vnVE2GuLNtXlOyR"
+      "RGWMp2Ayclcow67tt_d26x-ph14\"}";
+static const char *JWE_ECDH_ES_X25519_A128GCM
+    = "eyJhbGciOiJFQ0RILUVTIiwiZW5jIjoiQTEyOEdDTSIsImVwayI6eyJjcnYiOiJYMjU1MTkiLCJrdHkiOiJPS1AiLCJ4IjoiV2xJ"
+      "YTlIdkJsajNjMDRXazdwR3pKcGtFUWFSRjlHU0w2QVd3M1l4REN6OCJ9fQ..rODMIvHQfm_nIXJK.nEuUN4Hpo-ydZNYfvuwRrS6"
+      "b8JK2Cq9lcCHdd1ZPFPUwts3LozFt3heaiLcPJTcodkEl_G7f03T5GJGzuhQ2.yGW2moIVMuWuS10vB42ldA";
+static const char *JWE_ECDH_ES_A256KW_X25519_A128CBC_HS256
+    = "eyJhbGciOiJFQ0RILUVTK0EyNTZLVyIsImVuYyI6IkExMjhDQkMtSFMyNTYiLCJlcGsiOnsiY3J2IjoiWDI1NTE5Iiwia3R5Ijoi"
+      "T0tQIiwieCI6InNWNlgwODB5TjZZVjNzSW8xdHcwbG54VEJ1ckZmUk9qTUFfY0RVbVBsVm8ifX0.TOF545p-jJum_sVmgLHyG70o"
+      "OrQAiIbh26FaaWl7BtBmcxRwFIMSOw.2YJ354jtFwx4ziCTPfbVKg.mJ9BzZZ7g8YSGy7Vp6MUmj__IGEVkVspwsdJ_jN-YcMYNu"
+      "BUutjKIoKEj2YscHbeWBCbbf3ASxoDnQ2l9rfoXA.SW6bSbJsr2-WBRyueHzPMw";
+static const char *JWE_ECDH_ES_X448_A256GCM
+    = "eyJhbGciOiJFQ0RILUVTIiwiZW5jIjoiQTI1NkdDTSIsImVwayI6eyJjcnYiOiJYNDQ4Iiwia3R5IjoiT0tQIiwieCI6Ik0teXN2"
+      "TnNySm9wWVlGak42cEQzWlZMLU0ybXU3Q0N2YjQ3Qi11WUYxVzQwakl6ZzltbTU0XzVLdnhDQ2dkTVdpQzQ1dzA5MXBUayJ9fQ.."
+      "ZiRgVCuUeAlaMRJL.__hVCFR7Q3j6JcdLpXajSyD4CBDgTXMshTkttWX_GA5dVr7S02MXtmzoqFp5sniofG3adyoX4hhp0xqh_1c"
+      "3.FDfw04OugrpSTuTLX_QpYw";
+static const char *JWE_ECDH_ES_A128KW_X448_A256GCM
+    = "eyJhbGciOiJFQ0RILUVTK0ExMjhLVyIsImVuYyI6IkEyNTZHQ00iLCJlcGsiOnsiY3J2IjoiWDQ0OCIsImt0eSI6Ik9LUCIsIngi"
+      "OiJVd2ZQUWE1ay0ycGZRVEZmTFVIby1JRnlWMnJ1TDBFYzJtdUQ5WjcxT3VlTWlCeTV4akZWSDJRWDA4Z3duaDg5S3J1cElSdHJI"
+      "eHcifX0.WeWvw-ve2aynM6NmLqYO-e_Q8cyD1AFwoU187TX8gmLJOQcrb7aDNg.RC5hj4D7Av2dLGNx.1FXtCTZ9P6IrUkbchJ6O"
+      "4tC7f_ka8TmobSXnq2Bfvnhs_8dz1gXTItlGaBYqnJGmydpAI7tf8_i6Cp3YIg-Z.9cXIIfIGpq5RK3y5HuCy7g";
+
+START_TEST(test_cjose_jwe_ecdh_es_okp_self_encrypt_self_decrypt)
+{
+    cjose_err err;
+    static const uint8_t plain[] = "Setec Astronomy";
+    const char *keys[] = { JWK_OKP_X25519, JWK_OKP_X448 };
+    const char *curves[] = { "X25519", "X448" };
+
+    for (size_t i = 0; i < sizeof(keys) / sizeof(keys[0]); i++)
+    {
+        _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_ECDH_ES, CJOSE_HDR_ENC_A256GCM, keys[i], plain, sizeof(plain) - 1);
+        _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_ECDH_ES, CJOSE_HDR_ENC_A128CBC_HS256, keys[i], plain, sizeof(plain) - 1);
+        _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_ECDH_ES_A128KW, CJOSE_HDR_ENC_A128GCM, keys[i], plain, sizeof(plain) - 1);
+        _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_ECDH_ES_A192KW, CJOSE_HDR_ENC_A192CBC_HS384, keys[i], plain,
+                                            sizeof(plain) - 1);
+        _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_ECDH_ES_A256KW, CJOSE_HDR_ENC_A256CBC_HS512, keys[i], plain,
+                                            sizeof(plain) - 1);
+
+        // the ephemeral key is a public OKP key on the recipient key's curve
+        cjose_jwk_t *jwk = cjose_jwk_import(keys[i], strlen(keys[i]), &err);
+        ck_assert(NULL != jwk);
+        cjose_header_t *hdr = cjose_header_new(&err);
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_ECDH_ES, &err));
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+        cjose_jwe_t *jwe = cjose_jwe_encrypt(jwk, hdr, plain, sizeof(plain) - 1, &err);
+        ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed for %s: %s", curves[i], err.message);
+        json_t *epk = json_object_get((json_t *)cjose_jwe_get_protected(jwe), CJOSE_HDR_EPK);
+        ck_assert(json_is_object(epk));
+        ck_assert_str_eq("OKP", json_string_value(json_object_get(epk, "kty")));
+        ck_assert_str_eq(curves[i], json_string_value(json_object_get(epk, "crv")));
+        ck_assert(NULL == json_object_get(epk, "d"));
+        cjose_jwe_release(jwe);
+        cjose_header_release(hdr);
+        cjose_jwk_release(jwk);
+    }
+}
+END_TEST
+
+START_TEST(test_cjose_jwe_ecdh_es_okp_interop)
+{
+    cjose_err err;
+    struct
+    {
+        const char *jwe;
+        const char *key;
+        const char *alg;
+        const char *crv;
+    } vectors[] = {
+        { JWE_ECDH_ES_X25519_A128GCM, JWK_OKP_X25519, CJOSE_HDR_ALG_ECDH_ES, "X25519" },
+        { JWE_ECDH_ES_A256KW_X25519_A128CBC_HS256, JWK_OKP_X25519, CJOSE_HDR_ALG_ECDH_ES_A256KW, "X25519" },
+        { JWE_ECDH_ES_X448_A256GCM, JWK_OKP_X448, CJOSE_HDR_ALG_ECDH_ES, "X448" },
+        { JWE_ECDH_ES_A128KW_X448_A256GCM, JWK_OKP_X448, CJOSE_HDR_ALG_ECDH_ES_A128KW, "X448" },
+    };
+    for (size_t i = 0; i < sizeof(vectors) / sizeof(vectors[0]); i++)
+    {
+        cjose_jwk_t *jwk = cjose_jwk_import(vectors[i].key, strlen(vectors[i].key), &err);
+        ck_assert(NULL != jwk);
+        cjose_jwe_t *jwe = cjose_jwe_import(vectors[i].jwe, strlen(vectors[i].jwe), &err);
+        ck_assert_msg(NULL != jwe, "cjose_jwe_import failed (%zu): %s", i, err.message);
+        ck_assert_str_eq(vectors[i].alg, cjose_header_get(cjose_jwe_get_protected(jwe), CJOSE_HDR_ALG, &err));
+        json_t *epk = json_object_get((json_t *)cjose_jwe_get_protected(jwe), CJOSE_HDR_EPK);
+        ck_assert_str_eq(vectors[i].crv, json_string_value(json_object_get(epk, "crv")));
+        size_t plain_len = 0;
+        uint8_t *plain = cjose_jwe_decrypt(jwe, jwk, &plain_len, &err);
+        ck_assert_msg(NULL != plain, "cjose_jwe_decrypt failed (%zu): %s", i, err.message);
+        ck_assert_int_eq(strlen(PLAINTEXT_RSA_OAEP_256), plain_len);
+        ck_assert(0 == memcmp(PLAINTEXT_RSA_OAEP_256, plain, plain_len));
+        cjose_get_dealloc()(plain);
+        cjose_jwe_release(jwe);
+        cjose_jwk_release(jwk);
+    }
+}
+END_TEST
+
+// re-encode the compact serialization with the given "epk" in the protected
+// header; the AAD changes with it, but the ephemeral key is checked before the
+// content is authenticated
+static char *_jwe_with_epk(const char *compact, const char *epk_json)
+{
+    cjose_err err;
+    const char *dot = strchr(compact, '.');
+    ck_assert(NULL != dot);
+    uint8_t *raw = NULL;
+    size_t raw_len = 0;
+    ck_assert(cjose_base64url_decode(compact, dot - compact, &raw, &raw_len, &err));
+    json_t *hdr = json_loadb((const char *)raw, raw_len, 0, NULL);
+    ck_assert(NULL != hdr);
+    json_t *epk = json_loads(epk_json, 0, NULL);
+    ck_assert(NULL != epk);
+    ck_assert(0 == json_object_set_new(hdr, CJOSE_HDR_EPK, epk));
+    char *hdr_str = json_dumps(hdr, JSON_COMPACT);
+    ck_assert(NULL != hdr_str);
+    char *hdr_b64u = NULL;
+    size_t hdr_b64u_len = 0;
+    ck_assert(cjose_base64url_encode((const uint8_t *)hdr_str, strlen(hdr_str), &hdr_b64u, &hdr_b64u_len, &err));
+    char *result = malloc(hdr_b64u_len + strlen(dot) + 1);
+    ck_assert(NULL != result);
+    memcpy(result, hdr_b64u, hdr_b64u_len);
+    strcpy(result + hdr_b64u_len, dot);
+    cjose_get_dealloc()(hdr_b64u);
+    cjose_get_dealloc()(hdr_str);
+    json_decref(hdr);
+    cjose_get_dealloc()(raw);
+    return result;
+}
+
+static void _ecdh_decrypt_expect(const char *compact, const char *key, cjose_errcode expected)
+{
+    cjose_err err;
+    memset(&err, 0, sizeof(err));
+    cjose_jwk_t *jwk = cjose_jwk_import(key, strlen(key), &err);
+    ck_assert(NULL != jwk);
+    cjose_jwe_t *jwe = cjose_jwe_import(compact, strlen(compact), &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_import failed: %s", err.message);
+    size_t plain_len = 0;
+    uint8_t *plain = cjose_jwe_decrypt(jwe, jwk, &plain_len, &err);
+    ck_assert_msg(NULL == plain, "cjose_jwe_decrypt succeeded unexpectedly");
+    ck_assert_int_eq(expected, err.code);
+    cjose_jwe_release(jwe);
+    cjose_jwk_release(jwk);
+}
+
+START_TEST(test_cjose_jwe_ecdh_es_okp_bad_params)
+{
+    cjose_err err;
+    static const uint8_t plain[] = "Setec Astronomy";
+
+    cjose_header_t *hdr = cjose_header_new(&err);
+    ck_assert(NULL != hdr);
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_ECDH_ES, &err));
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+
+    // the signature curves do not do key agreement
+    cjose_jwk_t *ed = cjose_jwk_import(JWK_OKP_ED25519, strlen(JWK_OKP_ED25519), &err);
+    ck_assert(NULL != ed);
+    ck_assert(NULL == cjose_jwe_encrypt(ed, hdr, plain, sizeof(plain) - 1, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_ECDH_ES_A128KW, &err));
+    ck_assert(NULL == cjose_jwe_encrypt(ed, hdr, plain, sizeof(plain) - 1, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_ECDH_ES, &err));
+
+    // a good X25519 JWE ...
+    cjose_jwk_t *x25519 = cjose_jwk_import(JWK_OKP_X25519, strlen(JWK_OKP_X25519), &err);
+    ck_assert(NULL != x25519);
+    cjose_jwe_t *jwe = cjose_jwe_encrypt(x25519, hdr, plain, sizeof(plain) - 1, &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed: %s", err.message);
+    char *compact = cjose_jwe_export(jwe, &err);
+    ck_assert(NULL != compact);
+    cjose_jwe_release(jwe);
+
+    // ... is refused with a key of another type or curve
+    _ecdh_decrypt_expect(compact, JWK_OKP_ED25519, CJOSE_ERR_INVALID_ARG);
+    _ecdh_decrypt_expect(compact, JWK_OKP_X448, CJOSE_ERR_INVALID_ARG);
+    _ecdh_decrypt_expect(compact, JWK_EC, CJOSE_ERR_INVALID_ARG);
+
+    // ... and with an ephemeral key of another type or curve, or of the wrong size
+    cjose_jwk_t *ec = cjose_jwk_import(JWK_EC, strlen(JWK_EC), &err);
+    cjose_jwk_t *x448 = cjose_jwk_import(JWK_OKP_X448, strlen(JWK_OKP_X448), &err);
+    ck_assert(NULL != ec && NULL != x448);
+    char *ec_epk = cjose_jwk_to_json(ec, false, &err);
+    char *x448_epk = cjose_jwk_to_json(x448, false, &err);
+    ck_assert(NULL != ec_epk && NULL != x448_epk);
+    const char *epks[] = { ec_epk, x448_epk, "{\"kty\":\"OKP\",\"crv\":\"X25519\",\"x\":\"AAAA\"}" };
+    for (size_t i = 0; i < sizeof(epks) / sizeof(epks[0]); i++)
+    {
+        char *modified = _jwe_with_epk(compact, epks[i]);
+        _ecdh_decrypt_expect(modified, JWK_OKP_X25519, CJOSE_ERR_INVALID_ARG);
+        free(modified);
+    }
+
+    cjose_get_dealloc()(ec_epk);
+    cjose_get_dealloc()(x448_epk);
+    cjose_get_dealloc()(compact);
+    cjose_jwk_release(ec);
+    cjose_jwk_release(x448);
+    cjose_jwk_release(x25519);
+    cjose_jwk_release(ed);
+    cjose_header_release(hdr);
+}
+END_TEST
+
 // AES GCM key wrapping JWEs produced by python-jwcrypto with the JWK_OCT_16,
 // JWK_OCT_24 and JWK_OCT_32 keys over PLAINTEXT_RSA_OAEP_256: three compact
 // serializations and a JSON serialization carrying "iv" and "tag" in the
@@ -2678,6 +2890,9 @@ Suite *cjose_jwe_suite(void)
     tcase_add_test(tc_jwe, test_cjose_jwe_generated_params);
     tcase_add_test(tc_jwe, test_cjose_jwe_json_header_rules);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_interop);
+    tcase_add_test(tc_jwe, test_cjose_jwe_ecdh_es_okp_self_encrypt_self_decrypt);
+    tcase_add_test(tc_jwe, test_cjose_jwe_ecdh_es_okp_interop);
+    tcase_add_test(tc_jwe, test_cjose_jwe_ecdh_es_okp_bad_params);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes_gcm);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes_kw_oversized_ek);

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -2012,6 +2012,119 @@ START_TEST(test_cjose_jwk_create_RSA_spec_weak_modulus)
 }
 END_TEST
 
+// RFC 8037 Appendix A.6 and A.7: Bob's and the ephemeral X25519 and X448 key
+// pairs and the shared secret Z; Bob's private keys are those of RFC 7748
+// section 6, whose public keys the RFC 8037 examples use
+static const char *RFC8037_X25519_BOB_D = "XasIfmJKikt54X-Lg4AO5m87sSkmGLb9HC-LJ_-I4Os";
+static const char *RFC8037_X25519_BOB_X = "3p7bfXt9wbTTW2HC7OQ1Nz-DQ8hbeGdNrfx-FG-IK08";
+static const char *RFC8037_X25519_EPH_D = "dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo";
+static const char *RFC8037_X25519_EPH_X = "hSDwCYkwp1R0i33ctD73Wg2_Og0mOBr066SpjqqbTmo";
+static const char *RFC8037_X25519_Z = "Sl2dW6TOLeFyjjv0gDUPJeB-IclH0Z4zdvCbPB4WF0I";
+static const char *RFC8037_X448_BOB_D = "HDBqesKg4uCZCylEcMujOeZFN3KwdYEdj60NHWknwSC7XuiXKw0-ITdMnJIbCdGwNm8QtlFzmS0";
+static const char *RFC8037_X448_BOB_X = "PreoKbDNIPW8_AtZm2_sz22kYnEHvbDU80W0MCfYuXL8PjT7QjKhPKcG3LV67D2uB73BxnvzNgk";
+static const char *RFC8037_X448_EPH_D = "mo9JJdFRn1d1z0awS1gA1O6e6LrovFVl1JjCjdnJuvV0qUGXRIlzkQBjgqbxJ6sdmsLYwKWYcms";
+static const char *RFC8037_X448_EPH_X = "mwj3zDG34-Z9ItWuoSEHSic70rg94Jxj-qc9LCLF2bvINmRyQdlT1AxbEtqIEg1TF3-A5TLEH6A";
+static const char *RFC8037_X448_Z = "B__0GBrGzJXsHBapSg900S2iMs5Ap3VSKB0oK7YMC1b9JGTDNVQ5NlIcJEAwhdWaRJpQN1FKh50";
+
+static cjose_jwk_t *_okp_from_b64u(cjose_jwk_okp_curve crv, const char *d, const char *x)
+{
+    cjose_err err;
+    cjose_jwk_okp_keyspec spec;
+    memset(&spec, 0, sizeof(spec));
+    spec.crv = crv;
+    if (NULL != d)
+    {
+        ck_assert(cjose_base64url_decode(d, strlen(d), &spec.d, &spec.dlen, &err));
+    }
+    ck_assert(cjose_base64url_decode(x, strlen(x), &spec.x, &spec.xlen, &err));
+    cjose_jwk_t *jwk = cjose_jwk_create_OKP_spec(&spec, &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_create_OKP_spec failed: %s", err.message);
+    _cjose_cleanse_dealloc(spec.d, spec.dlen);
+    cjose_get_dealloc()(spec.x);
+    return jwk;
+}
+
+// the ECDH of RFC 8037 Appendix A.6 and A.7, in both directions
+static void _ecdh_rfc8037(
+    cjose_jwk_okp_curve crv, const char *bob_d, const char *bob_x, const char *eph_d, const char *eph_x, const char *z_b64u)
+{
+    cjose_err err;
+    uint8_t *z = NULL;
+    size_t z_len = 0;
+    ck_assert(cjose_base64url_decode(z_b64u, strlen(z_b64u), &z, &z_len, &err));
+
+    // the private keys are given together with their public keys, which
+    // cjose checks belong together
+    cjose_jwk_t *eph = _okp_from_b64u(crv, eph_d, eph_x);
+    cjose_jwk_t *eph_pub = _okp_from_b64u(crv, NULL, eph_x);
+    cjose_jwk_t *bob = _okp_from_b64u(crv, bob_d, bob_x);
+    cjose_jwk_t *bob_pub = _okp_from_b64u(crv, NULL, bob_x);
+
+    // the sender computes Z from the ephemeral private key and Bob's public
+    // key, the receiver from Bob's private key and the ephemeral public key
+    const cjose_jwk_t *sides[][2] = { { eph, bob_pub }, { bob, eph_pub } };
+    for (size_t i = 0; i < 2; i++)
+    {
+        uint8_t *out = NULL;
+        size_t out_len = 0;
+        ck_assert_msg(cjose_jwk_derive_ecdh_bits(sides[i][0], sides[i][1], &out, &out_len, &err),
+                      "cjose_jwk_derive_ecdh_bits failed (%zu): %s", i, err.message);
+        ck_assert_int_eq(z_len, out_len);
+        ck_assert(0 == memcmp(z, out, z_len));
+        _cjose_cleanse_dealloc(out, out_len);
+    }
+
+    // a public-only key cannot be the private side
+    uint8_t *out = NULL;
+    size_t out_len = 0;
+    ck_assert(!cjose_jwk_derive_ecdh_bits(bob_pub, eph_pub, &out, &out_len, &err));
+
+    cjose_jwk_release(eph);
+    cjose_jwk_release(eph_pub);
+    cjose_jwk_release(bob);
+    cjose_jwk_release(bob_pub);
+    cjose_get_dealloc()(z);
+}
+
+START_TEST(test_cjose_jwk_derive_ecdh_bits_okp)
+{
+    cjose_err err;
+
+    _ecdh_rfc8037(CJOSE_JWK_OKP_X25519, RFC8037_X25519_BOB_D, RFC8037_X25519_BOB_X, RFC8037_X25519_EPH_D, RFC8037_X25519_EPH_X,
+                  RFC8037_X25519_Z);
+    _ecdh_rfc8037(CJOSE_JWK_OKP_X448, RFC8037_X448_BOB_D, RFC8037_X448_BOB_X, RFC8037_X448_EPH_D, RFC8037_X448_EPH_X,
+                  RFC8037_X448_Z);
+
+    // keys of different types or curves, and the signature curves, do not agree
+    cjose_jwk_t *ec = cjose_jwk_create_EC_random(CJOSE_JWK_EC_P_256, &err);
+    cjose_jwk_t *x25519 = cjose_jwk_create_OKP_random(CJOSE_JWK_OKP_X25519, &err);
+    cjose_jwk_t *x25519_peer = cjose_jwk_create_OKP_random(CJOSE_JWK_OKP_X25519, &err);
+    cjose_jwk_t *x448 = cjose_jwk_create_OKP_random(CJOSE_JWK_OKP_X448, &err);
+    cjose_jwk_t *ed = cjose_jwk_create_OKP_random(CJOSE_JWK_OKP_ED25519, &err);
+    ck_assert(NULL != ec && NULL != x25519 && NULL != x25519_peer && NULL != x448 && NULL != ed);
+    const cjose_jwk_t *pairs[][2] = { { ec, x25519 }, { x25519, ec }, { x25519, x448 }, { ed, ed }, { x25519, ed } };
+    for (size_t i = 0; i < sizeof(pairs) / sizeof(pairs[0]); i++)
+    {
+        uint8_t *out = NULL;
+        size_t out_len = 0;
+        ck_assert_msg(!cjose_jwk_derive_ecdh_bits(pairs[i][0], pairs[i][1], &out, &out_len, &err),
+                      "cjose_jwk_derive_ecdh_bits succeeded for mismatched keys (%zu)", i);
+        ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    }
+    uint8_t *out = NULL;
+    size_t out_len = 0;
+    ck_assert(cjose_jwk_derive_ecdh_bits(x25519, x25519_peer, &out, &out_len, &err));
+    ck_assert_int_eq(32, out_len);
+    _cjose_cleanse_dealloc(out, out_len);
+
+    cjose_jwk_release(ec);
+    cjose_jwk_release(x25519);
+    cjose_jwk_release(x25519_peer);
+    cjose_jwk_release(x448);
+    cjose_jwk_release(ed);
+}
+END_TEST
+
 Suite *cjose_jwk_suite(void)
 {
     Suite *suite = suite_create("jwk");
@@ -2024,6 +2137,7 @@ Suite *cjose_jwk_suite(void)
     tcase_add_test(tc_jwk, test_cjose_jwk_create_RSA_random);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_RSA_random_weak_keysize);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_RSA_spec_weak_modulus);
+    tcase_add_test(tc_jwk, test_cjose_jwk_derive_ecdh_bits_okp);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_P256_spec);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_rejects_out_of_range_private);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_P256_random);


### PR DESCRIPTION
## Summary

Adds the X25519 and X448 curves of RFC 8037 section 3.2 to the ECDH-ES key agreement: `ECDH-ES`, `ECDH-ES+A128KW`, `ECDH-ES+A192KW` and `ECDH-ES+A256KW` now accept OKP keys on those curves next to EC keys. cjose has had the OKP key type with X25519 and X448 since #169 but could only sign with OKP keys; this uses them for what RFC 8037 registered them for.

- **What changes.** The ephemeral key is generated with the type and curve of the recipient's key and published as an OKP JWK in `epk`; the Concat KDF, `apu`, `apv` and the key sizes are exactly those of RFC 7518, so the four ECDH-ES paths only swap their EC-only calls for two shared helpers, one that makes the ephemeral key and one that checks that the recipient key and `epk` are of the same type on the same curve. The key agreement in jwk.c performs that check itself as well, so the public `cjose_jwk_derive_ecdh_ephemeral_key` gains the two curves and refuses mismatched keys with `CJOSE_ERR_INVALID_ARG`. The Ed25519 and Ed448 signature keys are refused for key agreement everywhere. OpenSSL's exchange already rejects a small-order peer key (the all-zero shared secret of RFC 7748 section 6.1), so no extra check is needed there.
- **No new identifiers.** The ECDH-ES identifiers stay the polymorphic ones RFC 7518 defines and RFC 9864 section 6.2 explicitly leaves in place; the curve is pinned by the recipient's own key and an `epk` on any other curve is rejected before the key agreement runs.
- **Docs.** README rows for the ECDH-ES algorithms and the `jwk.h` comments of the derive functions, which said "EC key pair".
- **Tests.** In the `jwk` suite, the RFC 8037 Appendix A.6 and A.7 examples: the ephemeral key pair and Bob's public key are the RFC's, Bob's private keys come from RFC 7748 section 6 (the examples use its public keys), and the shared secret Z is checked in both directions; plus mismatched-key cases. In the `jwe` suite, round trips over both curves and all four algorithms with GCM and CBC content encryption, a check that `epk` is a public OKP key on the recipient's curve, python-jwcrypto vectors for both curves, and negative cases: an Ed25519 key offered for ECDH-ES on encrypt and on decrypt, decrypting an X25519 JWE with an X448 or EC key, and an `epk` of another type or curve or of the wrong size.

Independent of #184 and #185; whichever lands later needs at most a trivial rebase around adjacent README rows, which I will do.

## Testing

- `-pedantic -Wall -Werror` build and the full `check_cjose` run (122 checks) with `CJOSE_ENABLE_RSA1_5` OFF and ON against OpenSSL 3.5.5.
- valgrind on the `jwk` and `jwe` suites: no leaks, no errors.
- The `clang-format` target produces no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
