### PR TITLE
Reject unsupported multi-prime RSA JWKs

### DIFF
--- a/src/jwk.c
+++ b/src/jwk.c
@@ -49,6 +49,7 @@ static const char CJOSE_JWK_Q_STR[] = "q";
 static const char CJOSE_JWK_DP_STR[] = "dp";
 static const char CJOSE_JWK_DQ_STR[] = "dq";
 static const char CJOSE_JWK_QI_STR[] = "qi";
+static const char CJOSE_JWK_OTH_STR[] = "oth";
 static const char CJOSE_JWK_K_STR[] = "k";
 
 static const char *JWK_KTY_NAMES[] = { CJOSE_JWK_KTY_RSA_STR, CJOSE_JWK_KTY_EC_STR, CJOSE_JWK_KTY_OCT_STR, CJOSE_JWK_KTY_OKP_STR };
@@ -1934,8 +1935,8 @@ static bool _cjose_jwk_decode_json_object_base64url_attribute(
     return true;
 }
 
-// RFC 7517: a private member that is present but carries no value is a
-// malformed key, not a public one, so it must not be read as an absent member
+// RFC 7518 section 6.3.2: a private member that is present but carries no
+// value is a malformed key, not a public one, so it must not be read as absent
 static bool _cjose_jwk_decode_private_attribute(json_t *jwk_json, const char *key, uint8_t **buffer, size_t *buflen, cjose_err *err)
 {
     if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, key, buffer, buflen, err))
@@ -2054,6 +2055,15 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     size_t dp_buflen = 0;
     size_t dq_buflen = 0;
     size_t qi_buflen = 0;
+
+    // cjose supports only two-prime RSA keys; RFC 7518 section 6.3.2.7
+    // requires consumers that do not support multi-prime keys not to use a
+    // key carrying the "oth" parameter
+    if (NULL != json_object_get(jwk_json, CJOSE_JWK_OTH_STR))
+    {
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        goto import_RSA_cleanup;
+    }
 
     // get the decoded value of n (buflen = 0 means no particular expected len)
     if (!_cjose_jwk_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_N_STR, &n_buffer, &n_buflen, err))

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -1670,7 +1670,42 @@ START_TEST(test_cjose_jwk_import_invalid)
 }
 END_TEST
 
-// RFC 7517 gives every private member a base64url value: one that is present
+// RFC 7518 section 6.3.2.7: cjose does not support multi-prime RSA keys, so
+// an RSA JWK carrying the "oth" private-key parameter must not be used
+START_TEST(test_cjose_jwk_import_unsupported_rsa_oth)
+{
+    cjose_err err;
+    static const char *const oth_values[] = {
+        "[{\"r\":\"AQ\",\"d\":\"AQ\",\"t\":\"AQ\"}]",
+        "null",
+    };
+
+    cjose_jwk_t *rsa = cjose_jwk_create_RSA_random(2048, NULL, 0, &err);
+    ck_assert_msg(NULL != rsa, "cjose_jwk_create_RSA_random failed: %s", err.message);
+    char *priv = cjose_jwk_to_json(rsa, true, &err);
+    ck_assert(NULL != priv);
+
+    for (size_t i = 0; i < sizeof(oth_values) / sizeof(oth_values[0]); i++)
+    {
+        size_t len = strlen(priv) + strlen(oth_values[i]) + 16;
+        char *with_oth = malloc(len);
+        ck_assert(NULL != with_oth);
+        snprintf(with_oth, len, "%.*s,\"oth\":%s}", (int)strlen(priv) - 1, priv, oth_values[i]);
+
+        memset(&err, 0, sizeof(err));
+        cjose_jwk_t *bad = cjose_jwk_import(with_oth, strlen(with_oth), &err);
+        ck_assert_msg(NULL == bad, "RSA JWK with oth value %s was accepted", oth_values[i]);
+        ck_assert_int_eq(CJOSE_ERR_INVALID_ARG, err.code);
+        cjose_jwk_release(bad);
+        free(with_oth);
+    }
+
+    cjose_get_dealloc()(priv);
+    cjose_jwk_release(rsa);
+}
+END_TEST
+
+// RFC 7518 section 6.3.2 gives every private member a base64url value: one that is present
 // but carries no value is a malformed key, and reading it as an absent member
 // turned the key into a public one
 START_TEST(test_cjose_jwk_import_empty_private_member)
@@ -2217,6 +2252,7 @@ Suite *cjose_jwk_suite(void)
     tcase_add_test(tc_jwk, test_cjose_jwk_import_json_invalid);
     tcase_add_test(tc_jwk, test_cjose_jwk_import_valid);
     tcase_add_test(tc_jwk, test_cjose_jwk_import_invalid);
+    tcase_add_test(tc_jwk, test_cjose_jwk_import_unsupported_rsa_oth);
     tcase_add_test(tc_jwk, test_cjose_jwk_import_empty_private_member);
     tcase_add_test(tc_jwk, test_cjose_jwk_import_underflow_length);
     tcase_add_test(tc_jwk, test_cjose_jwk_import_no_zero_termination);


### PR DESCRIPTION
## Summary

`cjose` supports only two-prime RSA keys. RFC 7518 section 6.3.2.7 defines the `oth` parameter for RSA keys with three or more prime factors and requires consumers that do not support multi-prime keys not to use such keys.

Previously, RSA JWK import ignored `oth` and could silently interpret an unsupported key as a two-prime RSA key.

This change rejects any RSA JWK containing `oth` with `CJOSE_ERR_INVALID_ARG` before importing the key material.

## Testing

- Added regression coverage for a populated `oth` array.
- Added coverage for a `null` `oth` value.