### PR TITLE
Refuse a "crit" header and enforce the disjointness of the JWE header locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ JWE key management algorithms (`alg`):
 | `RSA-OAEP-256` | RSAES OAEP with SHA-256 and MGF1 with SHA-256 | |
 | `RSA1_5` | RSAES-PKCS1-v1_5 | build option `CJOSE_ENABLE_RSA1_5` |
 | `A128KW`, `A192KW`, `A256KW` | AES Key Wrap | |
+| `A128GCMKW`, `A192GCMKW`, `A256GCMKW` | AES GCM key wrapping | |
 | `dir` | direct use of a shared symmetric key | |
 | `ECDH-ES` | ECDH-ES direct key agreement | |
 | `ECDH-ES+A128KW`, `ECDH-ES+A192KW`, `ECDH-ES+A256KW` | ECDH-ES with AES Key Wrap | |

--- a/include/cjose/header.h
+++ b/include/cjose/header.h
@@ -42,6 +42,10 @@ extern "C" {
 #define CJOSE_HDR_APU "apu"
 #define CJOSE_HDR_APV "apv"
 
+/** For the AES GCM key wrapping algorithms, the initialization vector and the authentication tag of the encrypted key. */
+#define CJOSE_HDR_IV "iv"
+#define CJOSE_HDR_TAG "tag"
+
 /** The JWA algorithm attribute value for none. */
 #define CJOSE_HDR_ALG_NONE "none"
 
@@ -61,6 +65,11 @@ extern "C" {
 #define CJOSE_HDR_ALG_A128KW "A128KW"
 #define CJOSE_HDR_ALG_A192KW "A192KW"
 #define CJOSE_HDR_ALG_A256KW "A256KW"
+
+/** The JWE algorithm attribute value for A128GCMKW, A192GCMKW and A256GCMKW (AES GCM key wrapping, RFC 7518 section 4.7). */
+#define CJOSE_HDR_ALG_A128GCMKW "A128GCMKW"
+#define CJOSE_HDR_ALG_A192GCMKW "A192GCMKW"
+#define CJOSE_HDR_ALG_A256GCMKW "A256GCMKW"
 
 /** The JWE algorithm attribute value for ECDH-ES with A128KW, A192KW or A256KW key wrapping. */
 #define CJOSE_HDR_ALG_ECDH_ES_A128KW "ECDH-ES+A128KW"

--- a/src/header.c
+++ b/src/header.c
@@ -14,14 +14,31 @@
 static const char *CJOSE_HDR_CRIT = "crit";
 
 ////////////////////////////////////////////////////////////////////////////////
-bool _cjose_header_validate_crit(cjose_header_t *header, const char *const *supported, size_t supported_len, cjose_err *err)
+bool _cjose_header_validate_crit(
+    cjose_header_t *const *headers, size_t headers_len, const char *const *supported, size_t supported_len, cjose_err *err)
 {
-    if (NULL == header)
+    if (NULL == headers || 0 == headers_len)
     {
         return true;
     }
 
-    json_t *crit = json_object_get((json_t *)header, CJOSE_HDR_CRIT);
+    // the list has to be integrity protected, so it may only appear in the
+    // protected header (RFC 7515 section 4.1.11)
+    for (size_t i = 1; i < headers_len; i++)
+    {
+        if (NULL != headers[i] && NULL != json_object_get((json_t *)headers[i], CJOSE_HDR_CRIT))
+        {
+            CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+            return false;
+        }
+    }
+
+    if (NULL == headers[0])
+    {
+        return true;
+    }
+
+    json_t *crit = json_object_get((json_t *)headers[0], CJOSE_HDR_CRIT);
     if (NULL == crit)
     {
         return true;
@@ -65,6 +82,90 @@ bool _cjose_header_validate_crit(cjose_header_t *header, const char *const *supp
         {
             CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
             return false;
+        }
+
+        // RFC 7515 section 4.1.11: the list must not carry duplicate names
+        for (size_t i = 0; i < index; i++)
+        {
+            if (0 == strcmp(name, json_string_value(json_array_get(crit, i))))
+            {
+                CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+bool _cjose_header_validate_crit_present(cjose_header_t *const *headers, size_t headers_len, cjose_err *err)
+{
+    if (NULL == headers || 0 == headers_len || NULL == headers[0])
+    {
+        return true;
+    }
+
+    json_t *crit = json_object_get((json_t *)headers[0], CJOSE_HDR_CRIT);
+    if (!json_is_array(crit))
+    {
+        return true;
+    }
+
+    size_t index = 0;
+    json_t *entry = NULL;
+    json_array_foreach(crit, index, entry)
+    {
+        if (!json_is_string(entry))
+        {
+            CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+            return false;
+        }
+
+        const char *name = json_string_value(entry);
+        bool found = false;
+        for (size_t i = 0; i < headers_len && !found; i++)
+        {
+            found = (NULL != headers[i]) && (NULL != json_object_get((json_t *)headers[i], name));
+        }
+
+        if (!found)
+        {
+            CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+bool _cjose_header_validate_disjoint(cjose_header_t *const *headers, size_t headers_len, cjose_err *err)
+{
+    if (NULL == headers)
+    {
+        return true;
+    }
+
+    for (size_t i = 0; i < headers_len; i++)
+    {
+        if (NULL == headers[i])
+        {
+            continue;
+        }
+
+        const char *name = NULL;
+        json_t *value = NULL;
+        json_object_foreach((json_t *)headers[i], name, value)
+        {
+            for (size_t j = i + 1; j < headers_len; j++)
+            {
+                if (NULL != headers[j] && NULL != json_object_get((json_t *)headers[j], name))
+                {
+                    CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+                    return false;
+                }
+            }
         }
     }
 

--- a/src/header.c
+++ b/src/header.c
@@ -14,122 +14,22 @@
 static const char *CJOSE_HDR_CRIT = "crit";
 
 ////////////////////////////////////////////////////////////////////////////////
-bool _cjose_header_validate_crit(
-    cjose_header_t *const *headers, size_t headers_len, const char *const *supported, size_t supported_len, cjose_err *err)
+bool _cjose_header_validate_crit(cjose_header_t *const *headers, size_t headers_len, cjose_err *err)
 {
-    if (NULL == headers || 0 == headers_len)
+    if (NULL == headers)
     {
         return true;
     }
 
-    // the list has to be integrity protected, so it may only appear in the
-    // protected header (RFC 7515 section 4.1.11)
-    for (size_t i = 1; i < headers_len; i++)
+    // RFC 7515 section 4.1.11: the "crit" list names extensions to the JOSE
+    // specifications that a recipient has to understand and process, and a
+    // producer must not list a name the specifications or JWA define. cjose
+    // implements no extension, so every name a list can carry is either one
+    // it must reject as unsupported or one the producer was not allowed to
+    // put there: a header that carries the list at all is refused.
+    for (size_t i = 0; i < headers_len; i++)
     {
         if (NULL != headers[i] && NULL != json_object_get((json_t *)headers[i], CJOSE_HDR_CRIT))
-        {
-            CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-            return false;
-        }
-    }
-
-    if (NULL == headers[0])
-    {
-        return true;
-    }
-
-    json_t *crit = json_object_get((json_t *)headers[0], CJOSE_HDR_CRIT);
-    if (NULL == crit)
-    {
-        return true;
-    }
-
-    if (!json_is_array(crit))
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-        return false;
-    }
-
-    // RFC 7515 section 4.1.11: if present, the "crit" list MUST NOT be empty
-    if (0 == json_array_size(crit))
-    {
-        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-        return false;
-    }
-
-    size_t index = 0;
-    json_t *entry = NULL;
-    json_array_foreach(crit, index, entry)
-    {
-        if (!json_is_string(entry))
-        {
-            CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-            return false;
-        }
-
-        const char *name = json_string_value(entry);
-        bool found = false;
-        for (size_t i = 0; i < supported_len; i++)
-        {
-            if (0 == strcmp(name, supported[i]))
-            {
-                found = true;
-                break;
-            }
-        }
-
-        if (!found)
-        {
-            CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-            return false;
-        }
-
-        // RFC 7515 section 4.1.11: the list must not carry duplicate names
-        for (size_t i = 0; i < index; i++)
-        {
-            if (0 == strcmp(name, json_string_value(json_array_get(crit, i))))
-            {
-                CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-                return false;
-            }
-        }
-    }
-
-    return true;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-bool _cjose_header_validate_crit_present(cjose_header_t *const *headers, size_t headers_len, cjose_err *err)
-{
-    if (NULL == headers || 0 == headers_len || NULL == headers[0])
-    {
-        return true;
-    }
-
-    json_t *crit = json_object_get((json_t *)headers[0], CJOSE_HDR_CRIT);
-    if (!json_is_array(crit))
-    {
-        return true;
-    }
-
-    size_t index = 0;
-    json_t *entry = NULL;
-    json_array_foreach(crit, index, entry)
-    {
-        if (!json_is_string(entry))
-        {
-            CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
-            return false;
-        }
-
-        const char *name = json_string_value(entry);
-        bool found = false;
-        for (size_t i = 0; i < headers_len && !found; i++)
-        {
-            found = (NULL != headers[i]) && (NULL != json_object_get((json_t *)headers[i], name));
-        }
-
-        if (!found)
         {
             CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
             return false;

--- a/src/include/header_int.h
+++ b/src/include/header_int.h
@@ -12,18 +12,11 @@
 
 #include "cjose/header.h"
 
-// RFC 7515 section 4.1.11 and RFC 7516 section 4.1.13: validate the "crit" list
-// of a JOSE header. headers[0] is the protected header, which is the only one
-// that may carry the list, and headers[] together make up the JOSE header the
-// listed names have to occur in; entries other than the first may be NULL.
-bool _cjose_header_validate_crit(
-    cjose_header_t *const *headers, size_t headers_len, const char *const *supported, size_t supported_len, cjose_err *err);
-
-// RFC 7515 section 4.1.11: every name in the "crit" list of headers[0] must
-// occur as a header parameter name within the JOSE header. Only for a header
-// that is complete: when producing, the algorithm still adds parameters of its
-// own after the rest of the list has been validated.
-bool _cjose_header_validate_crit_present(cjose_header_t *const *headers, size_t headers_len, cjose_err *err);
+// RFC 7515 section 4.1.11 and RFC 7516 section 4.1.13: a "crit" list names
+// extensions that have to be understood and processed. cjose implements none,
+// and a producer may not list a name the specifications define, so a header
+// that carries the list is refused. Entries may be NULL.
+bool _cjose_header_validate_crit(cjose_header_t *const *headers, size_t headers_len, cjose_err *err);
 
 // RFC 7516 section 7.2.1: the member names of the JWE protected header, the JWE
 // shared unprotected header and a JWE per-recipient unprotected header must be

--- a/src/include/header_int.h
+++ b/src/include/header_int.h
@@ -12,6 +12,22 @@
 
 #include "cjose/header.h"
 
-bool _cjose_header_validate_crit(cjose_header_t *header, const char *const *supported, size_t supported_len, cjose_err *err);
+// RFC 7515 section 4.1.11 and RFC 7516 section 4.1.13: validate the "crit" list
+// of a JOSE header. headers[0] is the protected header, which is the only one
+// that may carry the list, and headers[] together make up the JOSE header the
+// listed names have to occur in; entries other than the first may be NULL.
+bool _cjose_header_validate_crit(
+    cjose_header_t *const *headers, size_t headers_len, const char *const *supported, size_t supported_len, cjose_err *err);
+
+// RFC 7515 section 4.1.11: every name in the "crit" list of headers[0] must
+// occur as a header parameter name within the JOSE header. Only for a header
+// that is complete: when producing, the algorithm still adds parameters of its
+// own after the rest of the list has been validated.
+bool _cjose_header_validate_crit_present(cjose_header_t *const *headers, size_t headers_len, cjose_err *err);
+
+// RFC 7516 section 7.2.1: the member names of the JWE protected header, the JWE
+// shared unprotected header and a JWE per-recipient unprotected header must be
+// disjoint. Entries may be NULL.
+bool _cjose_header_validate_disjoint(cjose_header_t *const *headers, size_t headers_len, cjose_err *err);
 
 #endif // SRC_HEADER_INT_H

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -441,19 +441,12 @@ static bool _cjose_jwe_validate_alg(cjose_header_t *protected_header,
                                     _jwe_int_recipient_t *recipient,
                                     cjose_err *err)
 {
-    // the parameters an algorithm family adds are only processed for that
-    // family, so they are understood as critical parameters there alone: "epk",
-    // "apu" and "apv" for ECDH-ES (RFC 7518 section 4.6), "iv" and "tag" for
-    // the AES GCM key wrapping algorithms (RFC 7518 section 4.7)
-    static const char *const supported_crit_headers[] = { "alg", "enc", "cty" };
-    static const char *const supported_crit_headers_ecdh_es[] = { "alg", "enc", "cty", "epk", "apu", "apv" };
-    static const char *const supported_crit_headers_aes_gcm_kw[] = { "alg", "enc", "cty", "iv", "tag" };
-
     cjose_header_t *headers[] = { protected_header, unprotected_header, (cjose_header_t *)recipient->unprotected };
     const size_t headers_len = sizeof(headers) / sizeof(headers[0]);
 
-    // RFC 7516 section 7.2.1: the three header locations must be disjoint
-    if (!_cjose_header_validate_disjoint(headers, headers_len, err))
+    // RFC 7516 section 7.2.1: the three header locations must be disjoint, and
+    // RFC 7515 section 4.1.11: none of them may carry a "crit" list
+    if (!_cjose_header_validate_disjoint(headers, headers_len, err) || !_cjose_header_validate_crit(headers, headers_len, err))
     {
         return false;
     }
@@ -467,24 +460,7 @@ static bool _cjose_jwe_validate_alg(cjose_header_t *protected_header,
         return false;
     }
 
-    const char *const *crit_headers = supported_crit_headers;
-    size_t crit_headers_len = sizeof(supported_crit_headers) / sizeof(supported_crit_headers[0]);
     const bool is_aes_gcm_kw = _cjose_jwe_alg_is_aes_gcm_kw(alg);
-    if (is_aes_gcm_kw)
-    {
-        crit_headers = supported_crit_headers_aes_gcm_kw;
-        crit_headers_len = sizeof(supported_crit_headers_aes_gcm_kw) / sizeof(supported_crit_headers_aes_gcm_kw[0]);
-    }
-    else if (_cjose_jwe_alg_is_ecdh_es(alg))
-    {
-        crit_headers = supported_crit_headers_ecdh_es;
-        crit_headers_len = sizeof(supported_crit_headers_ecdh_es) / sizeof(supported_crit_headers_ecdh_es[0]);
-    }
-
-    if (!_cjose_header_validate_crit(headers, headers_len, crit_headers, crit_headers_len, err))
-    {
-        return false;
-    }
 
     // set JWE build functions based on header contents
     if (strcmp(alg, CJOSE_HDR_ALG_RSA_OAEP) == 0)
@@ -2263,9 +2239,7 @@ static bool _cjose_jwe_validate_decrypt_key(_jwe_int_recipient_t *recipient,
         return false;
     }
 
-    if (((0 == strcmp(alg, CJOSE_HDR_ALG_ECDH_ES)) || (0 == strcmp(alg, CJOSE_HDR_ALG_ECDH_ES_A128KW))
-         || (0 == strcmp(alg, CJOSE_HDR_ALG_ECDH_ES_A192KW)) || (0 == strcmp(alg, CJOSE_HDR_ALG_ECDH_ES_A256KW)))
-        && jwk->kty != CJOSE_JWK_KTY_EC)
+    if (_cjose_jwe_alg_is_ecdh_es(alg) && jwk->kty != CJOSE_JWK_KTY_EC)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return false;
@@ -2376,18 +2350,14 @@ cjose_jwe_t *cjose_jwe_encrypt_multi_iv(const cjose_jwe_recipient_t *recipients,
     }
 
     // the algorithms have written the parameters they produce by now, so the
-    // assembled headers are validated once more: what leaves here has to be a
-    // JWE that can be imported again, with the names of its header locations
-    // disjoint (RFC 7516 section 7.2.1) and every critical parameter present
-    // in its JOSE header (RFC 7515 section 4.1.11)
+    // names of the assembled headers are checked once more: what leaves here
+    // has to be a JWE that can be imported again (RFC 7516 section 7.2.1)
     for (size_t i = 0; i < recipient_count; i++)
     {
         cjose_header_t *headers[]
             = { (cjose_header_t *)jwe->hdr, (cjose_header_t *)jwe->shared_hdr, (cjose_header_t *)jwe->to[i].unprotected };
-        const size_t headers_len = sizeof(headers) / sizeof(headers[0]);
 
-        if (!_cjose_header_validate_disjoint(headers, headers_len, err)
-            || !_cjose_header_validate_crit_present(headers, headers_len, err))
+        if (!_cjose_header_validate_disjoint(headers, sizeof(headers) / sizeof(headers[0]), err))
         {
             cjose_jwe_release(jwe);
             return NULL;
@@ -2731,10 +2701,7 @@ cjose_jwe_t *cjose_jwe_import(const char *cser, size_t cser_len, cjose_err *err)
     }
 
     // validate the JSON header. No unprotected headers can exist.
-    cjose_header_t *imported_headers[] = { (cjose_header_t *)jwe->hdr };
-
     if (!_cjose_jwe_validate_alg((cjose_header_t *)jwe->hdr, NULL, false, jwe->to, err)
-        || !_cjose_header_validate_crit_present(imported_headers, sizeof(imported_headers) / sizeof(imported_headers[0]), err)
         || !_cjose_jwe_validate_enc(jwe, (cjose_header_t *)jwe->hdr, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -2773,15 +2740,7 @@ static inline bool _cjose_read_json_recipient(cjose_jwe_t *jwe,
         return false;
     }
 
-    if (!_cjose_jwe_validate_alg(protected_header, jwe->shared_hdr, is_multiple, recipient, err))
-    {
-        return false;
-    }
-
-    // the JOSE header of an imported JWE is complete, so the names the "crit"
-    // list carries have to occur in it (RFC 7515 section 4.1.11)
-    cjose_header_t *headers[] = { protected_header, jwe->shared_hdr, (cjose_header_t *)recipient->unprotected };
-    return _cjose_header_validate_crit_present(headers, sizeof(headers) / sizeof(headers[0]), err);
+    return _cjose_jwe_validate_alg(protected_header, jwe->shared_hdr, is_multiple, recipient, err);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -911,6 +911,19 @@ _cjose_jwe_encrypt_ek_aes_gcm_kw(_jwe_int_recipient_t *recipient, cjose_jwe_t *j
         return false;
     }
 
+    // the "iv" and "tag" parameters are produced here: if the caller supplied
+    // either of them in one of its header objects, the parameter would end up
+    // in two of the three header locations, which RFC 7516 section 7.2.1 does
+    // not allow, and the wrong one could be picked up when decrypting
+    if (NULL != _cjose_jwe_get_json_from_headers(jwe->hdr, jwe->shared_hdr, (cjose_header_t *)recipient->unprotected, CJOSE_HDR_IV)
+        || NULL
+               != _cjose_jwe_get_json_from_headers(jwe->hdr, jwe->shared_hdr, (cjose_header_t *)recipient->unprotected,
+                                                   CJOSE_HDR_TAG))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
     // generate random CEK
     if (!jwe->fns.set_cek(jwe, NULL, true, err))
     {

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -370,6 +370,13 @@ static json_t *_cjose_jwe_recipient_param_target(cjose_jwe_t *jwe, _jwe_int_reci
     return copy;
 }
 
+static bool _cjose_jwe_alg_is_ecdh_es(const char *alg)
+{
+    return (NULL != alg)
+           && ((0 == strcmp(alg, CJOSE_HDR_ALG_ECDH_ES)) || (0 == strcmp(alg, CJOSE_HDR_ALG_ECDH_ES_A128KW))
+               || (0 == strcmp(alg, CJOSE_HDR_ALG_ECDH_ES_A192KW)) || (0 == strcmp(alg, CJOSE_HDR_ALG_ECDH_ES_A256KW)));
+}
+
 static bool _cjose_jwe_alg_is_aes_gcm_kw(const char *alg)
 {
     return (NULL != alg)
@@ -420,12 +427,22 @@ static bool _cjose_jwe_validate_alg(cjose_header_t *protected_header,
                                     _jwe_int_recipient_t *recipient,
                                     cjose_err *err)
 {
-    static const char *const supported_crit_headers[] = { "alg", "enc", "cty", "epk", "apu", "apv" };
+    // the parameters an algorithm family adds are only processed for that
+    // family, so they are understood as critical parameters there alone: "epk",
+    // "apu" and "apv" for ECDH-ES (RFC 7518 section 4.6), "iv" and "tag" for
+    // the AES GCM key wrapping algorithms (RFC 7518 section 4.7)
+    static const char *const supported_crit_headers[] = { "alg", "enc", "cty" };
+    static const char *const supported_crit_headers_ecdh_es[] = { "alg", "enc", "cty", "epk", "apu", "apv" };
+    static const char *const supported_crit_headers_aes_gcm_kw[] = { "alg", "enc", "cty", "iv", "tag" };
 
-    // RFC 7518 section 4.7 defines "iv" and "tag" for the AES GCM key wrapping
-    // algorithms alone, and they are only processed there, so they are accepted
-    // as critical parameters for those algorithms and refused for every other
-    static const char *const supported_crit_headers_aes_gcm_kw[] = { "alg", "enc", "cty", "epk", "apu", "apv", "iv", "tag" };
+    cjose_header_t *headers[] = { protected_header, unprotected_header, (cjose_header_t *)recipient->unprotected };
+    const size_t headers_len = sizeof(headers) / sizeof(headers[0]);
+
+    // RFC 7516 section 7.2.1: the three header locations must be disjoint
+    if (!_cjose_header_validate_disjoint(headers, headers_len, err))
+    {
+        return false;
+    }
 
     const char *alg = _cjose_jwe_get_from_headers(protected_header, unprotected_header, (cjose_header_t *)recipient->unprotected,
                                                   CJOSE_HDR_ALG);
@@ -436,15 +453,21 @@ static bool _cjose_jwe_validate_alg(cjose_header_t *protected_header,
         return false;
     }
 
+    const char *const *crit_headers = supported_crit_headers;
+    size_t crit_headers_len = sizeof(supported_crit_headers) / sizeof(supported_crit_headers[0]);
     const bool is_aes_gcm_kw = _cjose_jwe_alg_is_aes_gcm_kw(alg);
-    const char *const *crit_headers = is_aes_gcm_kw ? supported_crit_headers_aes_gcm_kw : supported_crit_headers;
-    const size_t crit_headers_len = is_aes_gcm_kw
-                                        ? sizeof(supported_crit_headers_aes_gcm_kw) / sizeof(supported_crit_headers_aes_gcm_kw[0])
-                                        : sizeof(supported_crit_headers) / sizeof(supported_crit_headers[0]);
+    if (is_aes_gcm_kw)
+    {
+        crit_headers = supported_crit_headers_aes_gcm_kw;
+        crit_headers_len = sizeof(supported_crit_headers_aes_gcm_kw) / sizeof(supported_crit_headers_aes_gcm_kw[0]);
+    }
+    else if (_cjose_jwe_alg_is_ecdh_es(alg))
+    {
+        crit_headers = supported_crit_headers_ecdh_es;
+        crit_headers_len = sizeof(supported_crit_headers_ecdh_es) / sizeof(supported_crit_headers_ecdh_es[0]);
+    }
 
-    if (!_cjose_header_validate_crit(protected_header, crit_headers, crit_headers_len, err)
-        || !_cjose_header_validate_crit(unprotected_header, crit_headers, crit_headers_len, err)
-        || !_cjose_header_validate_crit((cjose_header_t *)recipient->unprotected, crit_headers, crit_headers_len, err))
+    if (!_cjose_header_validate_crit(headers, headers_len, crit_headers, crit_headers_len, err))
     {
         return false;
     }
@@ -2305,7 +2328,7 @@ cjose_jwe_t *cjose_jwe_encrypt_multi_iv(const cjose_jwe_recipient_t *recipients,
         jwe->to[i].unprotected = json_incref(recipients[i].unprotected_header);
 
         // make sure we have an alg header
-        if (!_cjose_jwe_validate_alg(protected_header, jwe->to[i].unprotected, recipient_count > 1, jwe->to + i, err))
+        if (!_cjose_jwe_validate_alg(protected_header, shared_unprotected_header, recipient_count > 1, jwe->to + i, err))
         {
             cjose_jwe_release(jwe);
             return NULL;
@@ -2669,7 +2692,10 @@ cjose_jwe_t *cjose_jwe_import(const char *cser, size_t cser_len, cjose_err *err)
     }
 
     // validate the JSON header. No unprotected headers can exist.
+    cjose_header_t *imported_headers[] = { (cjose_header_t *)jwe->hdr };
+
     if (!_cjose_jwe_validate_alg((cjose_header_t *)jwe->hdr, NULL, false, jwe->to, err)
+        || !_cjose_header_validate_crit_present(imported_headers, sizeof(imported_headers) / sizeof(imported_headers[0]), err)
         || !_cjose_jwe_validate_enc(jwe, (cjose_header_t *)jwe->hdr, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -2708,7 +2734,15 @@ static inline bool _cjose_read_json_recipient(cjose_jwe_t *jwe,
         return false;
     }
 
-    return _cjose_jwe_validate_alg(protected_header, jwe->shared_hdr, is_multiple, recipient, err);
+    if (!_cjose_jwe_validate_alg(protected_header, jwe->shared_hdr, is_multiple, recipient, err))
+    {
+        return false;
+    }
+
+    // the JOSE header of an imported JWE is complete, so the names the "crit"
+    // list carries have to occur in it (RFC 7515 section 4.1.11)
+    cjose_header_t *headers[] = { protected_header, jwe->shared_hdr, (cjose_header_t *)recipient->unprotected };
+    return _cjose_header_validate_crit_present(headers, sizeof(headers) / sizeof(headers[0]), err);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -39,6 +39,12 @@ static bool _cjose_jwe_encrypt_ek_aes_kw(_jwe_int_recipient_t *recipient, cjose_
 static bool _cjose_jwe_decrypt_ek_aes_kw(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err);
 
 static bool
+_cjose_jwe_encrypt_ek_aes_gcm_kw(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err);
+
+static bool
+_cjose_jwe_decrypt_ek_aes_gcm_kw(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err);
+
+static bool
 _cjose_jwe_encrypt_ek_rsa_oaep(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err);
 
 static bool
@@ -318,6 +324,52 @@ static const char *_cjose_jwe_get_from_headers(cjose_header_t *protected_header,
     return NULL;
 }
 
+// like _cjose_jwe_get_from_headers, but returns the JSON value so that a
+// parameter can be checked for its expected type (borrowed reference)
+static json_t *_cjose_jwe_get_json_from_headers(cjose_header_t *protected_header,
+                                                cjose_header_t *unprotected_header,
+                                                cjose_header_t *personal_header,
+                                                const char *key)
+{
+    cjose_header_t *headers[] = { personal_header, unprotected_header, protected_header };
+    for (int i = 0; i < 3; i++)
+    {
+        if (NULL == headers[i])
+        {
+            continue;
+        }
+        json_t *obj = json_object_get((json_t *)headers[i], key);
+        if (NULL != obj)
+        {
+            return obj;
+        }
+    }
+    return NULL;
+}
+
+// the header object a per-recipient parameter (like the "iv" and "tag" of the
+// AES GCM key wrapping algorithms) is written to when encrypting: the protected
+// header for a single recipient, so that the compact serialization carries it,
+// and the recipient's own header otherwise. The caller's header objects are
+// never modified: the JWE holds a deep copy of the protected header already and
+// gets one of the recipient header here.
+static json_t *_cjose_jwe_recipient_param_target(cjose_jwe_t *jwe, _jwe_int_recipient_t *recipient, cjose_err *err)
+{
+    if (jwe->to_count < 2)
+    {
+        return jwe->hdr;
+    }
+    json_t *copy = (NULL == recipient->unprotected) ? json_object() : json_deep_copy(recipient->unprotected);
+    if (NULL == copy)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        return NULL;
+    }
+    json_decref(recipient->unprotected);
+    recipient->unprotected = copy;
+    return copy;
+}
+
 static bool _cjose_jwe_validate_enc(cjose_jwe_t *jwe, cjose_header_t *protected_header, cjose_err *err)
 {
 
@@ -361,7 +413,7 @@ static bool _cjose_jwe_validate_alg(cjose_header_t *protected_header,
                                     _jwe_int_recipient_t *recipient,
                                     cjose_err *err)
 {
-    static const char *const supported_crit_headers[] = { "alg", "enc", "cty", "epk", "apu", "apv" };
+    static const char *const supported_crit_headers[] = { "alg", "enc", "cty", "epk", "apu", "apv", "iv", "tag" };
 
     if (!_cjose_header_validate_crit(protected_header, supported_crit_headers,
                                      sizeof(supported_crit_headers) / sizeof(supported_crit_headers[0]), err)
@@ -455,6 +507,13 @@ static bool _cjose_jwe_validate_alg(cjose_header_t *protected_header,
     {
         recipient->fns.encrypt_ek = _cjose_jwe_encrypt_ek_aes_kw;
         recipient->fns.decrypt_ek = _cjose_jwe_decrypt_ek_aes_kw;
+    }
+
+    if ((strcmp(alg, CJOSE_HDR_ALG_A128GCMKW) == 0) || (strcmp(alg, CJOSE_HDR_ALG_A192GCMKW) == 0)
+        || (strcmp(alg, CJOSE_HDR_ALG_A256GCMKW) == 0))
+    {
+        recipient->fns.encrypt_ek = _cjose_jwe_encrypt_ek_aes_gcm_kw;
+        recipient->fns.decrypt_ek = _cjose_jwe_decrypt_ek_aes_gcm_kw;
     }
 
     // ensure required builders have been assigned
@@ -751,6 +810,226 @@ static bool _cjose_jwe_decrypt_ek_aes_kw(_jwe_int_recipient_t *recipient, cjose_
         return false;
     }
     return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// AES GCM key wrapping (RFC 7518 section 4.7): the CEK is encrypted with AES GCM
+// under a key encryption key of the size the "alg" names, with a random 96-bit
+// IV and no additional authenticated data; the IV and the 128-bit tag travel as
+// the "iv" and "tag" header parameters of the recipient
+#define CJOSE_JWE_AES_GCM_KW_IV_LEN 12
+#define CJOSE_JWE_AES_GCM_KW_TAG_LEN 16
+
+static size_t _cjose_jwe_aes_gcm_kw_keylen(const char *alg)
+{
+    if (NULL == alg)
+    {
+        return 0;
+    }
+    if (0 == strcmp(alg, CJOSE_HDR_ALG_A128GCMKW))
+    {
+        return 16;
+    }
+    if (0 == strcmp(alg, CJOSE_HDR_ALG_A192GCMKW))
+    {
+        return 24;
+    }
+    if (0 == strcmp(alg, CJOSE_HDR_ALG_A256GCMKW))
+    {
+        return 32;
+    }
+    return 0;
+}
+
+static const EVP_CIPHER *_cjose_jwe_aes_gcm_cipher(size_t key_len)
+{
+    switch (key_len)
+    {
+    case 16:
+        return EVP_aes_128_gcm();
+    case 24:
+        return EVP_aes_192_gcm();
+    case 32:
+        return EVP_aes_256_gcm();
+    default:
+        return NULL;
+    }
+}
+
+// the key encryption key of the AES GCM key wrapping algorithms is a symmetric
+// key of exactly the size the "alg" names
+static size_t
+_cjose_jwe_aes_gcm_kw_kek_len(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err)
+{
+    const char *alg
+        = _cjose_jwe_get_from_headers(jwe->hdr, jwe->shared_hdr, (cjose_header_t *)recipient->unprotected, CJOSE_HDR_ALG);
+    const size_t kek_len = _cjose_jwe_aes_gcm_kw_keylen(alg);
+    if (0 == kek_len || CJOSE_JWK_KTY_OCT != jwk->kty || NULL == jwk->keydata || jwk->keysize != kek_len * 8)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return 0;
+    }
+    return kek_len;
+}
+
+static bool
+_cjose_jwe_encrypt_ek_aes_gcm_kw(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err)
+{
+    EVP_CIPHER_CTX *ctx = NULL;
+    uint8_t iv[CJOSE_JWE_AES_GCM_KW_IV_LEN];
+    uint8_t tag[CJOSE_JWE_AES_GCM_KW_TAG_LEN];
+    char *iv_b64u = NULL;
+    char *tag_b64u = NULL;
+    size_t b64u_len = 0;
+    int len = 0;
+    int final_len = 0;
+    bool result = false;
+
+    if (NULL == jwe || NULL == jwk)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
+    const size_t kek_len = _cjose_jwe_aes_gcm_kw_kek_len(recipient, jwe, jwk, err);
+    if (0 == kek_len)
+    {
+        return false;
+    }
+
+    // generate random CEK
+    if (!jwe->fns.set_cek(jwe, NULL, true, err))
+    {
+        return false;
+    }
+
+    if (RAND_bytes(iv, sizeof(iv)) != 1)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        return false;
+    }
+
+    // AES GCM does not expand its input: the encrypted key is as long as the CEK
+    cjose_get_dealloc()(recipient->enc_key.raw);
+    recipient->enc_key.raw = NULL;
+    recipient->enc_key.raw_len = 0;
+    if (!_cjose_jwe_malloc(jwe->cek_len, false, &recipient->enc_key.raw, err))
+    {
+        return false;
+    }
+    recipient->enc_key.raw_len = jwe->cek_len;
+
+    ctx = EVP_CIPHER_CTX_new();
+    if (NULL == ctx || EVP_EncryptInit_ex(ctx, _cjose_jwe_aes_gcm_cipher(kek_len), NULL, jwk->keydata, iv) != 1
+        || EVP_EncryptUpdate(ctx, recipient->enc_key.raw, &len, jwe->cek, jwe->cek_len) != 1 || (size_t)len != jwe->cek_len
+        || EVP_EncryptFinal_ex(ctx, NULL, &final_len) != 1 || 0 != final_len
+        || EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, sizeof(tag), tag) != 1)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto cjose_encrypt_ek_aes_gcm_kw_finish;
+    }
+
+    // publish the IV and the tag with the recipient
+    json_t *target = _cjose_jwe_recipient_param_target(jwe, recipient, err);
+    if (NULL == target || !cjose_base64url_encode(iv, sizeof(iv), &iv_b64u, &b64u_len, err)
+        || !cjose_header_set((cjose_header_t *)target, CJOSE_HDR_IV, iv_b64u, err)
+        || !cjose_base64url_encode(tag, sizeof(tag), &tag_b64u, &b64u_len, err)
+        || !cjose_header_set((cjose_header_t *)target, CJOSE_HDR_TAG, tag_b64u, err))
+    {
+        goto cjose_encrypt_ek_aes_gcm_kw_finish;
+    }
+
+    result = true;
+
+cjose_encrypt_ek_aes_gcm_kw_finish:
+
+    EVP_CIPHER_CTX_free(ctx);
+    cjose_get_dealloc()(iv_b64u);
+    cjose_get_dealloc()(tag_b64u);
+
+    return result;
+}
+
+static bool
+_cjose_jwe_decrypt_ek_aes_gcm_kw(_jwe_int_recipient_t *recipient, cjose_jwe_t *jwe, const cjose_jwk_t *jwk, cjose_err *err)
+{
+    EVP_CIPHER_CTX *ctx = NULL;
+    uint8_t *iv = NULL;
+    size_t iv_len = 0;
+    uint8_t *tag = NULL;
+    size_t tag_len = 0;
+    int len = 0;
+    int final_len = 0;
+    bool result = false;
+
+    if (NULL == jwe || NULL == jwk)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
+    const size_t kek_len = _cjose_jwe_aes_gcm_kw_kek_len(recipient, jwe, jwk, err);
+    if (0 == kek_len)
+    {
+        return false;
+    }
+
+    // the "iv" and "tag" parameters must be present with the recipient and
+    // have their fixed sizes: check that before touching the encrypted key
+    json_t *iv_obj
+        = _cjose_jwe_get_json_from_headers(jwe->hdr, jwe->shared_hdr, (cjose_header_t *)recipient->unprotected, CJOSE_HDR_IV);
+    json_t *tag_obj
+        = _cjose_jwe_get_json_from_headers(jwe->hdr, jwe->shared_hdr, (cjose_header_t *)recipient->unprotected, CJOSE_HDR_TAG);
+    if (!json_is_string(iv_obj) || !json_is_string(tag_obj))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+    if (!cjose_base64url_decode(json_string_value(iv_obj), strlen(json_string_value(iv_obj)), &iv, &iv_len, err)
+        || !cjose_base64url_decode(json_string_value(tag_obj), strlen(json_string_value(tag_obj)), &tag, &tag_len, err))
+    {
+        goto cjose_decrypt_ek_aes_gcm_kw_finish;
+    }
+    if (CJOSE_JWE_AES_GCM_KW_IV_LEN != iv_len || CJOSE_JWE_AES_GCM_KW_TAG_LEN != tag_len)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        goto cjose_decrypt_ek_aes_gcm_kw_finish;
+    }
+
+    // the CEK buffer has the size the enc header dictates and the encrypted
+    // key must be exactly that long, so an attacker-controlled encrypted key
+    // can never be written past it
+    if (!jwe->fns.set_cek(jwe, NULL, false, err))
+    {
+        goto cjose_decrypt_ek_aes_gcm_kw_finish;
+    }
+    if (recipient->enc_key.raw_len != jwe->cek_len)
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        goto cjose_decrypt_ek_aes_gcm_kw_finish;
+    }
+
+    ctx = EVP_CIPHER_CTX_new();
+    if (NULL == ctx || EVP_DecryptInit_ex(ctx, _cjose_jwe_aes_gcm_cipher(kek_len), NULL, jwk->keydata, iv) != 1
+        || EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG, (int)tag_len, tag) != 1
+        || EVP_DecryptUpdate(ctx, jwe->cek, &len, recipient->enc_key.raw, recipient->enc_key.raw_len) != 1
+        || (size_t)len != jwe->cek_len || EVP_DecryptFinal_ex(ctx, NULL, &final_len) != 1)
+    {
+        // the tag did not verify: do not leave the unauthenticated output behind
+        _cjose_release_cek(&jwe->cek, jwe->cek_len);
+        CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
+        goto cjose_decrypt_ek_aes_gcm_kw_finish;
+    }
+
+    result = true;
+
+cjose_decrypt_ek_aes_gcm_kw_finish:
+
+    EVP_CIPHER_CTX_free(ctx);
+    cjose_get_dealloc()(iv);
+    cjose_get_dealloc()(tag);
+
+    return result;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1907,7 +2186,9 @@ static bool _cjose_jwe_validate_decrypt_key(_jwe_int_recipient_t *recipient,
     }
 
     if (((0 == strcmp(alg, CJOSE_HDR_ALG_A128KW)) || (0 == strcmp(alg, CJOSE_HDR_ALG_A192KW))
-         || (0 == strcmp(alg, CJOSE_HDR_ALG_A256KW)) || (0 == strcmp(alg, CJOSE_HDR_ALG_DIR)))
+         || (0 == strcmp(alg, CJOSE_HDR_ALG_A256KW)) || (0 == strcmp(alg, CJOSE_HDR_ALG_A128GCMKW))
+         || (0 == strcmp(alg, CJOSE_HDR_ALG_A192GCMKW)) || (0 == strcmp(alg, CJOSE_HDR_ALG_A256GCMKW))
+         || (0 == strcmp(alg, CJOSE_HDR_ALG_DIR)))
         && jwk->kty != CJOSE_JWK_KTY_OCT)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -370,6 +370,20 @@ static json_t *_cjose_jwe_recipient_param_target(cjose_jwe_t *jwe, _jwe_int_reci
     return copy;
 }
 
+// a header parameter that the key agreement or the key wrapping produces itself
+// must not be supplied by the caller: it would either end up in two of the three
+// header locations, which RFC 7516 section 7.2.1 does not allow, or silently
+// replace what the caller set
+static bool _cjose_jwe_reject_generated_param(cjose_jwe_t *jwe, _jwe_int_recipient_t *recipient, const char *name, cjose_err *err)
+{
+    if (NULL != _cjose_jwe_get_json_from_headers(jwe->hdr, jwe->shared_hdr, (cjose_header_t *)recipient->unprotected, name))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+    return true;
+}
+
 static bool _cjose_jwe_alg_is_ecdh_es(const char *alg)
 {
     return (NULL != alg)
@@ -934,16 +948,10 @@ _cjose_jwe_encrypt_ek_aes_gcm_kw(_jwe_int_recipient_t *recipient, cjose_jwe_t *j
         return false;
     }
 
-    // the "iv" and "tag" parameters are produced here: if the caller supplied
-    // either of them in one of its header objects, the parameter would end up
-    // in two of the three header locations, which RFC 7516 section 7.2.1 does
-    // not allow, and the wrong one could be picked up when decrypting
-    if (NULL != _cjose_jwe_get_json_from_headers(jwe->hdr, jwe->shared_hdr, (cjose_header_t *)recipient->unprotected, CJOSE_HDR_IV)
-        || NULL
-               != _cjose_jwe_get_json_from_headers(jwe->hdr, jwe->shared_hdr, (cjose_header_t *)recipient->unprotected,
-                                                   CJOSE_HDR_TAG))
+    // the "iv" and "tag" parameters are produced here
+    if (!_cjose_jwe_reject_generated_param(jwe, recipient, CJOSE_HDR_IV, err)
+        || !_cjose_jwe_reject_generated_param(jwe, recipient, CJOSE_HDR_TAG, err))
     {
-        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return false;
     }
 
@@ -1258,6 +1266,12 @@ static bool _cjose_jwe_encrypt_ek_ecdh_es(_jwe_int_recipient_t *recipient, cjose
     uint8_t *derived = NULL;
     bool result = false;
 
+    // the "epk" parameter is produced here
+    if (!_cjose_jwe_reject_generated_param(jwe, recipient, CJOSE_HDR_EPK, err))
+    {
+        return false;
+    }
+
     // generate and export random EPK
     epk_jwk = cjose_jwk_create_EC_random(cjose_jwk_EC_get_curve(jwk, err), err);
     if (NULL == epk_jwk)
@@ -1439,6 +1453,12 @@ static bool _cjose_jwe_encrypt_ek_ecdh_es_kw(
     size_t otherinfo_len = 0;
     uint8_t *kek = NULL;
     bool result = false;
+
+    // the "epk" parameter is produced here
+    if (!_cjose_jwe_reject_generated_param(jwe, recipient, CJOSE_HDR_EPK, err))
+    {
+        return false;
+    }
 
     // generate and export random EPK
     epk_jwk = cjose_jwk_create_EC_random(cjose_jwk_EC_get_curve(jwk, err), err);
@@ -2349,6 +2369,25 @@ cjose_jwe_t *cjose_jwe_encrypt_multi_iv(const cjose_jwe_recipient_t *recipients,
 
         // build JWE content-encryption key and encrypted key
         if (!jwe->to[i].fns.encrypt_ek(jwe->to + i, jwe, recipients[i].jwk, err))
+        {
+            cjose_jwe_release(jwe);
+            return NULL;
+        }
+    }
+
+    // the algorithms have written the parameters they produce by now, so the
+    // assembled headers are validated once more: what leaves here has to be a
+    // JWE that can be imported again, with the names of its header locations
+    // disjoint (RFC 7516 section 7.2.1) and every critical parameter present
+    // in its JOSE header (RFC 7515 section 4.1.11)
+    for (size_t i = 0; i < recipient_count; i++)
+    {
+        cjose_header_t *headers[]
+            = { (cjose_header_t *)jwe->hdr, (cjose_header_t *)jwe->shared_hdr, (cjose_header_t *)jwe->to[i].unprotected };
+        const size_t headers_len = sizeof(headers) / sizeof(headers[0]);
+
+        if (!_cjose_header_validate_disjoint(headers, headers_len, err)
+            || !_cjose_header_validate_crit_present(headers, headers_len, err))
         {
             cjose_jwe_release(jwe);
             return NULL;

--- a/src/jwe.c
+++ b/src/jwe.c
@@ -370,6 +370,13 @@ static json_t *_cjose_jwe_recipient_param_target(cjose_jwe_t *jwe, _jwe_int_reci
     return copy;
 }
 
+static bool _cjose_jwe_alg_is_aes_gcm_kw(const char *alg)
+{
+    return (NULL != alg)
+           && ((0 == strcmp(alg, CJOSE_HDR_ALG_A128GCMKW)) || (0 == strcmp(alg, CJOSE_HDR_ALG_A192GCMKW))
+               || (0 == strcmp(alg, CJOSE_HDR_ALG_A256GCMKW)));
+}
+
 static bool _cjose_jwe_validate_enc(cjose_jwe_t *jwe, cjose_header_t *protected_header, cjose_err *err)
 {
 
@@ -413,17 +420,12 @@ static bool _cjose_jwe_validate_alg(cjose_header_t *protected_header,
                                     _jwe_int_recipient_t *recipient,
                                     cjose_err *err)
 {
-    static const char *const supported_crit_headers[] = { "alg", "enc", "cty", "epk", "apu", "apv", "iv", "tag" };
+    static const char *const supported_crit_headers[] = { "alg", "enc", "cty", "epk", "apu", "apv" };
 
-    if (!_cjose_header_validate_crit(protected_header, supported_crit_headers,
-                                     sizeof(supported_crit_headers) / sizeof(supported_crit_headers[0]), err)
-        || !_cjose_header_validate_crit(unprotected_header, supported_crit_headers,
-                                        sizeof(supported_crit_headers) / sizeof(supported_crit_headers[0]), err)
-        || !_cjose_header_validate_crit((cjose_header_t *)recipient->unprotected, supported_crit_headers,
-                                        sizeof(supported_crit_headers) / sizeof(supported_crit_headers[0]), err))
-    {
-        return false;
-    }
+    // RFC 7518 section 4.7 defines "iv" and "tag" for the AES GCM key wrapping
+    // algorithms alone, and they are only processed there, so they are accepted
+    // as critical parameters for those algorithms and refused for every other
+    static const char *const supported_crit_headers_aes_gcm_kw[] = { "alg", "enc", "cty", "epk", "apu", "apv", "iv", "tag" };
 
     const char *alg = _cjose_jwe_get_from_headers(protected_header, unprotected_header, (cjose_header_t *)recipient->unprotected,
                                                   CJOSE_HDR_ALG);
@@ -431,6 +433,19 @@ static bool _cjose_jwe_validate_alg(cjose_header_t *protected_header,
     if (NULL == alg)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return false;
+    }
+
+    const bool is_aes_gcm_kw = _cjose_jwe_alg_is_aes_gcm_kw(alg);
+    const char *const *crit_headers = is_aes_gcm_kw ? supported_crit_headers_aes_gcm_kw : supported_crit_headers;
+    const size_t crit_headers_len = is_aes_gcm_kw
+                                        ? sizeof(supported_crit_headers_aes_gcm_kw) / sizeof(supported_crit_headers_aes_gcm_kw[0])
+                                        : sizeof(supported_crit_headers) / sizeof(supported_crit_headers[0]);
+
+    if (!_cjose_header_validate_crit(protected_header, crit_headers, crit_headers_len, err)
+        || !_cjose_header_validate_crit(unprotected_header, crit_headers, crit_headers_len, err)
+        || !_cjose_header_validate_crit((cjose_header_t *)recipient->unprotected, crit_headers, crit_headers_len, err))
+    {
         return false;
     }
 
@@ -509,8 +524,7 @@ static bool _cjose_jwe_validate_alg(cjose_header_t *protected_header,
         recipient->fns.decrypt_ek = _cjose_jwe_decrypt_ek_aes_kw;
     }
 
-    if ((strcmp(alg, CJOSE_HDR_ALG_A128GCMKW) == 0) || (strcmp(alg, CJOSE_HDR_ALG_A192GCMKW) == 0)
-        || (strcmp(alg, CJOSE_HDR_ALG_A256GCMKW) == 0))
+    if (is_aes_gcm_kw)
     {
         recipient->fns.encrypt_ek = _cjose_jwe_encrypt_ek_aes_gcm_kw;
         recipient->fns.decrypt_ek = _cjose_jwe_decrypt_ek_aes_gcm_kw;
@@ -2186,9 +2200,7 @@ static bool _cjose_jwe_validate_decrypt_key(_jwe_int_recipient_t *recipient,
     }
 
     if (((0 == strcmp(alg, CJOSE_HDR_ALG_A128KW)) || (0 == strcmp(alg, CJOSE_HDR_ALG_A192KW))
-         || (0 == strcmp(alg, CJOSE_HDR_ALG_A256KW)) || (0 == strcmp(alg, CJOSE_HDR_ALG_A128GCMKW))
-         || (0 == strcmp(alg, CJOSE_HDR_ALG_A192GCMKW)) || (0 == strcmp(alg, CJOSE_HDR_ALG_A256GCMKW))
-         || (0 == strcmp(alg, CJOSE_HDR_ALG_DIR)))
+         || (0 == strcmp(alg, CJOSE_HDR_ALG_A256KW)) || _cjose_jwe_alg_is_aes_gcm_kw(alg) || (0 == strcmp(alg, CJOSE_HDR_ALG_DIR)))
         && jwk->kty != CJOSE_JWK_KTY_OCT)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);

--- a/src/jws.c
+++ b/src/jws.c
@@ -85,8 +85,11 @@ static bool _cjose_jws_validate_hdr(cjose_jws_t *jws, cjose_err *err)
 {
     static const char *const supported_crit_headers[] = { "alg", "cty" };
 
-    if (!_cjose_header_validate_crit((cjose_header_t *)jws->hdr, supported_crit_headers,
-                                     sizeof(supported_crit_headers) / sizeof(supported_crit_headers[0]), err))
+    cjose_header_t *headers[] = { (cjose_header_t *)jws->hdr };
+
+    if (!_cjose_header_validate_crit(headers, sizeof(headers) / sizeof(headers[0]), supported_crit_headers,
+                                     sizeof(supported_crit_headers) / sizeof(supported_crit_headers[0]), err)
+        || !_cjose_header_validate_crit_present(headers, sizeof(headers) / sizeof(headers[0]), err))
     {
         return false;
     }

--- a/src/jws.c
+++ b/src/jws.c
@@ -83,13 +83,9 @@ static bool _cjose_jws_build_hdr(cjose_jws_t *jws, cjose_header_t *header, cjose
 ////////////////////////////////////////////////////////////////////////////////
 static bool _cjose_jws_validate_hdr(cjose_jws_t *jws, cjose_err *err)
 {
-    static const char *const supported_crit_headers[] = { "alg", "cty" };
-
     cjose_header_t *headers[] = { (cjose_header_t *)jws->hdr };
 
-    if (!_cjose_header_validate_crit(headers, sizeof(headers) / sizeof(headers[0]), supported_crit_headers,
-                                     sizeof(supported_crit_headers) / sizeof(supported_crit_headers[0]), err)
-        || !_cjose_header_validate_crit_present(headers, sizeof(headers) / sizeof(headers[0]), err))
+    if (!_cjose_header_validate_crit(headers, sizeof(headers) / sizeof(headers[0]), err))
     {
         return false;
     }

--- a/test/check_header.c
+++ b/test/check_header.c
@@ -115,8 +115,9 @@ START_TEST(test_cjose_header_set_get_raw)
 }
 END_TEST
 
-// regression: RFC 7515 section 4.1.11 requires a "crit" list, if present, to
-// be non-empty; _cjose_header_validate_crit accepted an empty list
+// RFC 7515 section 4.1.11: the "crit" list, if present, must be a non-empty
+// array of supported, non-duplicate names that occur in the JOSE header, and it
+// must be integrity protected, so it may only appear in the protected header
 START_TEST(test_cjose_header_validate_crit)
 {
     cjose_err err;
@@ -125,31 +126,132 @@ START_TEST(test_cjose_header_validate_crit)
 
     cjose_header_t *header = cjose_header_new(&err);
     ck_assert_msg(NULL != header, "cjose_header_new failed");
+    cjose_header_t *headers[] = { header, NULL };
+    const size_t headers_len = sizeof(headers) / sizeof(headers[0]);
 
     // no "crit" header at all is fine
-    ck_assert(_cjose_header_validate_crit(header, supported, supported_len, &err));
+    ck_assert(_cjose_header_validate_crit(headers, headers_len, supported, supported_len, &err));
 
-    // a supported extension is fine
+    // a supported extension that occurs in the header is fine
+    ck_assert(cjose_header_set(header, "cty", "JWT", &err));
     ck_assert(cjose_header_set_raw(header, "crit", "[\"cty\"]", &err));
-    ck_assert(_cjose_header_validate_crit(header, supported, supported_len, &err));
+    ck_assert(_cjose_header_validate_crit(headers, headers_len, supported, supported_len, &err));
 
     // an unsupported extension is rejected
     ck_assert(cjose_header_set_raw(header, "crit", "[\"exp\"]", &err));
-    ck_assert(!_cjose_header_validate_crit(header, supported, supported_len, &err));
+    ck_assert(!_cjose_header_validate_crit(headers, headers_len, supported, supported_len, &err));
     ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
 
     // a non-array value is rejected
     ck_assert(cjose_header_set(header, "crit", "cty", &err));
-    ck_assert(!_cjose_header_validate_crit(header, supported, supported_len, &err));
+    ck_assert(!_cjose_header_validate_crit(headers, headers_len, supported, supported_len, &err));
     ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
 
     // an empty list is rejected (RFC 7515 section 4.1.11)
     memset(&err, 0, sizeof(err));
     ck_assert(cjose_header_set_raw(header, "crit", "[]", &err));
-    ck_assert(!_cjose_header_validate_crit(header, supported, supported_len, &err));
+    ck_assert(!_cjose_header_validate_crit(headers, headers_len, supported, supported_len, &err));
     ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
 
+    // a duplicate name is rejected
+    memset(&err, 0, sizeof(err));
+    ck_assert(cjose_header_set_raw(header, "crit", "[\"cty\",\"cty\"]", &err));
+    ck_assert(!_cjose_header_validate_crit(headers, headers_len, supported, supported_len, &err));
+    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
+
+    // the list is refused in a header other than the protected one
+    memset(&err, 0, sizeof(err));
+    ck_assert(cjose_header_set_raw(header, "crit", "[\"cty\"]", &err));
+    cjose_header_t *other = cjose_header_new(&err);
+    ck_assert(NULL != other);
+    ck_assert(cjose_header_set_raw(other, "crit", "[\"cty\"]", &err));
+    cjose_header_t *both[] = { header, other };
+    ck_assert(!_cjose_header_validate_crit(both, 2, supported, supported_len, &err));
+    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
+
+    cjose_header_release(other);
     cjose_header_release(header);
+}
+END_TEST
+
+// RFC 7515 section 4.1.11: a name in the "crit" list must occur as a header
+// parameter name within the JOSE header
+START_TEST(test_cjose_header_validate_crit_present)
+{
+    cjose_err err;
+
+    cjose_header_t *header = cjose_header_new(&err);
+    ck_assert_msg(NULL != header, "cjose_header_new failed");
+    cjose_header_t *headers[] = { header, NULL };
+    const size_t headers_len = sizeof(headers) / sizeof(headers[0]);
+
+    // no "crit" header at all is fine
+    ck_assert(_cjose_header_validate_crit_present(headers, headers_len, &err));
+
+    // a name that does not occur in the JOSE header is rejected
+    ck_assert(cjose_header_set_raw(header, "crit", "[\"cty\"]", &err));
+    ck_assert(!_cjose_header_validate_crit_present(headers, headers_len, &err));
+    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
+
+    // ... and accepted once it does
+    memset(&err, 0, sizeof(err));
+    ck_assert(cjose_header_set(header, "cty", "JWT", &err));
+    ck_assert(_cjose_header_validate_crit_present(headers, headers_len, &err));
+
+    // the name may occur in any of the headers that make up the JOSE header
+    cjose_header_t *other = cjose_header_new(&err);
+    ck_assert(NULL != other);
+    ck_assert(cjose_header_set(other, "alg", "HS256", &err));
+    ck_assert(cjose_header_set_raw(header, "crit", "[\"alg\"]", &err));
+    ck_assert(!_cjose_header_validate_crit_present(headers, headers_len, &err));
+    cjose_header_t *both[] = { header, other };
+    memset(&err, 0, sizeof(err));
+    ck_assert(_cjose_header_validate_crit_present(both, 2, &err));
+
+    cjose_header_release(other);
+    cjose_header_release(header);
+}
+END_TEST
+
+// RFC 7516 section 7.2.1: the member names of the JWE protected header, the
+// shared unprotected header and a per-recipient unprotected header are disjoint
+START_TEST(test_cjose_header_validate_disjoint)
+{
+    cjose_err err;
+
+    cjose_header_t *protected_header = cjose_header_new(&err);
+    cjose_header_t *shared = cjose_header_new(&err);
+    cjose_header_t *personal = cjose_header_new(&err);
+    ck_assert(NULL != protected_header && NULL != shared && NULL != personal);
+    ck_assert(cjose_header_set(protected_header, "enc", "A128GCM", &err));
+    ck_assert(cjose_header_set(shared, "cty", "JWT", &err));
+    ck_assert(cjose_header_set(personal, "alg", "A128KW", &err));
+
+    cjose_header_t *headers[] = { protected_header, shared, personal };
+    const size_t headers_len = sizeof(headers) / sizeof(headers[0]);
+    ck_assert(_cjose_header_validate_disjoint(headers, headers_len, &err));
+
+    // a NULL entry is skipped
+    cjose_header_t *with_null[] = { protected_header, NULL, personal };
+    ck_assert(_cjose_header_validate_disjoint(with_null, headers_len, &err));
+
+    // the same name in the protected and the per-recipient header is refused
+    ck_assert(cjose_header_set(personal, "enc", "A128GCM", &err));
+    ck_assert(!_cjose_header_validate_disjoint(headers, headers_len, &err));
+    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
+
+    // ... as is the same name in the shared and the per-recipient header
+    memset(&err, 0, sizeof(err));
+    ck_assert(cjose_header_set_raw(personal, "enc", "null", &err));
+    json_object_del((json_t *)personal, "enc");
+    ck_assert(_cjose_header_validate_disjoint(headers, headers_len, &err));
+    ck_assert(cjose_header_set(personal, "cty", "JWT", &err));
+    ck_assert(!_cjose_header_validate_disjoint(headers, headers_len, &err));
+    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
+
+    cjose_header_release(personal);
+    cjose_header_release(shared);
+    cjose_header_release(protected_header);
 }
 END_TEST
 
@@ -163,6 +265,8 @@ Suite *cjose_header_suite(void)
     tcase_add_test(tc_header, test_cjose_header_set_get);
     tcase_add_test(tc_header, test_cjose_header_set_get_raw);
     tcase_add_test(tc_header, test_cjose_header_validate_crit);
+    tcase_add_test(tc_header, test_cjose_header_validate_crit_present);
+    tcase_add_test(tc_header, test_cjose_header_validate_disjoint);
     suite_add_tcase(suite, tc_header);
 
     return suite;

--- a/test/check_header.c
+++ b/test/check_header.c
@@ -115,14 +115,13 @@ START_TEST(test_cjose_header_set_get_raw)
 }
 END_TEST
 
-// RFC 7515 section 4.1.11: the "crit" list, if present, must be a non-empty
-// array of supported, non-duplicate names that occur in the JOSE header, and it
-// must be integrity protected, so it may only appear in the protected header
+// RFC 7515 section 4.1.11: a "crit" list names extensions that have to be
+// understood and processed, and a producer may not list a name the JOSE
+// specifications define. cjose implements no extension, so a header carrying
+// the list is refused wherever it appears
 START_TEST(test_cjose_header_validate_crit)
 {
     cjose_err err;
-    static const char *const supported[] = { "alg", "cty" };
-    const size_t supported_len = sizeof(supported) / sizeof(supported[0]);
 
     cjose_header_t *header = cjose_header_new(&err);
     ck_assert_msg(NULL != header, "cjose_header_new failed");
@@ -130,83 +129,27 @@ START_TEST(test_cjose_header_validate_crit)
     const size_t headers_len = sizeof(headers) / sizeof(headers[0]);
 
     // no "crit" header at all is fine
-    ck_assert(_cjose_header_validate_crit(headers, headers_len, supported, supported_len, &err));
+    ck_assert(_cjose_header_validate_crit(headers, headers_len, &err));
 
-    // a supported extension that occurs in the header is fine
-    ck_assert(cjose_header_set(header, "cty", "JWT", &err));
-    ck_assert(cjose_header_set_raw(header, "crit", "[\"cty\"]", &err));
-    ck_assert(_cjose_header_validate_crit(headers, headers_len, supported, supported_len, &err));
+    // any list is refused, whatever it holds
+    static const char *const lists[] = { "[\"cty\"]", "[\"exp\"]", "[]", "[\"alg\",\"alg\"]", "\"cty\"" };
+    for (size_t i = 0; i < sizeof(lists) / sizeof(lists[0]); i++)
+    {
+        memset(&err, 0, sizeof(err));
+        ck_assert(cjose_header_set_raw(header, "crit", lists[i], &err));
+        ck_assert_msg(!_cjose_header_validate_crit(headers, headers_len, &err), "crit %s accepted", lists[i]);
+        ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
+    }
 
-    // an unsupported extension is rejected
-    ck_assert(cjose_header_set_raw(header, "crit", "[\"exp\"]", &err));
-    ck_assert(!_cjose_header_validate_crit(headers, headers_len, supported, supported_len, &err));
-    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
-
-    // a non-array value is rejected
-    ck_assert(cjose_header_set(header, "crit", "cty", &err));
-    ck_assert(!_cjose_header_validate_crit(headers, headers_len, supported, supported_len, &err));
-    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
-
-    // an empty list is rejected (RFC 7515 section 4.1.11)
+    // also when it sits in a header other than the first
     memset(&err, 0, sizeof(err));
-    ck_assert(cjose_header_set_raw(header, "crit", "[]", &err));
-    ck_assert(!_cjose_header_validate_crit(headers, headers_len, supported, supported_len, &err));
-    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
-
-    // a duplicate name is rejected
-    memset(&err, 0, sizeof(err));
-    ck_assert(cjose_header_set_raw(header, "crit", "[\"cty\",\"cty\"]", &err));
-    ck_assert(!_cjose_header_validate_crit(headers, headers_len, supported, supported_len, &err));
-    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
-
-    // the list is refused in a header other than the protected one
-    memset(&err, 0, sizeof(err));
-    ck_assert(cjose_header_set_raw(header, "crit", "[\"cty\"]", &err));
+    json_object_del((json_t *)header, "crit");
     cjose_header_t *other = cjose_header_new(&err);
     ck_assert(NULL != other);
     ck_assert(cjose_header_set_raw(other, "crit", "[\"cty\"]", &err));
     cjose_header_t *both[] = { header, other };
-    ck_assert(!_cjose_header_validate_crit(both, 2, supported, supported_len, &err));
+    ck_assert(!_cjose_header_validate_crit(both, 2, &err));
     ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
-
-    cjose_header_release(other);
-    cjose_header_release(header);
-}
-END_TEST
-
-// RFC 7515 section 4.1.11: a name in the "crit" list must occur as a header
-// parameter name within the JOSE header
-START_TEST(test_cjose_header_validate_crit_present)
-{
-    cjose_err err;
-
-    cjose_header_t *header = cjose_header_new(&err);
-    ck_assert_msg(NULL != header, "cjose_header_new failed");
-    cjose_header_t *headers[] = { header, NULL };
-    const size_t headers_len = sizeof(headers) / sizeof(headers[0]);
-
-    // no "crit" header at all is fine
-    ck_assert(_cjose_header_validate_crit_present(headers, headers_len, &err));
-
-    // a name that does not occur in the JOSE header is rejected
-    ck_assert(cjose_header_set_raw(header, "crit", "[\"cty\"]", &err));
-    ck_assert(!_cjose_header_validate_crit_present(headers, headers_len, &err));
-    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
-
-    // ... and accepted once it does
-    memset(&err, 0, sizeof(err));
-    ck_assert(cjose_header_set(header, "cty", "JWT", &err));
-    ck_assert(_cjose_header_validate_crit_present(headers, headers_len, &err));
-
-    // the name may occur in any of the headers that make up the JOSE header
-    cjose_header_t *other = cjose_header_new(&err);
-    ck_assert(NULL != other);
-    ck_assert(cjose_header_set(other, "alg", "HS256", &err));
-    ck_assert(cjose_header_set_raw(header, "crit", "[\"alg\"]", &err));
-    ck_assert(!_cjose_header_validate_crit_present(headers, headers_len, &err));
-    cjose_header_t *both[] = { header, other };
-    memset(&err, 0, sizeof(err));
-    ck_assert(_cjose_header_validate_crit_present(both, 2, &err));
 
     cjose_header_release(other);
     cjose_header_release(header);
@@ -265,7 +208,6 @@ Suite *cjose_header_suite(void)
     tcase_add_test(tc_header, test_cjose_header_set_get);
     tcase_add_test(tc_header, test_cjose_header_set_get_raw);
     tcase_add_test(tc_header, test_cjose_header_validate_crit);
-    tcase_add_test(tc_header, test_cjose_header_validate_crit_present);
     tcase_add_test(tc_header, test_cjose_header_validate_disjoint);
     suite_add_tcase(suite, tc_header);
 

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -828,6 +828,203 @@ START_TEST(test_cjose_jwe_aes_gcm_kw_caller_supplied_params)
 }
 END_TEST
 
+static void _jwe_hdr_crit_cty(json_t *hdr)
+{
+    json_t *crit = json_array();
+    json_array_append_new(crit, json_string("cty"));
+    json_object_set_new(hdr, "crit", crit);
+}
+
+static void _jwe_hdr_crit_epk(json_t *hdr)
+{
+    json_t *crit = json_array();
+    json_array_append_new(crit, json_string(CJOSE_HDR_EPK));
+    json_object_set_new(hdr, "crit", crit);
+}
+
+// "epk", "apu" and "apv" are ECDH-ES parameters (RFC 7518 section 4.6) and are
+// understood as critical parameters for those algorithms alone
+START_TEST(test_cjose_jwe_crit_ecdh_es_params)
+{
+    cjose_err err;
+    static const uint8_t plain[] = "Setec Astronomy";
+    static const char *const params[] = { CJOSE_HDR_EPK, CJOSE_HDR_APU, CJOSE_HDR_APV };
+
+    for (size_t p = 0; p < sizeof(params) / sizeof(params[0]); p++)
+    {
+        // accepted for ECDH-ES
+        memset(&err, 0, sizeof(err));
+        cjose_header_t *hdr = cjose_header_new(&err);
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_ECDH_ES, &err));
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A128CBC_HS256, &err));
+        json_t *crit = json_array();
+        json_array_append_new(crit, json_string(params[p]));
+        json_object_set_new((json_t *)hdr, "crit", crit);
+        cjose_jwk_t *ec = cjose_jwk_import(JWK_EC, strlen(JWK_EC), &err);
+        ck_assert(NULL != ec);
+        cjose_jwe_t *jwe = cjose_jwe_encrypt(ec, hdr, plain, sizeof(plain) - 1, &err);
+        ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed for ECDH-ES crit %s: %s", params[p], err.message);
+        cjose_jwe_release(jwe);
+        cjose_jwk_release(ec);
+        cjose_header_release(hdr);
+
+        // refused for an algorithm that does not process them
+        memset(&err, 0, sizeof(err));
+        hdr = cjose_header_new(&err);
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128KW, &err));
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+        crit = json_array();
+        json_array_append_new(crit, json_string(params[p]));
+        json_object_set_new((json_t *)hdr, "crit", crit);
+        cjose_jwk_t *oct = cjose_jwk_import(JWK_OCT_16, strlen(JWK_OCT_16), &err);
+        ck_assert(NULL != oct);
+        ck_assert_msg(NULL == cjose_jwe_encrypt(oct, hdr, plain, sizeof(plain) - 1, &err), "crit %s accepted for A128KW",
+                      params[p]);
+        ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+        cjose_jwk_release(oct);
+        cjose_header_release(hdr);
+    }
+
+    // an imported JWE marking "epk" critical is refused for the same reason
+    memset(&err, 0, sizeof(err));
+    cjose_jwk_t *oct = cjose_jwk_import(JWK_OCT_16, strlen(JWK_OCT_16), &err);
+    cjose_header_t *hdr = cjose_header_new(&err);
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128KW, &err));
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+    cjose_jwe_t *jwe = cjose_jwe_encrypt(oct, hdr, plain, sizeof(plain) - 1, &err);
+    ck_assert(NULL != jwe);
+    char *compact = cjose_jwe_export(jwe, &err);
+    ck_assert(NULL != compact);
+    cjose_jwe_release(jwe);
+    char *modified = _jwe_with_modified_header(compact, _jwe_hdr_crit_epk);
+    ck_assert(NULL == cjose_jwe_import(modified, strlen(modified), &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    free(modified);
+
+    // a critical parameter that does not occur in the header is refused too
+    memset(&err, 0, sizeof(err));
+    modified = _jwe_with_modified_header(compact, _jwe_hdr_crit_cty);
+    ck_assert(NULL == cjose_jwe_import(modified, strlen(modified), &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    free(modified);
+
+    cjose_get_dealloc()(compact);
+    cjose_header_release(hdr);
+    cjose_jwk_release(oct);
+}
+END_TEST
+
+// rewrite the "protected" member of a JSON serialization and import the result
+static bool _import_json_modified(const char *json, void (*modify)(json_t *form), cjose_err *err)
+{
+    json_t *form = json_loads(json, 0, NULL);
+    ck_assert(NULL != form);
+    modify(form);
+    char *modified = json_dumps(form, JSON_COMPACT);
+    ck_assert(NULL != modified);
+    cjose_jwe_t *jwe = cjose_jwe_import_json(modified, strlen(modified), err);
+    const bool imported = (NULL != jwe);
+    cjose_jwe_release(jwe);
+    free(modified);
+    json_decref(form);
+    return imported;
+}
+
+// the same name in the protected header and in a recipient header
+static void _json_duplicate_name(json_t *form)
+{
+    json_t *header = json_object_get(json_array_get(json_object_get(form, "recipients"), 0), "header");
+    json_object_set_new(header, CJOSE_HDR_ENC, json_string(CJOSE_HDR_ENC_A128GCM));
+}
+
+// the same name in the shared unprotected header and in a recipient header
+static void _json_duplicate_shared(json_t *form)
+{
+    json_t *shared = json_object();
+    json_object_set_new(shared, CJOSE_HDR_KID, json_string("k16"));
+    json_object_set_new(form, "unprotected", shared);
+}
+
+// a "crit" list in a header that is not integrity protected
+static void _json_crit_unprotected(json_t *form)
+{
+    json_t *header = json_object_get(json_array_get(json_object_get(form, "recipients"), 0), "header");
+    json_t *crit = json_array();
+    json_array_append_new(crit, json_string(CJOSE_HDR_ALG));
+    json_object_set_new(header, "crit", crit);
+}
+
+// RFC 7516 section 7.2.1: the names of the three header locations of a JSON
+// serialization must be disjoint, and RFC 7515 section 4.1.11 keeps "crit" in
+// the protected header
+START_TEST(test_cjose_jwe_json_header_rules)
+{
+    cjose_err err;
+    static const uint8_t plain[] = "Setec Astronomy";
+
+    cjose_jwk_t *jwk16 = cjose_jwk_import(JWK_OCT_16, strlen(JWK_OCT_16), &err);
+    cjose_jwk_t *jwk32 = cjose_jwk_import(JWK_OCT_32, strlen(JWK_OCT_32), &err);
+    ck_assert(NULL != jwk16 && NULL != jwk32);
+    ck_assert(cjose_jwk_set_kid(jwk16, "k16", 3, &err));
+    ck_assert(cjose_jwk_set_kid(jwk32, "k32", 3, &err));
+
+    cjose_header_t *protected_header = cjose_header_new(&err);
+    ck_assert(cjose_header_set(protected_header, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A128GCM, &err));
+    cjose_header_t *hdr16 = cjose_header_new(&err);
+    ck_assert(cjose_header_set(hdr16, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128KW, &err));
+    ck_assert(cjose_header_set(hdr16, CJOSE_HDR_KID, "k16", &err));
+    cjose_header_t *hdr32 = cjose_header_new(&err);
+    ck_assert(cjose_header_set(hdr32, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A256KW, &err));
+    ck_assert(cjose_header_set(hdr32, CJOSE_HDR_KID, "k32", &err));
+    cjose_jwe_recipient_t recipients[] = { { jwk16, hdr16 }, { jwk32, hdr32 } };
+
+    cjose_jwe_t *jwe = cjose_jwe_encrypt_multi(recipients, 2, protected_header, NULL, plain, sizeof(plain) - 1, &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt_multi failed: %s", err.message);
+    char *json = cjose_jwe_export_json(jwe, &err);
+    ck_assert(NULL != json);
+    cjose_jwe_release(jwe);
+
+    // what cjose produces itself imports again
+    memset(&err, 0, sizeof(err));
+    jwe = cjose_jwe_import_json(json, strlen(json), &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_import_json failed: %s", err.message);
+    cjose_jwe_release(jwe);
+
+    void (*const cases[])(json_t *) = { _json_duplicate_name, _json_duplicate_shared, _json_crit_unprotected };
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++)
+    {
+        memset(&err, 0, sizeof(err));
+        ck_assert_msg(!_import_json_modified(json, cases[i], &err), "cjose_jwe_import_json accepted case %zu", i);
+        ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    }
+
+    // the same names are refused when encrypting, not only when importing
+    memset(&err, 0, sizeof(err));
+    ck_assert(cjose_header_set(hdr16, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A128GCM, &err));
+    ck_assert_msg(NULL == cjose_jwe_encrypt_multi(recipients, 2, protected_header, NULL, plain, sizeof(plain) - 1, &err),
+                  "cjose_jwe_encrypt_multi accepted a duplicate header name");
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    json_object_del((json_t *)hdr16, CJOSE_HDR_ENC);
+
+    // ... including against the shared unprotected header, which the
+    // encryption path did not look at before
+    memset(&err, 0, sizeof(err));
+    cjose_header_t *shared = cjose_header_new(&err);
+    ck_assert(cjose_header_set(shared, CJOSE_HDR_KID, "k16", &err));
+    ck_assert_msg(NULL == cjose_jwe_encrypt_multi(recipients, 2, protected_header, shared, plain, sizeof(plain) - 1, &err),
+                  "cjose_jwe_encrypt_multi accepted a name shared with a recipient header");
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    cjose_header_release(shared);
+
+    cjose_get_dealloc()(json);
+    cjose_header_release(hdr16);
+    cjose_header_release(hdr32);
+    cjose_header_release(protected_header);
+    cjose_jwk_release(jwk16);
+    cjose_jwk_release(jwk32);
+}
+END_TEST
+
 START_TEST(test_cjose_jwe_self_encrypt_self_decrypt_empty)
 {
     static const uint8_t plain[] = "";
@@ -2490,6 +2687,8 @@ Suite *cjose_jwe_suite(void)
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_multiple_recipients);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_crit);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_caller_supplied_params);
+    tcase_add_test(tc_jwe, test_cjose_jwe_crit_ecdh_es_params);
+    tcase_add_test(tc_jwe, test_cjose_jwe_json_header_rules);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_interop);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes_gcm);

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -852,11 +852,16 @@ START_TEST(test_cjose_jwe_crit_ecdh_es_params)
 
     for (size_t p = 0; p < sizeof(params) / sizeof(params[0]); p++)
     {
-        // accepted for ECDH-ES
+        // accepted for ECDH-ES, as long as the parameter is in the header: the
+        // key agreement writes "epk" itself, "apu" and "apv" come from the caller
         memset(&err, 0, sizeof(err));
         cjose_header_t *hdr = cjose_header_new(&err);
         ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_ECDH_ES, &err));
         ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A128CBC_HS256, &err));
+        if (0 != strcmp(params[p], CJOSE_HDR_EPK))
+        {
+            ck_assert(cjose_header_set(hdr, params[p], "cGFydHk", &err));
+        }
         json_t *crit = json_array();
         json_array_append_new(crit, json_string(params[p]));
         json_object_set_new((json_t *)hdr, "crit", crit);
@@ -864,7 +869,24 @@ START_TEST(test_cjose_jwe_crit_ecdh_es_params)
         ck_assert(NULL != ec);
         cjose_jwe_t *jwe = cjose_jwe_encrypt(ec, hdr, plain, sizeof(plain) - 1, &err);
         ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed for ECDH-ES crit %s: %s", params[p], err.message);
+        // what the encryption produces imports again
+        char *round = cjose_jwe_export(jwe, &err);
+        ck_assert(NULL != round);
+        cjose_jwe_t *back = cjose_jwe_import(round, strlen(round), &err);
+        ck_assert_msg(NULL != back, "cjose_jwe_import failed for ECDH-ES crit %s: %s", params[p], err.message);
+        cjose_jwe_release(back);
+        cjose_get_dealloc()(round);
         cjose_jwe_release(jwe);
+
+        // ... and refused when the critical parameter never occurs in the header
+        if (0 != strcmp(params[p], CJOSE_HDR_EPK))
+        {
+            memset(&err, 0, sizeof(err));
+            json_object_del((json_t *)hdr, params[p]);
+            ck_assert_msg(NULL == cjose_jwe_encrypt(ec, hdr, plain, sizeof(plain) - 1, &err),
+                          "cjose_jwe_encrypt accepted crit %s without the parameter", params[p]);
+            ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+        }
         cjose_jwk_release(ec);
         cjose_header_release(hdr);
 
@@ -911,6 +933,84 @@ START_TEST(test_cjose_jwe_crit_ecdh_es_params)
     cjose_get_dealloc()(compact);
     cjose_header_release(hdr);
     cjose_jwk_release(oct);
+}
+END_TEST
+
+// a parameter the algorithm produces itself must not come from the caller, and
+// the JWE that leaves the encryption has to be one that can be imported again
+START_TEST(test_cjose_jwe_generated_params)
+{
+    cjose_err err;
+    static const uint8_t plain[] = "Setec Astronomy";
+
+    cjose_jwk_t *ec = cjose_jwk_import(JWK_EC, strlen(JWK_EC), &err);
+    ck_assert(NULL != ec);
+    static const char *const EPK = "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"AA\",\"y\":\"BB\"}";
+
+    // in the protected header, where the key agreement would replace it
+    memset(&err, 0, sizeof(err));
+    cjose_header_t *hdr = cjose_header_new(&err);
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_ECDH_ES, &err));
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A128CBC_HS256, &err));
+    ck_assert(cjose_header_set_raw(hdr, CJOSE_HDR_EPK, EPK, &err));
+    ck_assert_msg(NULL == cjose_jwe_encrypt(ec, hdr, plain, sizeof(plain) - 1, &err), "caller supplied epk accepted");
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    cjose_header_release(hdr);
+
+    // in a per-recipient header, which would leave "epk" in two locations
+    memset(&err, 0, sizeof(err));
+    cjose_header_t *protected_header = cjose_header_new(&err);
+    ck_assert(cjose_header_set(protected_header, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A128CBC_HS256, &err));
+    cjose_header_t *rec_hdr = cjose_header_new(&err);
+    ck_assert(cjose_header_set(rec_hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_ECDH_ES, &err));
+    ck_assert(cjose_header_set_raw(rec_hdr, CJOSE_HDR_EPK, EPK, &err));
+    cjose_jwe_recipient_t one[] = { { ec, rec_hdr } };
+    ck_assert_msg(NULL == cjose_jwe_encrypt_multi(one, 1, protected_header, NULL, plain, sizeof(plain) - 1, &err),
+                  "epk in a recipient header accepted");
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+
+    // in the shared unprotected header
+    memset(&err, 0, sizeof(err));
+    cjose_header_t *shared = cjose_header_new(&err);
+    ck_assert(cjose_header_set_raw(shared, CJOSE_HDR_EPK, EPK, &err));
+    cjose_header_t *plain_rec = cjose_header_new(&err);
+    ck_assert(cjose_header_set(plain_rec, CJOSE_HDR_ALG, CJOSE_HDR_ALG_ECDH_ES, &err));
+    cjose_jwe_recipient_t one_shared[] = { { ec, plain_rec } };
+    ck_assert_msg(NULL == cjose_jwe_encrypt_multi(one_shared, 1, protected_header, shared, plain, sizeof(plain) - 1, &err),
+                  "epk in the shared header accepted");
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    cjose_header_release(plain_rec);
+    cjose_header_release(shared);
+    cjose_header_release(rec_hdr);
+    cjose_header_release(protected_header);
+    cjose_jwk_release(ec);
+
+    // the AES GCM key wrapping parameters keep the same treatment, and a JWE
+    // that marks one of them critical round-trips
+    memset(&err, 0, sizeof(err));
+    cjose_jwk_t *jwk16 = cjose_jwk_import(JWK_OCT_16, strlen(JWK_OCT_16), &err);
+    ck_assert(NULL != jwk16);
+    hdr = cjose_header_new(&err);
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128GCMKW, &err));
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+    json_t *crit = json_array();
+    json_array_append_new(crit, json_string(CJOSE_HDR_IV));
+    json_object_set_new((json_t *)hdr, "crit", crit);
+    cjose_jwe_t *jwe = cjose_jwe_encrypt(jwk16, hdr, plain, sizeof(plain) - 1, &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed: %s", err.message);
+    char *compact = cjose_jwe_export(jwe, &err);
+    ck_assert(NULL != compact);
+    cjose_jwe_t *back = cjose_jwe_import(compact, strlen(compact), &err);
+    ck_assert_msg(NULL != back, "cjose_jwe_import failed: %s", err.message);
+    size_t plain_len = 0;
+    uint8_t *decrypted = cjose_jwe_decrypt(back, jwk16, &plain_len, &err);
+    ck_assert_msg(NULL != decrypted, "cjose_jwe_decrypt failed: %s", err.message);
+    cjose_get_dealloc()(decrypted);
+    cjose_jwe_release(back);
+    cjose_get_dealloc()(compact);
+    cjose_jwe_release(jwe);
+    cjose_header_release(hdr);
+    cjose_jwk_release(jwk16);
 }
 END_TEST
 
@@ -2688,6 +2788,7 @@ Suite *cjose_jwe_suite(void)
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_crit);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_caller_supplied_params);
     tcase_add_test(tc_jwe, test_cjose_jwe_crit_ecdh_es_params);
+    tcase_add_test(tc_jwe, test_cjose_jwe_generated_params);
     tcase_add_test(tc_jwe, test_cjose_jwe_json_header_rules);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_interop);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes);

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -451,6 +451,221 @@ START_TEST(test_cjose_jwe_ecdh_es_kw_self_encrypt_self_decrypt)
 }
 END_TEST
 
+START_TEST(test_cjose_jwe_aes_gcm_kw_self_encrypt_self_decrypt)
+{
+    static const uint8_t plain[] = "Setec Astronomy";
+
+    _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_A128GCMKW, CJOSE_HDR_ENC_A128GCM, JWK_OCT_16, plain, sizeof(plain) - 1);
+    _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_A128GCMKW, CJOSE_HDR_ENC_A256CBC_HS512, JWK_OCT_16, plain, sizeof(plain) - 1);
+    _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_A192GCMKW, CJOSE_HDR_ENC_A192GCM, JWK_OCT_24, plain, sizeof(plain) - 1);
+    _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_A192GCMKW, CJOSE_HDR_ENC_A128CBC_HS256, JWK_OCT_24, plain, sizeof(plain) - 1);
+    _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_A256GCMKW, CJOSE_HDR_ENC_A256GCM, JWK_OCT_32, plain, sizeof(plain) - 1);
+    _self_encrypt_self_decrypt_with_key(CJOSE_HDR_ALG_A256GCMKW, CJOSE_HDR_ENC_A192CBC_HS384, JWK_OCT_32, plain, sizeof(plain) - 1);
+}
+END_TEST
+
+// re-encode the compact serialization with the protected header modified by
+// the given function; the AAD changes with it, but the checks under test run
+// before the content is authenticated
+static char *_jwe_with_modified_header(const char *compact, void (*modify)(json_t *hdr))
+{
+    cjose_err err;
+    const char *dot = strchr(compact, '.');
+    ck_assert(NULL != dot);
+    uint8_t *raw = NULL;
+    size_t raw_len = 0;
+    ck_assert(cjose_base64url_decode(compact, dot - compact, &raw, &raw_len, &err));
+    json_t *hdr = json_loadb((const char *)raw, raw_len, 0, NULL);
+    ck_assert(NULL != hdr);
+    modify(hdr);
+    char *hdr_str = json_dumps(hdr, JSON_COMPACT);
+    ck_assert(NULL != hdr_str);
+    char *hdr_b64u = NULL;
+    size_t hdr_b64u_len = 0;
+    ck_assert(cjose_base64url_encode((const uint8_t *)hdr_str, strlen(hdr_str), &hdr_b64u, &hdr_b64u_len, &err));
+    char *result = malloc(hdr_b64u_len + strlen(dot) + 1);
+    ck_assert(NULL != result);
+    memcpy(result, hdr_b64u, hdr_b64u_len);
+    strcpy(result + hdr_b64u_len, dot);
+    cjose_get_dealloc()(hdr_b64u);
+    cjose_get_dealloc()(hdr_str);
+    json_decref(hdr);
+    cjose_get_dealloc()(raw);
+    return result;
+}
+
+static void _jwe_hdr_short_iv(json_t *hdr) { json_object_set_new(hdr, CJOSE_HDR_IV, json_string("AAAAAAAAAAA")); }
+static void _jwe_hdr_short_tag(json_t *hdr) { json_object_set_new(hdr, CJOSE_HDR_TAG, json_string("AAAAAAAAAAAAAAAAAAAA")); }
+static void _jwe_hdr_drop_tag(json_t *hdr) { json_object_del(hdr, CJOSE_HDR_TAG); }
+static void _jwe_hdr_integer_iv(json_t *hdr) { json_object_set_new(hdr, CJOSE_HDR_IV, json_integer(12)); }
+static void _jwe_hdr_flip_tag(json_t *hdr)
+{
+    const char *tag = json_string_value(json_object_get(hdr, CJOSE_HDR_TAG));
+    char copy[64];
+    ck_assert(NULL != tag && strlen(tag) < sizeof(copy));
+    strcpy(copy, tag);
+    copy[0] = ('A' == copy[0]) ? 'B' : 'A';
+    json_object_set_new(hdr, CJOSE_HDR_TAG, json_string(copy));
+}
+
+// the "iv" and "tag" parameters live with the recipient and are checked
+// before the encrypted key is touched
+static void _decrypt_aes_gcm_kw_expect(const char *compact, const char *key, cjose_errcode expected)
+{
+    cjose_err err;
+    memset(&err, 0, sizeof(err));
+    cjose_jwk_t *jwk = cjose_jwk_import(key, strlen(key), &err);
+    ck_assert(NULL != jwk);
+    cjose_jwe_t *jwe = cjose_jwe_import(compact, strlen(compact), &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_import failed: %s", err.message);
+    size_t plain_len = 0;
+    uint8_t *plain = cjose_jwe_decrypt(jwe, jwk, &plain_len, &err);
+    ck_assert_msg(NULL == plain, "cjose_jwe_decrypt succeeded unexpectedly");
+    ck_assert_int_eq(expected, err.code);
+    cjose_jwe_release(jwe);
+    cjose_jwk_release(jwk);
+}
+
+START_TEST(test_cjose_jwe_aes_gcm_kw_bad_params)
+{
+    cjose_err err;
+    static const uint8_t plain[] = "Setec Astronomy";
+
+    cjose_header_t *hdr = cjose_header_new(&err);
+    ck_assert(NULL != hdr);
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128GCMKW, &err));
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+
+    // the key encryption key must be an oct key of the size the alg names
+    cjose_jwk_t *jwk32 = cjose_jwk_import(JWK_OCT_32, strlen(JWK_OCT_32), &err);
+    ck_assert(NULL != jwk32);
+    ck_assert(NULL == cjose_jwe_encrypt(jwk32, hdr, plain, sizeof(plain) - 1, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    cjose_jwk_t *ec = cjose_jwk_import(JWK_EC, strlen(JWK_EC), &err);
+    ck_assert(NULL != ec);
+    ck_assert(NULL == cjose_jwe_encrypt(ec, hdr, plain, sizeof(plain) - 1, &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+
+    // a good JWE, whose protected header carries the "iv" and "tag" parameters
+    cjose_jwk_t *jwk16 = cjose_jwk_import(JWK_OCT_16, strlen(JWK_OCT_16), &err);
+    ck_assert(NULL != jwk16);
+    cjose_jwe_t *jwe = cjose_jwe_encrypt(jwk16, hdr, plain, sizeof(plain) - 1, &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed: %s", err.message);
+    ck_assert(NULL != cjose_header_get(cjose_jwe_get_protected(jwe), CJOSE_HDR_IV, &err));
+    ck_assert(NULL != cjose_header_get(cjose_jwe_get_protected(jwe), CJOSE_HDR_TAG, &err));
+    char *compact = cjose_jwe_export(jwe, &err);
+    ck_assert(NULL != compact);
+    cjose_jwe_release(jwe);
+
+    // ... is refused with the wrong key size, the wrong key type and a
+    // tampered, missing, short or non-string parameter
+    _decrypt_aes_gcm_kw_expect(compact, JWK_OCT_32, CJOSE_ERR_INVALID_ARG);
+    _decrypt_aes_gcm_kw_expect(compact, JWK_EC, CJOSE_ERR_INVALID_ARG);
+    struct
+    {
+        void (*modify)(json_t *);
+        cjose_errcode expected;
+    } cases[] = {
+        { _jwe_hdr_flip_tag, CJOSE_ERR_CRYPTO },        { _jwe_hdr_drop_tag, CJOSE_ERR_INVALID_ARG },
+        { _jwe_hdr_short_iv, CJOSE_ERR_INVALID_ARG },   { _jwe_hdr_short_tag, CJOSE_ERR_INVALID_ARG },
+        { _jwe_hdr_integer_iv, CJOSE_ERR_INVALID_ARG },
+    };
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++)
+    {
+        char *modified = _jwe_with_modified_header(compact, cases[i].modify);
+        _decrypt_aes_gcm_kw_expect(modified, JWK_OCT_16, cases[i].expected);
+        free(modified);
+    }
+
+    // an encrypted key of any other length than the CEK is refused up front
+    size_t len = strlen(compact);
+    char *longer = malloc(len + 12);
+    ck_assert(NULL != longer);
+    const char *ek_end = strchr(strchr(compact, '.') + 1, '.');
+    size_t prefix = ek_end - compact;
+    memcpy(longer, compact, prefix);
+    memcpy(longer + prefix, "AAAAAAAAAAA", 11);
+    strcpy(longer + prefix + 11, ek_end);
+    _decrypt_aes_gcm_kw_expect(longer, JWK_OCT_16, CJOSE_ERR_INVALID_ARG);
+    free(longer);
+
+    cjose_get_dealloc()(compact);
+    cjose_jwk_release(jwk16);
+    cjose_jwk_release(jwk32);
+    cjose_jwk_release(ec);
+    cjose_header_release(hdr);
+}
+END_TEST
+
+// with several recipients the "iv" and "tag" of each go into its own header
+START_TEST(test_cjose_jwe_aes_gcm_kw_multiple_recipients)
+{
+    cjose_err err;
+    static const uint8_t plain[] = "Setec Astronomy";
+
+    cjose_jwk_t *jwk16 = cjose_jwk_import(JWK_OCT_16, strlen(JWK_OCT_16), &err);
+    cjose_jwk_t *jwk32 = cjose_jwk_import(JWK_OCT_32, strlen(JWK_OCT_32), &err);
+    ck_assert(NULL != jwk16 && NULL != jwk32);
+    ck_assert(cjose_jwk_set_kid(jwk16, "k16", 3, &err));
+    ck_assert(cjose_jwk_set_kid(jwk32, "k32", 3, &err));
+
+    cjose_header_t *protected_header = cjose_header_new(&err);
+    ck_assert(cjose_header_set(protected_header, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A128GCM, &err));
+    cjose_header_t *hdr16 = cjose_header_new(&err);
+    ck_assert(cjose_header_set(hdr16, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128GCMKW, &err));
+    ck_assert(cjose_header_set(hdr16, CJOSE_HDR_KID, "k16", &err));
+    cjose_header_t *hdr32 = cjose_header_new(&err);
+    ck_assert(cjose_header_set(hdr32, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A256GCMKW, &err));
+    ck_assert(cjose_header_set(hdr32, CJOSE_HDR_KID, "k32", &err));
+    cjose_jwe_recipient_t recipients[] = { { jwk16, hdr16 }, { jwk32, hdr32 } };
+
+    cjose_jwe_t *jwe = cjose_jwe_encrypt_multi(recipients, 2, protected_header, NULL, plain, sizeof(plain) - 1, &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt_multi failed: %s", err.message);
+    // the caller's headers are left alone
+    ck_assert(NULL == cjose_header_get(hdr16, CJOSE_HDR_IV, &err));
+    ck_assert(NULL == cjose_header_get(protected_header, CJOSE_HDR_IV, &err));
+    char *json = cjose_jwe_export_json(jwe, &err);
+    ck_assert_msg(NULL != json, "cjose_jwe_export_json failed: %s", err.message);
+    cjose_jwe_release(jwe);
+
+    json_t *form = json_loads(json, 0, NULL);
+    ck_assert(NULL != form);
+    json_t *recs = json_object_get(form, "recipients");
+    ck_assert(json_is_array(recs) && 2 == json_array_size(recs));
+    for (size_t i = 0; i < 2; i++)
+    {
+        json_t *header = json_object_get(json_array_get(recs, i), "header");
+        ck_assert(json_is_string(json_object_get(header, CJOSE_HDR_IV)));
+        ck_assert(json_is_string(json_object_get(header, CJOSE_HDR_TAG)));
+    }
+    json_decref(form);
+
+    // each recipient decrypts on its own
+    cjose_jwe_recipient_t rec16[] = { { jwk16, NULL }, { NULL, NULL } };
+    cjose_jwe_recipient_t rec32[] = { { jwk32, NULL }, { NULL, NULL } };
+    cjose_jwe_recipient_t *locators[] = { rec16, rec32 };
+    for (size_t i = 0; i < 2; i++)
+    {
+        jwe = cjose_jwe_import_json(json, strlen(json), &err);
+        ck_assert_msg(NULL != jwe, "cjose_jwe_import_json failed: %s", err.message);
+        size_t plain_len = 0;
+        uint8_t *plain2 = cjose_jwe_decrypt_multi(jwe, cjose_multi_key_locator, locators[i], &plain_len, &err);
+        ck_assert_msg(NULL != plain2, "cjose_jwe_decrypt_multi failed (%zu): %s", i, err.message);
+        ck_assert_int_eq(sizeof(plain) - 1, plain_len);
+        ck_assert(0 == memcmp(plain, plain2, plain_len));
+        cjose_get_dealloc()(plain2);
+        cjose_jwe_release(jwe);
+    }
+
+    cjose_get_dealloc()(json);
+    cjose_header_release(hdr16);
+    cjose_header_release(hdr32);
+    cjose_header_release(protected_header);
+    cjose_jwk_release(jwk16);
+    cjose_jwk_release(jwk32);
+}
+END_TEST
+
 START_TEST(test_cjose_jwe_self_encrypt_self_decrypt_empty)
 {
     static const uint8_t plain[] = "";
@@ -1956,6 +2171,30 @@ static const char *JWE_JSON_RSA_OAEP_256
       "kLDnnVrPaHUEUL79-KWMa-8tZ-SN0aHc2SuKQGNtNZsawMO05A\",\"header\":{\"alg\":\"RSA-OAEP\",\"kid\":\"oaep\"}}],\"tag\""
       ":\"Qc5-QsMtp9mUGBa7L0BXaA\"}";
 
+// AES GCM key wrapping JWEs produced by python-jwcrypto with the JWK_OCT_16,
+// JWK_OCT_24 and JWK_OCT_32 keys over PLAINTEXT_RSA_OAEP_256: three compact
+// serializations and a JSON serialization carrying "iv" and "tag" in the
+// per-recipient header
+static const char *JWE_A128GCMKW_A256GCM
+    = "eyJhbGciOiJBMTI4R0NNS1ciLCJlbmMiOiJBMjU2R0NNIiwiaXYiOiJMQmhoNUFHZENkV0pfQmlGIiwidGFnIjoicGhBMTJUeDl6"
+      "RkhheEdPTnJHVXA3dyJ9.uhEgAJmgwWenubxqB5CoL7YAjwElRrBZoHTMN-mL-yA.OXsulVhRLairug-w.XNgbp7c1mP_f_QlWrA"
+      "9cQGhvacOK6NUJRJqNJObmVJGyNiH1Yid28DDvR6apWhepIl0NV0EkL12kvRe9ote9.wiJ-Q5nNu22TlMWoM_sL9g";
+static const char *JWE_A192GCMKW_A128CBC_HS256
+    = "eyJhbGciOiJBMTkyR0NNS1ciLCJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiaXYiOiJGTTl3YXBZTThUMFBOYXlfIiwidGFnIjoiMzNN"
+      "X3lpUXNwMHhpMEJXaDZZZVAwUSJ9.49QP3-SdJsWD_nEUN6ka59Ov3Z_2OlOaY2yAu4MbflA.PnGQh3ngHXIGvBR_2Sl-fA.3WKM"
+      "taH-VJUa4R__qtgjPUy2497u9NWjureWGaSxxB-ES9NgT83jpIM2Erx6hiOg-M-sfxMrKcBL4z-DWXl4rA.eEwnBj13oretdyScV"
+      "xJ45A";
+static const char *JWE_A256GCMKW_A256CBC_HS512
+    = "eyJhbGciOiJBMjU2R0NNS1ciLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwiaXYiOiJLRGRTZFZINUtoN1Q0cG5jIiwidGFnIjoieXNy"
+      "cm5uZVRmMkdRVDRMenZ4M2hHUSJ9.OuaUOMHkZl7oY9R1zVZVoGiaD6i9Mcpb6CeCsThzXZt7vgeCQWvsXxBE-eAYqTdvy6COKT8"
+      "3dV4kFp38IFRjfg.Gvgfo5lY_nw0_jvFrzGLBQ.cY1VYnnymEeY3SAHgDlW_8aCsz15bHY0magfUxAs5BpC_tm3wO2uxYJhPNRmg"
+      "PHuwJRCuxmbIfOAqC3R_R2tag.jXD4DClG41phS6M5F5rDht2FZ2QM11EOB-q6ymSLq9g";
+static const char *JWE_JSON_A256GCMKW
+    = "{\"ciphertext\":\"Famyc9uLPYVY1Wvc2_KlX8zJl7m0QzrJSYGIeVqAkm1IMdyN2m97i_vZl6KgGzKq2ZR0VzZX7_7rb8AD2pH6\""
+      ",\"encrypted_key\":\"CWy4y1ebAzgFfqTbPMghLQ\",\"header\":{\"iv\":\"wPnqa0PDy2Uxy1pP\",\"tag\":\"2FbgAiF9nTBIadcDp"
+      "pThRg\"},\"iv\":\"X2V4hXch6jcWGfbw\",\"protected\":\"eyJhbGciOiAiQTI1NkdDTUtXIiwgImVuYyI6ICJBMTI4R0NNIn0\",\"t"
+      "ag\":\"Of1_hDbaoJadMjP7c0h4zg\"}";
+
 START_TEST(test_cjose_jwe_rsa_oaep_256)
 {
     cjose_err err;
@@ -2022,6 +2261,53 @@ START_TEST(test_cjose_jwe_rsa_oaep_256)
 }
 END_TEST
 
+START_TEST(test_cjose_jwe_aes_gcm_kw_interop)
+{
+    cjose_err err;
+    struct
+    {
+        const char *jwe;
+        const char *key;
+        const char *alg;
+    } vectors[] = {
+        { JWE_A128GCMKW_A256GCM, JWK_OCT_16, CJOSE_HDR_ALG_A128GCMKW },
+        { JWE_A192GCMKW_A128CBC_HS256, JWK_OCT_24, CJOSE_HDR_ALG_A192GCMKW },
+        { JWE_A256GCMKW_A256CBC_HS512, JWK_OCT_32, CJOSE_HDR_ALG_A256GCMKW },
+    };
+    for (size_t i = 0; i < sizeof(vectors) / sizeof(vectors[0]); i++)
+    {
+        cjose_jwk_t *jwk = cjose_jwk_import(vectors[i].key, strlen(vectors[i].key), &err);
+        ck_assert(NULL != jwk);
+        cjose_jwe_t *jwe = cjose_jwe_import(vectors[i].jwe, strlen(vectors[i].jwe), &err);
+        ck_assert_msg(NULL != jwe, "cjose_jwe_import failed (%zu): %s", i, err.message);
+        ck_assert_str_eq(vectors[i].alg, cjose_header_get(cjose_jwe_get_protected(jwe), CJOSE_HDR_ALG, &err));
+        size_t plain_len = 0;
+        uint8_t *plain = cjose_jwe_decrypt(jwe, jwk, &plain_len, &err);
+        ck_assert_msg(NULL != plain, "cjose_jwe_decrypt failed (%zu): %s", i, err.message);
+        ck_assert_int_eq(strlen(PLAINTEXT_RSA_OAEP_256), plain_len);
+        ck_assert(0 == memcmp(PLAINTEXT_RSA_OAEP_256, plain, plain_len));
+        cjose_get_dealloc()(plain);
+        cjose_jwe_release(jwe);
+        cjose_jwk_release(jwk);
+    }
+
+    // the JSON serialization keeps "iv" and "tag" in the recipient's header
+    cjose_jwk_t *jwk = cjose_jwk_import(JWK_OCT_32, strlen(JWK_OCT_32), &err);
+    ck_assert(NULL != jwk);
+    cjose_jwe_t *jwe = cjose_jwe_import_json(JWE_JSON_A256GCMKW, strlen(JWE_JSON_A256GCMKW), &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_import_json failed: %s", err.message);
+    ck_assert(NULL == cjose_header_get(cjose_jwe_get_protected(jwe), CJOSE_HDR_IV, &err));
+    size_t plain_len = 0;
+    uint8_t *plain = cjose_jwe_decrypt(jwe, jwk, &plain_len, &err);
+    ck_assert_msg(NULL != plain, "cjose_jwe_decrypt failed: %s", err.message);
+    ck_assert_int_eq(strlen(PLAINTEXT_RSA_OAEP_256), plain_len);
+    ck_assert(0 == memcmp(PLAINTEXT_RSA_OAEP_256, plain, plain_len));
+    cjose_get_dealloc()(plain);
+    cjose_jwe_release(jwe);
+    cjose_jwk_release(jwk);
+}
+END_TEST
+
 Suite *cjose_jwe_suite(void)
 {
     Suite *suite = suite_create("jwe");
@@ -2037,6 +2323,10 @@ Suite *cjose_jwe_suite(void)
     tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt_large);
     tcase_add_test(tc_jwe, test_cjose_jwe_self_encrypt_self_decrypt_many);
     tcase_add_test(tc_jwe, test_cjose_jwe_ecdh_es_kw_self_encrypt_self_decrypt);
+    tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_self_encrypt_self_decrypt);
+    tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_bad_params);
+    tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_multiple_recipients);
+    tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_interop);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes_gcm);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes_kw_oversized_ek);

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -666,16 +666,17 @@ START_TEST(test_cjose_jwe_aes_gcm_kw_multiple_recipients)
 }
 END_TEST
 
-static void _jwe_hdr_crit_iv(json_t *hdr)
+static void _jwe_hdr_crit_alg(json_t *hdr)
 {
     json_t *crit = json_array();
-    json_array_append_new(crit, json_string(CJOSE_HDR_IV));
+    json_array_append_new(crit, json_string(CJOSE_HDR_ALG));
     json_object_set_new(hdr, "crit", crit);
 }
 
-// "iv" and "tag" are understood as critical parameters for the AES GCM key
-// wrapping algorithms, which process them, and for no other algorithm
-START_TEST(test_cjose_jwe_aes_gcm_kw_crit)
+// RFC 7515 section 4.1.11: cjose implements no extension, and a producer may
+// not list a name the JOSE specifications define, so a "crit" list is refused
+// whatever it holds, for every algorithm and in every header location
+START_TEST(test_cjose_jwe_crit_refused)
 {
     cjose_err err;
     static const uint8_t plain[] = "Setec Astronomy";
@@ -683,82 +684,80 @@ START_TEST(test_cjose_jwe_aes_gcm_kw_crit)
     struct
     {
         const char *alg;
+        const char *enc;
         const char *key;
-        bool accepted;
-    } cases[] = {
-        { CJOSE_HDR_ALG_A128GCMKW, JWK_OCT_16, true },
-        { CJOSE_HDR_ALG_A256GCMKW, JWK_OCT_32, true },
-        { CJOSE_HDR_ALG_A128KW, JWK_OCT_16, false },
-        { CJOSE_HDR_ALG_DIR, JWK_OCT_32, false },
+    } algs[] = {
+        { CJOSE_HDR_ALG_A128GCMKW, CJOSE_HDR_ENC_A256GCM, JWK_OCT_16 },
+        { CJOSE_HDR_ALG_A128KW, CJOSE_HDR_ENC_A256GCM, JWK_OCT_16 },
+        { CJOSE_HDR_ALG_ECDH_ES, CJOSE_HDR_ENC_A128CBC_HS256, JWK_EC },
+        { CJOSE_HDR_ALG_DIR, CJOSE_HDR_ENC_A256GCM, JWK_OCT_32 },
     };
+    static const char *const lists[] = { "[\"alg\"]", "[\"iv\"]", "[\"epk\"]", "[\"b64\"]" };
 
-    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++)
+    for (size_t a = 0; a < sizeof(algs) / sizeof(algs[0]); a++)
     {
-        for (size_t p = 0; p < 2; p++)
+        for (size_t l = 0; l < sizeof(lists) / sizeof(lists[0]); l++)
         {
-            const char *param = (0 == p) ? CJOSE_HDR_IV : CJOSE_HDR_TAG;
             memset(&err, 0, sizeof(err));
             cjose_header_t *hdr = cjose_header_new(&err);
-            ck_assert(NULL != hdr);
-            ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, cases[i].alg, &err));
-            ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
-            json_t *crit = json_array();
-            json_array_append_new(crit, json_string(param));
-            json_object_set_new((json_t *)hdr, "crit", crit);
-
-            cjose_jwk_t *jwk = cjose_jwk_import(cases[i].key, strlen(cases[i].key), &err);
+            ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, algs[a].alg, &err));
+            ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, algs[a].enc, &err));
+            ck_assert(cjose_header_set_raw(hdr, "crit", lists[l], &err));
+            cjose_jwk_t *jwk = cjose_jwk_import(algs[a].key, strlen(algs[a].key), &err);
             ck_assert(NULL != jwk);
