### PR TITLE
Version the shared library by its ABI: SONAME libcjose.so.1, symbol version CJOSE_1.0, Debian package libcjose1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release Notes #
 
+<a name="1.0.0"></a>
+## 1.0.0 (unreleased)
+
+### Breaking
+
+* The shared library has ABI version 1: it installs as libcjose.so.1 with SONAME libcjose.so.1, its exported symbols carry the CJOSE_1.0 symbol version, and the Debian package is named libcjose1. Programs built against libcjose.so.0 must be rebuilt
+* cjose_jwk_get_keydata returns implementation-specific data that must be treated as opaque for RSA, EC and OKP keys; it no longer hands out OpenSSL RSA and EC_KEY objects (#181)
+* OpenSSL 3.0.0 or newer is required and only non-deprecated OpenSSL APIs are used (#179, #180, #181)
+* The autoconf build is removed; CMake 3.22 or newer is the only build system (#178)
+* The library and the tests are built as strict C17 (#182); the tests need Check 0.12.0 or newer (#176)
+
 <a name="0.8.0"></a>
 ## [0.8.0](https://github.com/cisco/cjose/0.7.0..0.8.0)  (2026-09-12)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.22)
 
 project(cjose
-    VERSION 0.8.0
+    VERSION 1.0.0
     DESCRIPTION "JOSE implementation for C"
     HOMEPAGE_URL "https://github.com/cisco/cjose"
     LANGUAGES C)

--- a/cmake/exports/libcjose.version
+++ b/cmake/exports/libcjose.version
@@ -1,9 +1,12 @@
 # GNU ld / gold version script for the CJOSE shared library.
 # Only the public API symbols are made global; every other symbol
 # (internal helpers, third-party statics, etc.) is kept local/hidden.
-# An anonymous version node is used so the exported symbols remain
-# unversioned.
-{
+# The exported symbols carry the CJOSE_1.0 symbol version, the first
+# release of the library whose SONAME is libcjose.so.1. Symbols added by
+# a later release go into a node of their own that inherits from this
+# one, e.g. `CJOSE_1.1 { global: cjose_new_function; } CJOSE_1.0;`, so
+# that a binary records the release it needs.
+CJOSE_1.0 {
     global:
         CJOSE_HDR_ALG;
         CJOSE_HDR_ALG_A128KW;

--- a/platform/debian/debian/control
+++ b/platform/debian/debian/control
@@ -5,7 +5,7 @@ Standards-Version: 3.9.4
 Section: utils
 Priority: extra
 
-Package: libcjose0
+Package: libcjose1
 Architecture: any
 Pre-depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
@@ -16,6 +16,6 @@ Description: C library implementing the Javascript Object Signing and Encryption
 Package: libcjose-dev
 Section: libdevel
 Architecture: any
-Depends: libcjose0 (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Depends: libcjose1 (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Description: Development files for libcjose
  Development files for building software using libcjose

--- a/platform/debian/debian/files
+++ b/platform/debian/debian/files
@@ -1,2 +1,0 @@
-libcjose0_0.4.1-1_amd64.deb utils extra
-libcjose-dev_0.4.1-1_amd64.deb libdevel extra

--- a/platform/debian/debian/libcjose-dev.install
+++ b/platform/debian/debian/libcjose-dev.install
@@ -1,2 +1,5 @@
-usr/lib/libcjose.a
-usr/lib/pkgconfig/cjose.pc
+usr/include/cjose/*.h
+usr/lib/*/libcjose.so
+usr/lib/*/libcjose.a
+usr/lib/*/pkgconfig/cjose.pc
+usr/lib/*/cmake/cjose/*

--- a/platform/debian/debian/libcjose0.install
+++ b/platform/debian/debian/libcjose0.install
@@ -1,1 +1,0 @@
-usr/lib/libcjose.so*

--- a/platform/debian/debian/libcjose1.install
+++ b/platform/debian/debian/libcjose1.install
@@ -1,0 +1,1 @@
+usr/lib/*/libcjose.so.*


### PR DESCRIPTION
## Summary

Makes the ABI break of the 1.0.x cycle visible where linkers and package managers look for it.

- **SONAME and release number.** Every 0.x release shipped as `libcjose.so.0`, both under libtool, which never got a `-version-info`, and under CMake. Since #181 `cjose_jwk_get_keydata()` no longer hands out OpenSSL `RSA` and `EC_KEY` objects, which is a run-time ABI break the symbol set does not show, so this line is ABI 1 and the library must install as `libcjose.so.1`. `project(cjose VERSION ...)` is bumped to 1.0.0, which is what the existing `SOVERSION ${PROJECT_VERSION_MAJOR}` needs to produce that; the library, its symbol version and its package name then all say 1. Everything else in the tree derives the version from `PROJECT_VERSION`, so that one line is the whole change: `libcjose.so.1.0.0`, `CJOSE_VERSION "1.0.0"`, `cjose.pc` 1.0.0.
- **Symbol versioning.** The ELF version script versions the exported symbols with a `CJOSE_1.0` node instead of the anonymous node that left them unversioned. A binary linked against the library then records `libcjose.so.1` and `CJOSE_1.0` as its needs, and symbols added by a later release can go into a node of their own that inherits from it; the script's comment shows how. The Apple symbols list and the Windows def file are unchanged.
- **Debian package.** The runtime package is renamed to `libcjose1` (`control`, `libcjose1.install`). While validating that with a real `dpkg-buildpackage` run I found the packaging did not build at all since the CMake migration: the install globs still said `usr/lib/`, while CMake installs into the multiarch directory, and `libcjose-dev` listed no headers. The globs now use `usr/lib/*/`, the runtime package carries only the versioned library, the dev package the headers, the `libcjose.so` link, the static library, the pkg-config file and the CMake package. The stale generated `debian/files` of 0.4.1, which still named `libcjose0`, is dropped.
- **CHANGELOG.** A 1.0.0 section, marked unreleased since there is no tag yet, lists the breaking changes of this cycle, for you to reword or fold into the release entry: ABI 1, the opaque key data, OpenSSL 3.0.0 and no deprecated APIs, the autoconf removal, strict C17 and Check 0.12.0.

Nothing changes for the static library, the tests or the public headers.

## Testing

- `readelf -d` on the built library shows `SONAME libcjose.so.1`, the real file is `libcjose.so.1.0.0`, and all 97 exported symbols carry `@@CJOSE_1.0` in `nm -D`.
- `-pedantic -Wall -Werror` build and the full `check_cjose` run against OpenSSL 3.5.5, the `version` suite included; the `clang-format` target produces no diff.
- `dpkg-buildpackage -us -uc -b` on the tree with `platform/debian/debian` as `debian/` produces `libcjose1` containing `usr/lib/x86_64-linux-gnu/libcjose.so.1.0.0` and the `libcjose.so.1` link, with a `libcjose 1 libcjose1` shlibs entry, and `libcjose-dev` with the headers, `libcjose.so`, `libcjose.a`, `cjose.pc` and the CMake package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
