### PR TITLE
Refuse a private member whose value is base64url padding only

### DIFF
--- a/src/jwk.c
+++ b/src/jwk.c
@@ -1943,7 +1943,9 @@ static bool _cjose_jwk_decode_private_attribute(json_t *jwk_json, const char *ke
     {
         return false;
     }
-    if (NULL != json_object_get(jwk_json, key) && NULL == *buffer)
+    // base64url padding on its own decodes to nothing, so the buffer can be
+    // present and still carry no octets
+    if (NULL != json_object_get(jwk_json, key) && (NULL == *buffer || 0 == *buflen))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return false;

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -1712,7 +1712,9 @@ START_TEST(test_cjose_jwk_import_empty_private_member)
 {
     cjose_err err;
     static const char *const members[] = { "d", "p", "q", "dp", "dq", "qi" };
-    static const char *const values[] = { "\"\"", "null" };
+    // an empty string, a JSON null, and base64url padding that decodes to
+    // nothing at all
+    static const char *const values[] = { "\"\"", "null", "\"==\"", "\"====\"" };
 
     cjose_jwk_t *rsa = cjose_jwk_create_RSA_random(2048, NULL, 0, &err);
     ck_assert_msg(NULL != rsa, "cjose_jwk_create_RSA_random failed: %s", err.message);


### PR DESCRIPTION
## Summary

Follow-up to #189, which landed while this was in flight. The guard it added tests the decoded buffer pointer:

```c
if (NULL != json_object_get(jwk_json, key) && NULL == *buffer)
```

but base64url padding on its own decodes to **zero octets with a non-NULL buffer**: `cjose_base64url_decode` breaks out of its loop on the first `=`, publishes the allocated buffer and reports a length of 0. So a private member of `"=="` or `"===="` walks past the check and

```json
{"kty":"RSA","n":"...","e":"AQAB","d":"=="}
```

still imports as a **public** RSA key, which is exactly what #189 set out to prevent. `"="` alone was already refused, by the `inlen % 4 == 1` gate in the decoder, which is why the hole is easy to miss. The same applies to `p`, `q`, `dp`, `dq` and `qi`.

The guard now tests the decoded length as well. EC and OKP keys were never affected: their importers pass a non-zero expected length, so the decoder's length check rejects the padding first. RSA passes 0, meaning "any length", so there is nothing else to catch it.

Found by an independent review agent over the open PRs, which is the practice you asked for in #185 — this is the first thing it turned up.

## Testing

- `test_cjose_jwk_import_empty_private_member` now covers `"=="` and `"===="` beside the empty string and `null`, so 24 negative cases over the six private members, plus the public and private serializations of the same key still importing. It fails on master with "a d of "==" was accepted".
- Full `check_cjose`, `clang-format` produces no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