-            cjose_jwe_t *jwe = cjose_jwe_encrypt(jwk, hdr, plain, sizeof(plain) - 1, &err);
-            if (cases[i].accepted)
-            {
-                ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed for %s crit %s: %s", cases[i].alg, param, err.message);
-                cjose_jwe_release(jwe);
-            }
-            else
-            {
-                ck_assert_msg(NULL == jwe, "cjose_jwe_encrypt accepted crit %s for %s", param, cases[i].alg);
-                ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
-            }
+            ck_assert_msg(NULL == cjose_jwe_encrypt(jwk, hdr, plain, sizeof(plain) - 1, &err), "crit %s accepted for %s", lists[l],
+                          algs[a].alg);
+            ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
             cjose_jwk_release(jwk);
             cjose_header_release(hdr);
         }
     }
 
-    // the same on import: a JWE of another algorithm that marks "iv" critical
-    // is refused, where the AES GCM key wrapping one is not
+    // an imported JWE that carries the list in its protected header is refused
+    memset(&err, 0, sizeof(err));
     cjose_jwk_t *jwk16 = cjose_jwk_import(JWK_OCT_16, strlen(JWK_OCT_16), &err);
     ck_assert(NULL != jwk16);
     cjose_header_t *hdr = cjose_header_new(&err);
