### PR TITLE
Survive a NULL cjose_err when decrypting with ECDH-ES and a key wrapping algorithm

### DIFF
--- a/src/jwe.c
+++ b/src/jwe.c
@@ -1515,6 +1515,14 @@ static bool _cjose_jwe_decrypt_ek_ecdh_es_kw(
     uint8_t *kek = NULL;
     bool result = false;
 
+    // err is optional in the public API, but the logic below inspects
+    // err->code to distinguish an absent EPK header from a real failure;
+    // fall back to a local error object when the caller did not supply one
+    cjose_err local_err;
+    if (NULL == err)
+    {
+        err = &local_err;
+    }
     memset(err, 0, sizeof(cjose_err));
     epk_json = cjose_header_get_raw(jwe->hdr, CJOSE_HDR_EPK, err);
     if (NULL != epk_json)

--- a/test/check_jwe.c
+++ b/test/check_jwe.c
@@ -2291,36 +2291,46 @@ END_TEST
 // crashing when the public JWE API was invoked with a NULL err argument.
 START_TEST(test_cjose_jwe_ecdh_es_null_err)
 {
+    // the trailing cjose_err is optional throughout the public API, so every
+    // ECDH-ES variant has to survive a NULL one: the key agreement inspects
+    // err->code to tell an absent "epk" header from a real failure
+    static const char *const algs[]
+        = { CJOSE_HDR_ALG_ECDH_ES, CJOSE_HDR_ALG_ECDH_ES_A128KW, CJOSE_HDR_ALG_ECDH_ES_A192KW, CJOSE_HDR_ALG_ECDH_ES_A256KW };
+
     cjose_jwk_t *jwk = cjose_jwk_import(JWK_EC, strlen(JWK_EC), NULL);
     ck_assert_msg(NULL != jwk, "cjose_jwk_import failed for EC key");
 
-    cjose_header_t *hdr = cjose_header_new(NULL);
-    ck_assert_msg(NULL != hdr, "cjose_header_new failed");
-    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, CJOSE_HDR_ALG_ECDH_ES, NULL));
-    ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, NULL));
+    for (size_t i = 0; i < sizeof(algs) / sizeof(algs[0]); i++)
+    {
+        cjose_header_t *hdr = cjose_header_new(NULL);
+        ck_assert_msg(NULL != hdr, "cjose_header_new failed");
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ALG, algs[i], NULL));
+        ck_assert(cjose_header_set(hdr, CJOSE_HDR_ENC, CJOSE_HDR_ENC_A256GCM, NULL));
 
-    // encrypt with a NULL err: must not crash in the ConcatKDF otherinfo path
-    cjose_jwe_t *jwe = cjose_jwe_encrypt(jwk, hdr, (const uint8_t *)PLAINTEXT, strlen(PLAINTEXT), NULL);
-    ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt (ECDH-ES) failed with NULL err");
+        // encrypt with a NULL err: must not crash in the ConcatKDF otherinfo path
+        cjose_jwe_t *jwe = cjose_jwe_encrypt(jwk, hdr, (const uint8_t *)PLAINTEXT, strlen(PLAINTEXT), NULL);
+        ck_assert_msg(NULL != jwe, "cjose_jwe_encrypt (%s) failed with NULL err", algs[i]);
 
-    char *compact = cjose_jwe_export(jwe, NULL);
-    ck_assert_msg(NULL != compact, "cjose_jwe_export failed");
+        char *compact = cjose_jwe_export(jwe, NULL);
+        ck_assert_msg(NULL != compact, "cjose_jwe_export failed");
 
-    cjose_jwe_t *jwe2 = cjose_jwe_import(compact, strlen(compact), NULL);
-    ck_assert_msg(NULL != jwe2, "cjose_jwe_import failed");
+        cjose_jwe_t *jwe2 = cjose_jwe_import(compact, strlen(compact), NULL);
+        ck_assert_msg(NULL != jwe2, "cjose_jwe_import failed");
 
-    // decrypt with a NULL err: again exercises the ConcatKDF path
-    size_t plain_len = 0;
-    uint8_t *plain = cjose_jwe_decrypt(jwe2, jwk, &plain_len, NULL);
-    ck_assert_msg(NULL != plain, "cjose_jwe_decrypt (ECDH-ES) failed with NULL err");
-    ck_assert(plain_len == strlen(PLAINTEXT));
-    ck_assert(strncmp(PLAINTEXT, (const char *)plain, plain_len) == 0);
+        // decrypt with a NULL err: again exercises the ConcatKDF path
+        size_t plain_len = 0;
+        uint8_t *plain = cjose_jwe_decrypt(jwe2, jwk, &plain_len, NULL);
+        ck_assert_msg(NULL != plain, "cjose_jwe_decrypt (%s) failed with NULL err", algs[i]);
+        ck_assert(plain_len == strlen(PLAINTEXT));
+        ck_assert(strncmp(PLAINTEXT, (const char *)plain, plain_len) == 0);
 
-    cjose_get_dealloc()(plain);
-    cjose_get_dealloc()(compact);
-    cjose_jwe_release(jwe);
-    cjose_jwe_release(jwe2);
-    cjose_header_release(hdr);
+        cjose_get_dealloc()(plain);
+        cjose_get_dealloc()(compact);
+        cjose_jwe_release(jwe);
+        cjose_jwe_release(jwe2);
+        cjose_header_release(hdr);
+    }
+
     cjose_jwk_release(jwk);
 }
 END_TEST


### PR DESCRIPTION
## Summary

`cjose_jwe_decrypt(jwe, jwk, &len, NULL)` on an `ECDH-ES+A128KW`, `ECDH-ES+A192KW` or `ECDH-ES+A256KW` JWE segfaults.

The trailing `cjose_err` is optional throughout the public API, and `cjose_jwe_decrypt` / `cjose_jwe_decrypt_multi` pass the caller's pointer straight through to the per-recipient key decryption function. `_cjose_jwe_decrypt_ek_ecdh_es_kw()` dereferences it in its first statement:

```c
memset(err, 0, sizeof(cjose_err));
```

The same line exists in the plain ECDH-ES function, but that one was given a local `cjose_err` to fall back on when the path was hardened, and the key wrapping variant was missed. Both need it for the same reason: the code that follows reads `err->code` to tell an absent `epk` header from a real failure, so it cannot simply skip the write.

Reproduced with a P-256 key: plain `ECDH-ES` decrypts fine with a NULL `err`, each of the three key wrapping algorithms dies with SIGSEGV.

## Testing

- `test_cjose_jwe_ecdh_es_null_err` now runs over all four ECDH-ES algorithms instead of only the bare one. Without the fix the test binary segfaults; with it the suite passes.
- Full `check_cjose` with RSA1_5 off and on, valgrind clean over the whole run, `clang-format` produces no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