-    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128KW, &err));
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128GCMKW, &err));
     ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
     cjose_jwe_t *jwe = cjose_jwe_encrypt(jwk16, hdr, plain, sizeof(plain) - 1, &err);
     ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed: %s", err.message);
     char *compact = cjose_jwe_export(jwe, &err);
     ck_assert(NULL != compact);
     cjose_jwe_release(jwe);
-    char *modified = _jwe_with_modified_header(compact, _jwe_hdr_crit_iv);
-    memset(&err, 0, sizeof(err));
-    ck_assert(NULL == cjose_jwe_import(modified, strlen(modified), &err));
+
+    char *modified = _jwe_with_modified_header(compact, _jwe_hdr_crit_alg);
+    ck_assert_msg(NULL == cjose_jwe_import(modified, strlen(modified), &err), "cjose_jwe_import accepted a crit list");
     ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
     free(modified);
+
+    // ... and so is one that carries it in an unprotected header
+    memset(&err, 0, sizeof(err));
+    cjose_jwe_recipient_t rec[] = { { jwk16, NULL } };
+    jwe = cjose_jwe_encrypt_multi(rec, 1, hdr, NULL, plain, sizeof(plain) - 1, &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt_multi failed: %s", err.message);
+    char *json = cjose_jwe_export_json(jwe, &err);
+    ck_assert(NULL != json);
+    cjose_jwe_release(jwe);
+
+    json_t *form = json_loads(json, 0, NULL);
+    ck_assert(NULL != form);
+    json_t *unprotected = json_object();
+    json_t *crit = json_array();
+    json_array_append_new(crit, json_string(CJOSE_HDR_ALG));
+    json_object_set_new(unprotected, "crit", crit);
+    json_object_set_new(form, "unprotected", unprotected);
+    char *tampered = json_dumps(form, JSON_COMPACT);
+    ck_assert(NULL != tampered);
+    ck_assert_msg(NULL == cjose_jwe_import_json(tampered, strlen(tampered), &err),
+                  "cjose_jwe_import_json accepted a crit list in an unprotected header");
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    free(tampered);
+    json_decref(form);
+
+    cjose_get_dealloc()(json);
     cjose_get_dealloc()(compact);
     cjose_header_release(hdr);
-
-    cjose_header_t *gcm_hdr = cjose_header_new(&err);
-    ck_assert(cjose_header_set(gcm_hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128GCMKW, &err));
-    ck_assert(cjose_header_set(gcm_hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
-    jwe = cjose_jwe_encrypt(jwk16, gcm_hdr, plain, sizeof(plain) - 1, &err);
-    ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed: %s", err.message);
-    compact = cjose_jwe_export(jwe, &err);
-    ck_assert(NULL != compact);
-    cjose_jwe_release(jwe);
-    modified = _jwe_with_modified_header(compact, _jwe_hdr_crit_iv);
-    jwe = cjose_jwe_import(modified, strlen(modified), &err);
-    ck_assert_msg(NULL != jwe, "cjose_jwe_import failed: %s", err.message);
-    cjose_jwe_release(jwe);
-    free(modified);
-    cjose_get_dealloc()(compact);
-    cjose_header_release(gcm_hdr);
     cjose_jwk_release(jwk16);
 }
 END_TEST
@@ -828,114 +827,6 @@ START_TEST(test_cjose_jwe_aes_gcm_kw_caller_supplied_params)
 }
 END_TEST
 
-static void _jwe_hdr_crit_cty(json_t *hdr)
-{
-    json_t *crit = json_array();
-    json_array_append_new(crit, json_string("cty"));
-    json_object_set_new(hdr, "crit", crit);
-}
-
-static void _jwe_hdr_crit_epk(json_t *hdr)
-{
-    json_t *crit = json_array();
-    json_array_append_new(crit, json_string(CJOSE_HDR_EPK));
-    json_object_set_new(hdr, "crit", crit);
-}
-
-// "epk", "apu" and "apv" are ECDH-ES parameters (RFC 7518 section 4.6) and are
-// understood as critical parameters for those algorithms alone
-START_TEST(test_cjose_jwe_crit_ecdh_es_params)
-{
-    cjose_err err;
-    static const uint8_t plain[] = "Setec Astronomy";
-    static const char *const params[] = { CJOSE_HDR_EPK, CJOSE_HDR_APU, CJOSE_HDR_APV };
-
-    for (size_t p = 0; p < sizeof(params) / sizeof(params[0]); p++)
-    {
-        // accepted for ECDH-ES, as long as the parameter is in the header: the
-        // key agreement writes "epk" itself, "apu" and "apv" come from the caller
-        memset(&err, 0, sizeof(err));
-        cjose_header_t *hdr = cjose_header_new(&err);
-        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_ECDH_ES, &err));
-        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A128CBC_HS256, &err));
-        if (0 != strcmp(params[p], CJOSE_HDR_EPK))
-        {
-            ck_assert(cjose_header_set(hdr, params[p], "cGFydHk", &err));
-        }
-        json_t *crit = json_array();
-        json_array_append_new(crit, json_string(params[p]));
-        json_object_set_new((json_t *)hdr, "crit", crit);
-        cjose_jwk_t *ec = cjose_jwk_import(JWK_EC, strlen(JWK_EC), &err);
-        ck_assert(NULL != ec);
-        cjose_jwe_t *jwe = cjose_jwe_encrypt(ec, hdr, plain, sizeof(plain) - 1, &err);
-        ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed for ECDH-ES crit %s: %s", params[p], err.message);
-        // what the encryption produces imports again
-        char *round = cjose_jwe_export(jwe, &err);
-        ck_assert(NULL != round);
-        cjose_jwe_t *back = cjose_jwe_import(round, strlen(round), &err);
-        ck_assert_msg(NULL != back, "cjose_jwe_import failed for ECDH-ES crit %s: %s", params[p], err.message);
-        cjose_jwe_release(back);
-        cjose_get_dealloc()(round);
-        cjose_jwe_release(jwe);
-
-        // ... and refused when the critical parameter never occurs in the header
-        if (0 != strcmp(params[p], CJOSE_HDR_EPK))
-        {
-            memset(&err, 0, sizeof(err));
-            json_object_del((json_t *)hdr, params[p]);
-            ck_assert_msg(NULL == cjose_jwe_encrypt(ec, hdr, plain, sizeof(plain) - 1, &err),
-                          "cjose_jwe_encrypt accepted crit %s without the parameter", params[p]);
-            ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
-        }
-        cjose_jwk_release(ec);
-        cjose_header_release(hdr);
-
-        // refused for an algorithm that does not process them
-        memset(&err, 0, sizeof(err));
-        hdr = cjose_header_new(&err);
-        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128KW, &err));
-        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
-        crit = json_array();
-        json_array_append_new(crit, json_string(params[p]));
-        json_object_set_new((json_t *)hdr, "crit", crit);
-        cjose_jwk_t *oct = cjose_jwk_import(JWK_OCT_16, strlen(JWK_OCT_16), &err);
-        ck_assert(NULL != oct);
-        ck_assert_msg(NULL == cjose_jwe_encrypt(oct, hdr, plain, sizeof(plain) - 1, &err), "crit %s accepted for A128KW",
-                      params[p]);
-        ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
-        cjose_jwk_release(oct);
-        cjose_header_release(hdr);
-    }
-
-    // an imported JWE marking "epk" critical is refused for the same reason
-    memset(&err, 0, sizeof(err));
-    cjose_jwk_t *oct = cjose_jwk_import(JWK_OCT_16, strlen(JWK_OCT_16), &err);
-    cjose_header_t *hdr = cjose_header_new(&err);
-    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128KW, &err));
-    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
-    cjose_jwe_t *jwe = cjose_jwe_encrypt(oct, hdr, plain, sizeof(plain) - 1, &err);
-    ck_assert(NULL != jwe);
-    char *compact = cjose_jwe_export(jwe, &err);
-    ck_assert(NULL != compact);
-    cjose_jwe_release(jwe);
-    char *modified = _jwe_with_modified_header(compact, _jwe_hdr_crit_epk);
-    ck_assert(NULL == cjose_jwe_import(modified, strlen(modified), &err));
-    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
-    free(modified);
-
-    // a critical parameter that does not occur in the header is refused too
-    memset(&err, 0, sizeof(err));
-    modified = _jwe_with_modified_header(compact, _jwe_hdr_crit_cty);
-    ck_assert(NULL == cjose_jwe_import(modified, strlen(modified), &err));
-    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
-    free(modified);
-
-    cjose_get_dealloc()(compact);
-    cjose_header_release(hdr);
-    cjose_jwk_release(oct);
-}
-END_TEST
-
 // a parameter the algorithm produces itself must not come from the caller, and
 // the JWE that leaves the encryption has to be one that can be imported again
 START_TEST(test_cjose_jwe_generated_params)
@@ -985,17 +876,14 @@ START_TEST(test_cjose_jwe_generated_params)
     cjose_header_release(protected_header);
     cjose_jwk_release(ec);
 
-    // the AES GCM key wrapping parameters keep the same treatment, and a JWE
-    // that marks one of them critical round-trips
+    // the AES GCM key wrapping parameters keep the same treatment, and what the
+    // encryption produces imports and decrypts again
     memset(&err, 0, sizeof(err));
     cjose_jwk_t *jwk16 = cjose_jwk_import(JWK_OCT_16, strlen(JWK_OCT_16), &err);
     ck_assert(NULL != jwk16);
     hdr = cjose_header_new(&err);
     ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128GCMKW, &err));
     ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
-    json_t *crit = json_array();
-    json_array_append_new(crit, json_string(CJOSE_HDR_IV));
-    json_object_set_new((json_t *)hdr, "crit", crit);
     cjose_jwe_t *jwe = cjose_jwe_encrypt(jwk16, hdr, plain, sizeof(plain) - 1, &err);
     ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed: %s", err.message);
     char *compact = cjose_jwe_export(jwe, &err);
@@ -2785,9 +2673,8 @@ Suite *cjose_jwe_suite(void)
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_self_encrypt_self_decrypt);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_bad_params);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_multiple_recipients);
-    tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_crit);
+    tcase_add_test(tc_jwe, test_cjose_jwe_crit_refused);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_caller_supplied_params);
-    tcase_add_test(tc_jwe, test_cjose_jwe_crit_ecdh_es_params);
     tcase_add_test(tc_jwe, test_cjose_jwe_generated_params);
     tcase_add_test(tc_jwe, test_cjose_jwe_json_header_rules);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_interop);

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -666,6 +666,103 @@ START_TEST(test_cjose_jwe_aes_gcm_kw_multiple_recipients)
 }
 END_TEST
 
+static void _jwe_hdr_crit_iv(json_t *hdr)
+{
+    json_t *crit = json_array();
+    json_array_append_new(crit, json_string(CJOSE_HDR_IV));
+    json_object_set_new(hdr, "crit", crit);
+}
+
+// "iv" and "tag" are understood as critical parameters for the AES GCM key
+// wrapping algorithms, which process them, and for no other algorithm
+START_TEST(test_cjose_jwe_aes_gcm_kw_crit)
+{
+    cjose_err err;
+    static const uint8_t plain[] = "Setec Astronomy";
+
+    struct
+    {
+        const char *alg;
+        const char *key;
+        bool accepted;
+    } cases[] = {
+        { CJOSE_HDR_ALG_A128GCMKW, JWK_OCT_16, true },
+        { CJOSE_HDR_ALG_A256GCMKW, JWK_OCT_32, true },
+        { CJOSE_HDR_ALG_A128KW, JWK_OCT_16, false },
+        { CJOSE_HDR_ALG_DIR, JWK_OCT_32, false },
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++)
+    {
+        for (size_t p = 0; p < 2; p++)
+        {
+            const char *param = (0 == p) ? CJOSE_HDR_IV : CJOSE_HDR_TAG;
+            memset(&err, 0, sizeof(err));
+            cjose_header_t *hdr = cjose_header_new(&err);
+            ck_assert(NULL != hdr);
+            ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, cases[i].alg, &err));
+            ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+            json_t *crit = json_array();
+            json_array_append_new(crit, json_string(param));
+            json_object_set_new((json_t *)hdr, "crit", crit);
+
+            cjose_jwk_t *jwk = cjose_jwk_import(cases[i].key, strlen(cases[i].key), &err);
+            ck_assert(NULL != jwk);
+            cjose_jwe_t *jwe = cjose_jwe_encrypt(jwk, hdr, plain, sizeof(plain) - 1, &err);
+            if (cases[i].accepted)
+            {
+                ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed for %s crit %s: %s", cases[i].alg, param, err.message);
+                cjose_jwe_release(jwe);
+            }
+            else
+            {
+                ck_assert_msg(NULL == jwe, "cjose_jwe_encrypt accepted crit %s for %s", param, cases[i].alg);
+                ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+            }
+            cjose_jwk_release(jwk);
+            cjose_header_release(hdr);
+        }
+    }
+
+    // the same on import: a JWE of another algorithm that marks "iv" critical
+    // is refused, where the AES GCM key wrapping one is not
+    cjose_jwk_t *jwk16 = cjose_jwk_import(JWK_OCT_16, strlen(JWK_OCT_16), &err);
+    ck_assert(NULL != jwk16);
+    cjose_header_t *hdr = cjose_header_new(&err);
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128KW, &err));
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+    cjose_jwe_t *jwe = cjose_jwe_encrypt(jwk16, hdr, plain, sizeof(plain) - 1, &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed: %s", err.message);
+    char *compact = cjose_jwe_export(jwe, &err);
+    ck_assert(NULL != compact);
+    cjose_jwe_release(jwe);
+    char *modified = _jwe_with_modified_header(compact, _jwe_hdr_crit_iv);
+    memset(&err, 0, sizeof(err));
+    ck_assert(NULL == cjose_jwe_import(modified, strlen(modified), &err));
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+    free(modified);
+    cjose_get_dealloc()(compact);
+    cjose_header_release(hdr);
+
+    cjose_header_t *gcm_hdr = cjose_header_new(&err);
+    ck_assert(cjose_header_set(gcm_hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128GCMKW, &err));
+    ck_assert(cjose_header_set(gcm_hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+    jwe = cjose_jwe_encrypt(jwk16, gcm_hdr, plain, sizeof(plain) - 1, &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt failed: %s", err.message);
+    compact = cjose_jwe_export(jwe, &err);
+    ck_assert(NULL != compact);
+    cjose_jwe_release(jwe);
+    modified = _jwe_with_modified_header(compact, _jwe_hdr_crit_iv);
+    jwe = cjose_jwe_import(modified, strlen(modified), &err);
+    ck_assert_msg(NULL != jwe, "cjose_jwe_import failed: %s", err.message);
+    cjose_jwe_release(jwe);
+    free(modified);
+    cjose_get_dealloc()(compact);
+    cjose_header_release(gcm_hdr);
+    cjose_jwk_release(jwk16);
+}
+END_TEST
+
 START_TEST(test_cjose_jwe_self_encrypt_self_decrypt_empty)
 {
     static const uint8_t plain[] = "";
@@ -2326,6 +2423,7 @@ Suite *cjose_jwe_suite(void)
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_self_encrypt_self_decrypt);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_bad_params);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_multiple_recipients);
+    tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_crit);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_interop);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes_gcm);

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -763,6 +763,71 @@ START_TEST(test_cjose_jwe_aes_gcm_kw_crit)
 }
 END_TEST
 
+// the "iv" and "tag" parameters are produced by the encryption: a caller that
+// supplies them itself would get the same name in two header locations, which
+// RFC 7516 section 7.2.1 does not allow
+START_TEST(test_cjose_jwe_aes_gcm_kw_caller_supplied_params)
+{
+    cjose_err err;
+    static const uint8_t plain[] = "Setec Astronomy";
+    static const char *const params[] = { CJOSE_HDR_IV, CJOSE_HDR_TAG };
+
+    cjose_jwk_t *jwk16 = cjose_jwk_import(JWK_OCT_16, strlen(JWK_OCT_16), &err);
+    cjose_jwk_t *jwk32 = cjose_jwk_import(JWK_OCT_32, strlen(JWK_OCT_32), &err);
+    ck_assert(NULL != jwk16 && NULL != jwk32);
+
+    for (size_t p = 0; p < sizeof(params) / sizeof(params[0]); p++)
+    {
+        // in the protected header, with a single recipient
+        memset(&err, 0, sizeof(err));
+        cjose_header_t *hdr = cjose_header_new(&err);
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128GCMKW, &err));
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+        ck_assert(cjose_header_set(hdr, params[p], "AAAAAAAAAAAAAAAA", &err));
+        ck_assert_msg(NULL == cjose_jwe_encrypt(jwk16, hdr, plain, sizeof(plain) - 1, &err), "caller supplied %s accepted",
+                      params[p]);
+        ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+        cjose_header_release(hdr);
+
+        // in the shared unprotected header
+        memset(&err, 0, sizeof(err));
+        hdr = cjose_header_new(&err);
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128GCMKW, &err));
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+        cjose_header_t *shared = cjose_header_new(&err);
+        ck_assert(cjose_header_set(shared, params[p], "AAAAAAAAAAAAAAAA", &err));
+        cjose_jwe_recipient_t one[] = { { jwk16, NULL } };
+        ck_assert_msg(NULL == cjose_jwe_encrypt_multi(one, 1, hdr, shared, plain, sizeof(plain) - 1, &err), "shared %s accepted",
+                      params[p]);
+        ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+        cjose_header_release(shared);
+
+        // in a per-recipient header, with several recipients
+        memset(&err, 0, sizeof(err));
+        cjose_header_t *hdr16 = cjose_header_new(&err);
+        ck_assert(cjose_header_set(hdr16, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A128GCMKW, &err));
+        cjose_header_t *hdr32 = cjose_header_new(&err);
+        ck_assert(cjose_header_set(hdr32, CJOSE_HDR_ALG, CJOSE_HDR_ALG_A256GCMKW, &err));
+        ck_assert(cjose_header_set(hdr32, params[p], "AAAAAAAAAAAAAAAA", &err));
+        cjose_header_t *shared_enc = cjose_header_new(&err);
+        ck_assert(cjose_header_set(shared_enc, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, &err));
+        cjose_jwe_recipient_t two[] = { { jwk16, hdr16 }, { jwk32, hdr32 } };
+        ck_assert_msg(NULL == cjose_jwe_encrypt_multi(two, 2, shared_enc, NULL, plain, sizeof(plain) - 1, &err),
+                      "per-recipient %s accepted", params[p]);
+        ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+        // the first recipient, which carried no parameter of its own, is untouched
+        ck_assert(NULL == cjose_header_get(hdr16, CJOSE_HDR_IV, &err));
+        cjose_header_release(hdr16);
+        cjose_header_release(hdr32);
+        cjose_header_release(shared_enc);
+        cjose_header_release(hdr);
+    }
+
+    cjose_jwk_release(jwk16);
+    cjose_jwk_release(jwk32);
+}
+END_TEST
+
 START_TEST(test_cjose_jwe_self_encrypt_self_decrypt_empty)
 {
     static const uint8_t plain[] = "";
@@ -2424,6 +2489,7 @@ Suite *cjose_jwe_suite(void)
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_bad_params);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_multiple_recipients);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_crit);
+    tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_caller_supplied_params);
     tcase_add_test(tc_jwe, test_cjose_jwe_aes_gcm_kw_interop);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes);
     tcase_add_test(tc_jwe, test_cjose_jwe_decrypt_aes_gcm);

--- a/test/check_jws.c
+++ b/test/check_jws.c
@@ -1499,6 +1499,41 @@ START_TEST(test_cjose_jws_verify_ec_sig_bad_length)
 }
 END_TEST
 
+// RFC 7515 section 4.1.11: a name in the "crit" list must occur as a header
+// parameter name within the JOSE header, which is complete when signing
+START_TEST(test_cjose_jws_crit_present)
+{
+    cjose_err err;
+    static const uint8_t plain[] = "Setec Astronomy";
+
+    cjose_jwk_t *jwk = cjose_jwk_import(JWK_COMMON_OCT, strlen(JWK_COMMON_OCT), &err);
+    ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
+
+    // "cty" marked critical without a "cty" header is refused
+    cjose_header_t *hdr = cjose_header_new(&err);
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_HS256, &err));
+    ck_assert(cjose_header_set_raw(hdr, "crit", "[\"cty\"]", &err));
+    ck_assert_msg(NULL == cjose_jws_sign(jwk, hdr, plain, sizeof(plain) - 1, &err), "cjose_jws_sign accepted an absent crit name");
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+
+    // ... and accepted once the header carries it
+    memset(&err, 0, sizeof(err));
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_CTY, "JWT", &err));
+    cjose_jws_t *jws = cjose_jws_sign(jwk, hdr, plain, sizeof(plain) - 1, &err);
+    ck_assert_msg(NULL != jws, "cjose_jws_sign failed: %s", err.message);
+    const char *compact = NULL;
+    ck_assert(cjose_jws_export(jws, &compact, &err));
+    cjose_jws_t *imported = cjose_jws_import(compact, strlen(compact), &err);
+    ck_assert_msg(NULL != imported, "cjose_jws_import failed: %s", err.message);
+    ck_assert(cjose_jws_verify(imported, jwk, &err));
+    cjose_jws_release(imported);
+    cjose_jws_release(jws);
+
+    cjose_header_release(hdr);
+    cjose_jwk_release(jwk);
+}
+END_TEST
+
 Suite *cjose_jws_suite(void)
 {
     Suite *suite = suite_create("jws");
@@ -1533,6 +1568,7 @@ Suite *cjose_jws_suite(void)
     tcase_add_test(tc_jws, test_cjose_jws_none);
     tcase_add_test(tc_jws, test_cjose_jws_verify_ps_sig_bad_length);
     tcase_add_test(tc_jws, test_cjose_jws_verify_ec_sig_bad_length);
+    tcase_add_test(tc_jws, test_cjose_jws_crit_present);
     suite_add_tcase(suite, tc_jws);
 
     return suite;

--- a/test/check_jws.c
+++ b/test/check_jws.c
@@ -1499,9 +1499,9 @@ START_TEST(test_cjose_jws_verify_ec_sig_bad_length)
 }
 END_TEST
 
-// RFC 7515 section 4.1.11: a name in the "crit" list must occur as a header
-// parameter name within the JOSE header, which is complete when signing
-START_TEST(test_cjose_jws_crit_present)
+// RFC 7515 section 4.1.11: cjose implements no extension, so a JWS whose
+// header carries a "crit" list is refused, when signing and when verifying
+START_TEST(test_cjose_jws_crit_refused)
 {
     cjose_err err;
     static const uint8_t plain[] = "Setec Astronomy";
@@ -1509,26 +1509,42 @@ START_TEST(test_cjose_jws_crit_present)
     cjose_jwk_t *jwk = cjose_jwk_import(JWK_COMMON_OCT, strlen(JWK_COMMON_OCT), &err);
     ck_assert_msg(NULL != jwk, "cjose_jwk_import failed: %s", err.message);
 
-    // "cty" marked critical without a "cty" header is refused
     cjose_header_t *hdr = cjose_header_new(&err);
     ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_HS256, &err));
+    ck_assert(cjose_header_set(hdr, CJOSE_HDR_CTY, "JWT", &err));
     ck_assert(cjose_header_set_raw(hdr, "crit", "[\"cty\"]", &err));
-    ck_assert_msg(NULL == cjose_jws_sign(jwk, hdr, plain, sizeof(plain) - 1, &err), "cjose_jws_sign accepted an absent crit name");
+    ck_assert_msg(NULL == cjose_jws_sign(jwk, hdr, plain, sizeof(plain) - 1, &err), "cjose_jws_sign accepted a crit list");
     ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
 
-    // ... and accepted once the header carries it
+    // the same JWS, made without the list and given one afterwards, is refused
+    // when it is imported
     memset(&err, 0, sizeof(err));
-    ck_assert(cjose_header_set(hdr, CJOSE_HDR_CTY, "JWT", &err));
+    json_object_del((json_t *)hdr, "crit");
     cjose_jws_t *jws = cjose_jws_sign(jwk, hdr, plain, sizeof(plain) - 1, &err);
     ck_assert_msg(NULL != jws, "cjose_jws_sign failed: %s", err.message);
     const char *compact = NULL;
     ck_assert(cjose_jws_export(jws, &compact, &err));
-    cjose_jws_t *imported = cjose_jws_import(compact, strlen(compact), &err);
-    ck_assert_msg(NULL != imported, "cjose_jws_import failed: %s", err.message);
-    ck_assert(cjose_jws_verify(imported, jwk, &err));
-    cjose_jws_release(imported);
-    cjose_jws_release(jws);
 
+    json_t *header = json_pack("{s:s,s:s,s:[s]}", "alg", "HS256", "cty", "JWT", "crit", "cty");
+    char *header_str = json_dumps(header, JSON_COMPACT);
+    char *header_b64u = NULL;
+    size_t header_b64u_len = 0;
+    ck_assert(cjose_base64url_encode((const uint8_t *)header_str, strlen(header_str), &header_b64u, &header_b64u_len, &err));
+    const char *rest = strchr(compact, '.');
+    char *tampered = malloc(header_b64u_len + strlen(rest) + 1);
+    ck_assert(NULL != tampered);
+    memcpy(tampered, header_b64u, header_b64u_len);
+    strcpy(tampered + header_b64u_len, rest);
+
+    memset(&err, 0, sizeof(err));
+    ck_assert_msg(NULL == cjose_jws_import(tampered, strlen(tampered), &err), "cjose_jws_import accepted a crit list");
+    ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+
+    free(tampered);
+    cjose_get_dealloc()(header_b64u);
+    cjose_get_dealloc()(header_str);
+    json_decref(header);
+    cjose_jws_release(jws);
     cjose_header_release(hdr);
     cjose_jwk_release(jwk);
 }
@@ -1568,7 +1584,7 @@ Suite *cjose_jws_suite(void)
     tcase_add_test(tc_jws, test_cjose_jws_none);
     tcase_add_test(tc_jws, test_cjose_jws_verify_ps_sig_bad_length);
     tcase_add_test(tc_jws, test_cjose_jws_verify_ec_sig_bad_length);
-    tcase_add_test(tc_jws, test_cjose_jws_crit_present);
+    tcase_add_test(tc_jws, test_cjose_jws_crit_refused);
     suite_add_tcase(suite, tc_jws);
 
     return suite;


### PR DESCRIPTION
## Breaking change, please read first

**A JWE or JWS whose header carries a `crit` list is refused, on production and on consumption alike.** Until now a list was accepted as long as it named parameters cjose processes — `alg`, `enc` and `cty` for both, plus `epk`, `apu` and `apv` for a JWE — and `iv` and `tag` were added to that set by #184. `cjose_jws_sign`, `cjose_jwe_encrypt*`, `cjose_jws_import` and `cjose_jwe_import*` now fail with `CJOSE_ERR_INVALID_ARG` for any of them.

RFC 7515 section 4.1.11 is the reason: `crit` names extensions to the JOSE specifications that the recipient has to understand and process, a recipient must reject a list naming anything it does not support, and a producer must not list a name the specifications or JWA define, which a recipient may reject in turn. cjose implements no extension, so every name a list can carry falls under one of those two, and the conformant behaviour collapses to refusing the list.

Consequences worth being deliberate about:

- A caller that sets `crit` on a header it passes to cjose now gets an error instead of a token. There is no API change and no new symbol; only the behaviour.
- A token from a producer that emits `crit` naming registered parameters is refused where it used to be accepted. Such a producer is already outside RFC 7515 section 4.1.11, but it will be a visible change for whoever meets one.
- It supersedes the scoping of `iv` and `tag` in #184: that commit is in this branch and this one removes the mechanism it added. Happy to drop it from #184 instead, if you would rather that PR not carry a mechanism that disappears here.
- For the release notes, whenever you write them: *a JOSE header that carries a "crit" parameter is refused; a list naming parameters cjose processes, such as "alg", "enc" or "cty", used to be accepted.*

## The rest

### Disjoint header names (RFC 7516 section 7.2.1)

The member names of the JWE protected header, the shared unprotected header and a per-recipient unprotected header must be disjoint. They were not checked, and `_cjose_jwe_get_from_headers()` resolves a name by precedence — per-recipient, then shared, then protected — so a JWE that repeated a name was accepted and the *unprotected*, unauthenticated copy won. On master a JWE whose protected header says `{"alg":"A128KW"}` and which an attacker gives a per-recipient `{"alg":"dir"}` imports fine and the substituted algorithm drives the decryption; it is now refused. For `alg` that is the shape of an algorithm-confusion bug, though it does not appear to be exploitable, since a substituted algorithm fails either the key type check in `_cjose_jwe_validate_decrypt_key()` or the content authentication.

The lookup order is deliberately left as it is. Reversing it to prefer the protected header would be wrong, because the per-recipient header is the legitimate place for `alg` in a JSON serialization and valid multi-recipient JWEs would break. The invariant that makes the precedence safe is that exactly one location carries a given name, which is what the disjointness check establishes, and it runs before any header value is acted upon: the compact path validates the recipient before `_cjose_jwe_validate_enc()`, and the JSON path validates every recipient before it. A further guard inside the lookup helper, asserting a single source, would therefore be unreachable code, so there is none.

### The headers a JWE leaves the encryption with

Validation ran on the caller's headers only, so it never saw the parameters the algorithms write themselves and the encryption could produce a JWE that cjose's own import refuses: a caller-supplied `epk` in the shared or a per-recipient header survived next to the generated one. The assembled headers are therefore checked again once every recipient has been encrypted to, which gives the property that was missing — what `cjose_jwe_encrypt*` returns is a JWE that `cjose_jwe_import*` accepts.

A parameter the algorithm produces itself is also refused up front when it comes from the caller, as #184 does for `iv` and `tag`, and that now covers `epk`, which was silently replaced by the generated key when the caller set it in the protected header. The three uses share one helper.

One related fix this needed: `cjose_jwe_encrypt_multi_iv()` passed the recipient's own header to `_cjose_jwe_validate_alg()` in the place of the shared unprotected header, so the shared header was invisible to validation and, as a side effect, `alg` could not be resolved from it when encrypting, while the import path did resolve it there. The call now passes the shared header, which makes the two paths symmetric.

## Testing

- `check_cjose` in full, with RSA1_5 off and on, and valgrind clean on the whole run; the `clang-format` target produces no diff.
- The `crit` refusal is exercised for four algorithms against four different lists, in the protected header and in an unprotected one, when encrypting and when importing, for JWE and for JWS.
- Unit tests for the refusal and for the disjointness check in the `header` suite, and JWE regression tests for the generated parameters and for the round trip.
- Verified against the tip of #184 that the behaviours change: `crit` in every shape above, a JSON serialization repeating `enc` across the protected and a recipient header, the `alg` shadowing above, a caller-supplied `epk`, and an ECDH-ES JWE that the encryption emitted and the import refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
